### PR TITLE
Change "Datstore" to "Datastore"

### DIFF
--- a/localtesting/test_datastore.py
+++ b/localtesting/test_datastore.py
@@ -47,7 +47,7 @@ def GetEntityViaMemcache(entity_key):
 
 
 # [START datastore_example_test]
-class DatstoreTestCase(unittest.TestCase):
+class DatastoreTestCase(unittest.TestCase):
 
     def setUp(self):
         # First, create an instance of the Testbed class.


### PR DESCRIPTION
I noticed you had a test class called `Datstore` from this page:
https://cloud.google.com/appengine/docs/python/tools/localunittesting?hl=en
I think you might have meant `Datastore`