### PR TITLE
Rename model usage to entity

### DIFF
--- a/appengine/standard/ndb/entities/snippets.py
+++ b/appengine/standard/ndb/entities/snippets.py
@@ -21,13 +21,13 @@ class Account(ndb.Model):
     email = ndb.StringProperty()
 
 
-def create_model_using_keyword_arguments():
+def create_entity_using_keyword_arguments():
     sandy = Account(
         username='Sandy', userid=123, email='sandy@example.com')
     return sandy
 
 
-def create_model_using_attributes():
+def create_entity_using_attributes():
     sandy = Account()
     sandy.username = 'Sandy'
     sandy.userid = 123
@@ -35,7 +35,7 @@ def create_model_using_attributes():
     return sandy
 
 
-def create_model_using_populate():
+def create_entity_using_populate():
     sandy = Account()
     sandy.populate(
         username='Sandy',
@@ -50,16 +50,16 @@ def demonstrate_model_constructor_type_checking():
     return bad
 
 
-def dmonstrate_model_attribute_type_checking(sandy):
+def demonstrate_entity_attribute_type_checking(sandy):
     sandy.username = 42  # raises an exception
 
 
-def save_model(sandy):
+def save_entity(sandy):
     sandy_key = sandy.put()
     return sandy_key
 
 
-def get_model(sandy_key):
+def get_entity(sandy_key):
     sandy = sandy_key.get()
     return sandy
 
@@ -75,7 +75,7 @@ def get_url_safe_key(sandy_key):
     return url_string
 
 
-def get_model_from_url_safe_key(url_string):
+def get_entity_from_url_safe_key(url_string):
     sandy_key = ndb.Key(urlsafe=url_string)
     sandy = sandy_key.get()
     return sandy
@@ -88,17 +88,17 @@ def get_key_and_numeric_id_from_url_safe_key(url_string):
     return key, ident, kind_string
 
 
-def update_model_from_key(key):
+def update_entity_from_key(key):
     sandy = key.get()
     sandy.email = 'sandy@example.co.uk'
     sandy.put()
 
 
-def delete_model(sandy):
+def delete_entity(sandy):
     sandy.key.delete()
 
 
-def create_model_with_named_key():
+def create_entity_with_named_key():
     account = Account(
         username='Sandy', userid=1234, email='sandy@example.com',
         id='sandy@example.com')
@@ -114,7 +114,7 @@ def set_key_directly(account):
     account.key = ndb.Key(Account, 'sandy@example.com')
 
 
-def create_model_with_generated_id():
+def create_entity_with_generated_id():
     # note: no id kwarg
     account = Account(username='Sandy', userid=1234, email='sandy@example.com')
     account.put()
@@ -127,7 +127,7 @@ class Revision(ndb.Model):
     message_text = ndb.StringProperty()
 
 
-def demonstrate_models_with_parent_hierarchy():
+def demonstrate_entities_with_parent_hierarchy():
     ndb.Key('Account', 'sandy@example.com', 'Message', 123, 'Revision', '1')
     ndb.Key('Account', 'sandy@example.com', 'Message', 123, 'Revision', '2')
     ndb.Key('Account', 'larry@example.com', 'Message', 456, 'Revision', '1')
@@ -149,7 +149,7 @@ def create_root_key():
     return sandy_key
 
 
-def create_model_with_parent_keys():
+def create_entity_with_parent_keys():
     account_key = ndb.Key(Account, 'sandy@example.com')
 
     # Ask Datastore to allocate an ID.
@@ -167,7 +167,7 @@ def create_model_with_parent_keys():
     return initial_revision
 
 
-def get_parent_key_of_model(initial_revision):
+def get_parent_key_of_entity(initial_revision):
     message_key = initial_revision.key.parent()
     return message_key
 
@@ -182,7 +182,7 @@ class Mine(ndb.Expando):
     pass
 
 
-def create_expando_model():
+def create_entity_using_expando_model():
     e = Mine()
     e.foo = 1
     e.bar = 'blah'
@@ -206,7 +206,7 @@ class FlexEmployee(ndb.Expando):
     age = ndb.IntegerProperty()
 
 
-def create_expando_model_with_defined_properties():
+def create_expando_model_entity_with_defined_properties():
     employee = FlexEmployee(name='Sandy', location='SF')
     return employee
 
@@ -215,7 +215,7 @@ class Specialized(ndb.Expando):
     _default_indexed = False
 
 
-def create_expando_model_that_isnt_indexed_by_default():
+def create_expando_model_entity_that_isnt_indexed_by_default():
     e = Specialized(foo='a', bar=['b'])
     return e._properties
     # {

--- a/appengine/standard/ndb/entities/snippets_test.py
+++ b/appengine/standard/ndb/entities/snippets_test.py
@@ -19,18 +19,18 @@ import pytest
 import snippets
 
 
-def test_create_model_using_keyword_arguments(testbed):
-    result = snippets.create_model_using_keyword_arguments()
+def test_create_entity_using_keyword_arguments(testbed):
+    result = snippets.create_entity_using_keyword_arguments()
     assert isinstance(result, snippets.Account)
 
 
-def test_create_model_using_attributes(testbed):
-    result = snippets.create_model_using_attributes()
+def test_create_entity_using_attributes(testbed):
+    result = snippets.create_entity_using_attributes()
     assert isinstance(result, snippets.Account)
 
 
-def test_create_model_using_populate(testbed):
-    result = snippets.create_model_using_populate()
+def test_create_entity_using_populate(testbed):
+    result = snippets.create_entity_using_populate()
     assert isinstance(result, snippets.Account)
 
 
@@ -39,52 +39,52 @@ def test_demonstrate_model_constructor_type_checking(testbed):
         snippets.demonstrate_model_constructor_type_checking()
 
 
-def test_dmonstrate_model_attribute_type_checking(testbed):
+def test_demonstrate_entity_attribute_type_checking(testbed):
     with pytest.raises(datastore_errors.BadValueError):
-        snippets.dmonstrate_model_attribute_type_checking(
-            snippets.create_model_using_keyword_arguments())
+        snippets.demonstrate_entity_attribute_type_checking(
+            snippets.create_entity_using_keyword_arguments())
 
 
-def test_save_model(testbed):
-    result = snippets.save_model(
-        snippets.create_model_using_keyword_arguments())
+def test_save_entity(testbed):
+    result = snippets.save_entity(
+        snippets.create_entity_using_keyword_arguments())
     assert isinstance(result, snippets.ndb.Key)
 
 
-def test_get_model(testbed):
-    sandy_key = snippets.save_model(
-        snippets.create_model_using_keyword_arguments())
-    result = snippets.get_model(sandy_key)
+def test_get_entity(testbed):
+    sandy_key = snippets.save_entity(
+        snippets.create_entity_using_keyword_arguments())
+    result = snippets.get_entity(sandy_key)
     assert isinstance(result, snippets.Account)
 
 
 def test_get_key_kind_and_id(testbed):
-    sandy_key = snippets.save_model(
-        snippets.create_model_using_keyword_arguments())
+    sandy_key = snippets.save_entity(
+        snippets.create_entity_using_keyword_arguments())
     kind_string, ident = snippets.get_key_kind_and_id(sandy_key)
     assert kind_string == 'Account'
     assert isinstance(ident, long)
 
 
 def test_get_url_safe_key(testbed):
-    sandy_key = snippets.save_model(
-        snippets.create_model_using_keyword_arguments())
+    sandy_key = snippets.save_entity(
+        snippets.create_entity_using_keyword_arguments())
     result = snippets.get_url_safe_key(sandy_key)
     assert isinstance(result, str)
 
 
-def test_get_model_from_url_safe_key(testbed):
-    sandy_key = snippets.save_model(
-        snippets.create_model_using_keyword_arguments())
-    result = snippets.get_model_from_url_safe_key(
+def test_get_entity_from_url_safe_key(testbed):
+    sandy_key = snippets.save_entity(
+        snippets.create_entity_using_keyword_arguments())
+    result = snippets.get_entity_from_url_safe_key(
         snippets.get_url_safe_key(sandy_key))
     assert isinstance(result, snippets.Account)
     assert result.username == 'Sandy'
 
 
 def test_get_key_and_numeric_id_from_url_safe_key(testbed):
-    sandy_key = snippets.save_model(
-        snippets.create_model_using_keyword_arguments())
+    sandy_key = snippets.save_entity(
+        snippets.create_entity_using_keyword_arguments())
     urlsafe = snippets.get_url_safe_key(sandy_key)
     key, ident, kind_string = (
         snippets.get_key_and_numeric_id_from_url_safe_key(urlsafe))
@@ -93,25 +93,25 @@ def test_get_key_and_numeric_id_from_url_safe_key(testbed):
     assert isinstance(kind_string, str)
 
 
-def test_update_model_from_key(testbed):
-    sandy = snippets.create_model_using_keyword_arguments()
-    sandy_key = snippets.save_model(sandy)
+def test_update_entity_from_key(testbed):
+    sandy = snippets.create_entity_using_keyword_arguments()
+    sandy_key = snippets.save_entity(sandy)
     urlsafe = snippets.get_url_safe_key(sandy_key)
     key, ident, kind_string = (
         snippets.get_key_and_numeric_id_from_url_safe_key(urlsafe))
-    snippets.update_model_from_key(key)
+    snippets.update_entity_from_key(key)
     assert key.get().email == 'sandy@example.co.uk'
 
 
-def test_delete_model(testbed):
-    sandy = snippets.create_model_using_keyword_arguments()
-    snippets.save_model(sandy)
-    snippets.delete_model(sandy)
+def test_delete_entity(testbed):
+    sandy = snippets.create_entity_using_keyword_arguments()
+    snippets.save_entity(sandy)
+    snippets.delete_entity(sandy)
     assert sandy.key.get() is None
 
 
-def test_create_model_with_named_key(testbed):
-    result = snippets.create_model_with_named_key()
+def test_create_entity_with_named_key(testbed):
+    result = snippets.create_entity_with_named_key()
     assert 'sandy@example.com' == result
 
 
@@ -121,13 +121,13 @@ def test_set_key_directly(testbed):
     assert account.key.id() == 'sandy@example.com'
 
 
-def test_create_model_with_generated_id(testbed):
-    result = snippets.create_model_with_generated_id()
+def test_create_entity_with_generated_id(testbed):
+    result = snippets.create_entity_with_generated_id()
     assert isinstance(result.key.id(), long)
 
 
-def test_demonstrate_models_with_parent_hierarchy(testbed):
-    snippets.demonstrate_models_with_parent_hierarchy()
+def test_demonstrate_entities_with_parent_hierarchy(testbed):
+    snippets.demonstrate_entities_with_parent_hierarchy()
 
 
 def test_equivalent_ways_to_define_key_with_parent(testbed):
@@ -139,14 +139,14 @@ def test_create_root_key(testbed):
     assert result.id() == 'sandy@example.com'
 
 
-def test_create_model_with_parent_keys(testbed):
-    result = snippets.create_model_with_parent_keys()
+def test_create_entity_with_parent_keys(testbed):
+    result = snippets.create_entity_with_parent_keys()
     assert result.message_text == 'Hello'
 
 
-def test_get_parent_key_of_model(testbed):
-    initial_revision = snippets.create_model_with_parent_keys()
-    result = snippets.get_parent_key_of_model(initial_revision)
+def test_get_parent_key_of_entity(testbed):
+    initial_revision = snippets.create_entity_with_parent_keys()
+    result = snippets.get_parent_key_of_entity(initial_revision)
     assert result.kind() == 'Message'
 
 
@@ -155,26 +155,27 @@ def test_operate_on_multiple_keys_at_once(testbed):
         snippets.Account(email='a@a.com'), snippets.Account(email='b@b.com')])
 
 
