### PR TITLE
Use Main Project (now whitelisted)

### DIFF
--- a/monitoring/api/v3/custom_metric_test.py
+++ b/monitoring/api/v3/custom_metric_test.py
@@ -27,18 +27,8 @@ from custom_metric import create_custom_metric, get_custom_metric
 from custom_metric import read_timeseries, write_timeseries_value
 import list_resources
 
-""" Change this to run against other prjoects
- GOOGLE_APPLICATION_CREDENTIALS must be the service account for this project
-"""
-
-# temporarily hard code to whitelisted project
-TEST_PROJECT_ID = 'cloud-monitoring-dev'
-# TEST_PROJECT_ID = os.getenv("GCLOUD_PROJECT", 'cloud-monitoring-dev')
-
-""" Custom metric domain for all cusotm metrics"""
+""" Custom metric domain for all custom metrics"""
 CUSTOM_METRIC_DOMAIN = "custom.googleapis.com"
-
-PROJECT_RESOURCE = "projects/{}".format(TEST_PROJECT_ID)
 
 METRIC = 'compute.googleapis.com/instance/cpu/usage_time'
 METRIC_NAME = ''.join(
@@ -47,7 +37,8 @@ METRIC_RESOURCE = "{}/{}".format(
     CUSTOM_METRIC_DOMAIN, METRIC_NAME)
 
 
-def test_custom_metric():
+def test_custom_metric(cloud_config):
+    PROJECT_RESOURCE = "projects/{}".format(cloud_config.project)
     client = list_resources.get_client()
     # Use a constant seed so psuedo random number is known ahead of time
     random.seed(1)

--- a/monitoring/api/v3/list_resources_test.py
+++ b/monitoring/api/v3/list_resources_test.py
@@ -24,14 +24,11 @@ import re
 
 import list_resources
 
-# temporarily hard code to whitelisted project
-TEST_PROJECT_ID = 'cloud-monitoring-dev'
-# TEST_PROJECT_ID = os.getenv("GCLOUD_PROJECT", 'cloud-monitoring-dev')
-PROJECT_RESOURCE = "projects/{}".format(TEST_PROJECT_ID)
 METRIC = 'compute.googleapis.com/instance/cpu/usage_time'
 
 
-def test_list_monitored_resources(capsys):
+def test_list_monitored_resources(cloud_config, capsys):
+    PROJECT_RESOURCE = "projects/{}".format(cloud_config.project)
     client = list_resources.get_client()
     list_resources.list_monitored_resource_descriptors(
         client, PROJECT_RESOURCE)
@@ -41,7 +38,8 @@ def test_list_monitored_resources(capsys):
     assert regex.search(stdout) is not None
 
 
-def test_list_metrics(capsys):
+def test_list_metrics(cloud_config, capsys):
+    PROJECT_RESOURCE = "projects/{}".format(cloud_config.project)
     client = list_resources.get_client()
     list_resources.list_metric_descriptors(
         client, PROJECT_RESOURCE, METRIC)
@@ -51,7 +49,8 @@ def test_list_metrics(capsys):
     assert regex.search(stdout) is not None
 
 
-def test_list_timeseries(capsys):
+def test_list_timeseries(cloud_config, capsys):
+    PROJECT_RESOURCE = "projects/{}".format(cloud_config.project)
     client = list_resources.get_client()
     list_resources.list_timeseries(
         client, PROJECT_RESOURCE, METRIC)


### PR DESCRIPTION
Now use main integration test project because it can be whitelisted.

Fix all variables names of metric name to metric type. 

Even though I was experimenting with flaky, the custom metric tests now seem less flaky so I think for now we can run them as default.