### PR TITLE
Get rid of Django URL warnings

### DIFF
--- a/container_engine/django_tutorial/mysite/urls.py
+++ b/container_engine/django_tutorial/mysite/urls.py
@@ -14,10 +14,12 @@
 
 from django.conf import settings
 from django.conf.urls import include, url
+from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = [
-    url(r'^$', include('polls.urls')),
+    url(r'^', include('polls.urls')),
+    url(r'^admin/', admin.site.urls)
 ]
 
 # Only serve static files from Django during development

--- a/container_engine/django_tutorial/polls/urls.py
+++ b/container_engine/django_tutorial/polls/urls.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 from django.conf.urls import url
-from django.contrib import admin
 
 from . import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^admin/', admin.site.urls)
+    url(r'^$', views.index, name='index')
 ]

--- a/managed_vms/django_cloudsql/mysite/urls.py
+++ b/managed_vms/django_cloudsql/mysite/urls.py
@@ -15,5 +15,5 @@
 from django.conf.urls import include, url
 from django.contrib import admin
 
-urlpatterns = [url(r'^$', include('polls.urls')),
+urlpatterns = [url(r'^', include('polls.urls')),
                url(r'^admin/', admin.site.urls)]


### PR DESCRIPTION
Sorry, last PR for this wasn't quite this right, this should be right.