### PR TITLE
Removing reqcheck from travis tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = pep8, reqcheck, gae, py27, py34
+envlist = pep8, py27, py34, gae
 
 [testenv]
 passenv = *


### PR DESCRIPTION
This is to fix travis in the interim between and and when we merge #185.