-def test_create_expando_model(testbed):
-    result = snippets.create_expando_model()
+def test_create_entity_using_expando_model(testbed):
+    result = snippets.create_entity_using_expando_model()
     assert result.foo == 1
 
 
 def test_get_properties_defined_on_expando(testbed):
     result = snippets.get_properties_defined_on_expando(
-        snippets.create_expando_model())
+        snippets.create_entity_using_expando_model())
     assert result['foo'] is not None
     assert result['bar'] is not None
     assert result['tags'] is not None
 
 
-def test_create_expando_model_with_defined_properties(testbed):
-    result = snippets.create_expando_model_with_defined_properties()
+def test_create_entity_using_expando_model_with_defined_properties(testbed):
+    result = snippets.create_expando_model_entity_with_defined_properties()
     assert result.name == 'Sandy'
 
 
-def test_create_expando_model_that_isnt_indexed_by_default(testbed):
-    result = snippets.create_expando_model_that_isnt_indexed_by_default()
+def test_create_expando_model_entity_that_isnt_indexed_by_default(testbed):
+    result = (
+        snippets.create_expando_model_entity_that_isnt_indexed_by_default())
     assert result['foo']
     assert result['bar']
 


### PR DESCRIPTION
Models are the class, entities are the datastore
instantiations of this class, so this change
is more conceptually accurate.