### PR TITLE
Fix KeyError exception when project has no logs

### DIFF
--- a/cloud_logging/api/list_logs.py
+++ b/cloud_logging/api/list_logs.py
@@ -25,6 +25,7 @@ For more information, see the README.md under /cloud_logging.
 
 # [START all]
 import argparse
+import sys
 
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
@@ -36,6 +37,9 @@ def list_logs(project_id, logging_service):
 
     while request:
         response = request.execute()
+        if len(response)==0:
+            print "No logs found in project {0}".format(project_id)
+            sys.exit(1) 
         for log in response['logs']:
             print(log['name'])
 

--- a/cloud_logging/api/list_logs.py
+++ b/cloud_logging/api/list_logs.py
@@ -37,9 +37,9 @@ def list_logs(project_id, logging_service):
 
     while request:
         response = request.execute()
-        if len(response)==0:
-            print "No logs found in project {0}".format(project_id)
-            sys.exit(1) 
+        if not response:
+            print("No logs found in {0} project").format(project_id)
+            return False 
         for log in response['logs']:
             print(log['name'])
 


### PR DESCRIPTION
Script was throwing "KeyError: 'logs'" when the project does not have any logs. 