### PR TITLE
Typo fix in samples/datastore/api/tasks.py

### DIFF
--- a/datastore/api/tasks.py
+++ b/datastore/api/tasks.py
@@ -21,7 +21,7 @@ from gcloud import datastore
 
 
 def create_client(project_id):
-    return gcloud.datastore.Client(project_id)
+    return datastore.Client(project_id)
 # [END build_service]
 
 


### PR DESCRIPTION
In https://cloud.google.com/datastore/docs/datastore-api-tutorial#storing_data, `build_service` block starts with `import gcloud` so calling create_client() throws an error that `datastore` is undefined. 