### PR TITLE
Fix up Django URLs

### DIFF
--- a/cloud_logging/api/list_logs.py
+++ b/cloud_logging/api/list_logs.py
@@ -25,7 +25,6 @@ For more information, see the README.md under /cloud_logging.
 
 # [START all]
 import argparse
-import sys
 
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
@@ -39,7 +38,7 @@ def list_logs(project_id, logging_service):
         response = request.execute()
         if not response:
             print("No logs found in {0} project").format(project_id)
-            return False 
+            return False
         for log in response['logs']:
             print(log['name'])
 

--- a/container_engine/django_tutorial/mysite/urls.py
+++ b/container_engine/django_tutorial/mysite/urls.py
@@ -17,7 +17,7 @@ from django.conf.urls import include, url
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = [
-    url(r'^', include('polls.urls')),
+    url(r'^$', include('polls.urls')),
 ]
 
 # Only serve static files from Django during development

--- a/managed_vms/django_cloudsql/mysite/urls.py
+++ b/managed_vms/django_cloudsql/mysite/urls.py
@@ -15,5 +15,5 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 
-urlpatterns = [url(r'^polls/', include('polls.urls')),
+urlpatterns = [url(r'^$', include('polls.urls')),
                url(r'^admin/', admin.site.urls)]


### PR DESCRIPTION
Managed VMs tutorial should serve the polls app from the index.

Container Engine url should also have a dollar sign (not technically necessary but good for consistency).