### PR TITLE
TRAVIS_COMMIT_RANGE isn't set on non-PRs

### DIFF
--- a/nox.py
+++ b/nox.py
@@ -59,7 +59,7 @@ def get_changed_files():
         # This is not a pull request.
         changed = subprocess.check_output(
             ['git', 'show', '--pretty=format:', '--name-only',
-                os.environ.get('TRAVIS_COMMIT_RANGE')])
+                os.environ.get('TRAVIS_COMMIT')])
     elif pr is not None:
         changed = subprocess.check_output(
             ['git', 'diff', '--name-only',


### PR DESCRIPTION
Travis is dying after a PR merge - I believe because TRAVIS_COMMIT_RANGE is empty after a merge. This is my guess as to how to fix it - feel free to educate me if there's a way to test this out..