### PR TITLE
Deprecate X-Google-Metadata-Request in favor new Metadata-Flavor header

### DIFF
--- a/compute/api/startup-script.sh
+++ b/compute/api/startup-script.sh
@@ -21,9 +21,9 @@ apt-get -y install imagemagick
 # Use the metadata server to get the configuration specified during
 # instance creation. Read more about metadata here:
 # https://cloud.google.com/compute/docs/metadata#querying
-IMAGE_URL=$(curl http://metadata/computeMetadata/v1/instance/attributes/url -H "X-Google-Metadata-Request: True")
-TEXT=$(curl http://metadata/computeMetadata/v1/instance/attributes/text -H "X-Google-Metadata-Request: True")
-CS_BUCKET=$(curl http://metadata/computeMetadata/v1/instance/attributes/bucket -H "X-Google-Metadata-Request: True")
+IMAGE_URL=$(curl http://metadata/computeMetadata/v1/instance/attributes/url -H "Metadata-Flavor: Google")
+TEXT=$(curl http://metadata/computeMetadata/v1/instance/attributes/text -H "Metadata-Flavor: Google")
+CS_BUCKET=$(curl http://metadata/computeMetadata/v1/instance/attributes/bucket -H "Metadata-Flavor: Google")
 
 mkdir image-output
 cd image-output


### PR DESCRIPTION
We are deprecating the use of the X-Google-Metadata-Request header in favor
of the latest header, Metadata-Flavor.

The transition is explained here:

https://cloud.google.com/compute/docs/metadata#transitioning