### PR TITLE
Moving storage samples to py.test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,18 @@
+import os
+
+import pytest
+from testing.cloud import Config, get_resource_path
+
+
+@pytest.fixture(scope='session')
+def cloud_config():
+    """Provides a configuration option as a proxy to environment variables."""
+    return Config()
+
+
+@pytest.fixture(scope='module')
+def resource(request):
+    """Provides a function that returns the full path to a local or global
+    testing resource"""
+    local_path = os.path.dirname(request.module.__file__)
+    return lambda *args: get_resource_path(args, local_path)

--- a/storage/api/compose_objects_test.py
+++ b/storage/api/compose_objects_test.py
@@ -12,14 +12,12 @@
 # limitations under the License.
 
 from compose_objects import main
-from testing import CloudTest
 
 
-class TestComposeObjects(CloudTest):
-    def test_main(self):
-        main(
-            self.config.CLOUD_STORAGE_BUCKET,
-            'dest.txt',
-            [self.resource_path('file1.txt'),
-             self.resource_path('file2.txt')]
-        )
+def test_main(cloud_config, resource):
+    main(
+        cloud_config.CLOUD_STORAGE_BUCKET,
+        'dest.txt',
+        [resource('file1.txt'),
+         resource('file2.txt')]
+    )

--- a/storage/api/list_objects_test.py
+++ b/storage/api/list_objects_test.py
@@ -12,9 +12,7 @@
 # limitations under the License.
 
 from list_objects import main
-from testing import CloudTest
 
 
-class TestListObjects(CloudTest):
-    def test_main(self):
-        main(self.config.CLOUD_STORAGE_BUCKET)
+def test_main(cloud_config):
+    main(cloud_config.CLOUD_STORAGE_BUCKET)

--- a/testing/cloud.py
+++ b/testing/cloud.py
@@ -47,6 +47,20 @@ class Config(object):
         return os.environ[name]
 
 
+def get_resource_path(resource, local_path):
+    global_resource_path = os.path.join(GLOBAL_RESOURCE_PATH, *resource)
+    local_resource_path = os.path.join(local_path, 'resources', *resource)
+
+    if os.path.exists(local_resource_path):
+        return local_resource_path
+
+    if os.path.exists(global_resource_path):
+        return global_resource_path
+
+    raise EnvironmentError('Resource {} not found.'.format(
+        os.path.join(*resource)))
+
+
 class CloudTest(unittest.TestCase):
     """Common base class for cloud tests."""
     def __init__(self, *args, **kwargs):
@@ -58,16 +72,5 @@ class CloudTest(unittest.TestCase):
         silence_requests()
 
     def resource_path(self, *resource):
-        global_resource_path = os.path.join(GLOBAL_RESOURCE_PATH, *resource)
-        local_resource_path = os.path.join(
-            os.path.dirname(inspect.getfile(self.__class__)),
-            'resources', *resource)
-
-        if os.path.exists(local_resource_path):
-            return local_resource_path
-
-        if os.path.exists(global_resource_path):
-            return global_resource_path
-
-        raise EnvironmentError('Resource {} not found.'.format(
-            os.path.join(*resource)))
+        local_path = os.path.dirname(inspect.getfile(self.__class__))
+        return get_resource_path(resource, local_path)


### PR DESCRIPTION
@jerjou - there was also a slight refactor to the resource thingy in `cloud.py`. Once this repository stabilizes, I'll like move a lot of this over to `gcp-python-repo-tools`.