### PR TITLE
Update Bigtable samples to v2.

### DIFF
--- a/bigtable/hello/README.md
+++ b/bigtable/hello/README.md
@@ -1,19 +1,75 @@
 # Cloud Bigtable Hello World
 
 This is a simple application that demonstrates using the [Google Cloud Client
-Library][gcloud-python] to connect to and interact with Cloud Bigtable.
+Library][gcloud-python-bigtable] to connect to and interact with Cloud Bigtable.
 
-[gcloud-python]: https://github.com/GoogleCloudPlatform/gcloud-python
+<!-- auto-doc-link -->
+These samples are used on the following documentation page:
+
+> https://cloud.google.com/bigtable/docs/samples-python-hello
+
+<!-- end-auto-doc-link -->
+
+[gcloud-python-bigtable]: https://googlecloudplatform.github.io/gcloud-python/stable/bigtable-usage.html
+[sample-docs]: https://cloud.google.com/bigtable/docs/samples-python-hello
 
 
-## Provision a cluster
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
-Follow the instructions in the [user documentation](https://cloud.google.com/bigtable/docs/creating-cluster)
-to create a Google Cloud Platform project and Cloud Bigtable cluster if necessary.
-You'll need to reference your project ID, zone and cluster ID to run the application.
+- [Downloading the sample](#downloading-the-sample)
+- [Costs](#costs)
+- [Provisioning an instance](#provisioning-an-instance)
+- [Running the application](#running-the-application)
+- [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
-## Run the application
+## Downloading the sample
+
+Download the sample app and navigate into the app directory:
+
+1.  Clone the [Python samples
+    repository](https://github.com/GoogleCloudPlatform/python-docs-samples), to
+    your local machine:
+
+        git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+
+    Alternatively, you can [download the
+    sample](https://github.com/GoogleCloudPlatform/python-docs-samples/archive/master.zip)
+    as a zip file and extract it.
+
+2.  Change to the sample directory.
+
+        cd python-docs-samples/bigtable/hello
+
+
+## Costs
+
+This sample uses billable components of Cloud Platform, including:
+
++   Google Cloud Bigtable
+
+Use the [Pricing Calculator][bigtable-pricing] to generate a cost estimate
+based on your projected usage.  New Cloud Platform users might be eligible for
+a [free trial][free-trial].
+
+[bigtable-pricing]: https://cloud.google.com/products/calculator/#id=1eb47664-13a2-4be1-9d16-6722902a7572
+[free-trial]: https://cloud.google.com/free-trial
+
+
+## Provisioning an instance
+
+Follow the instructions in the [user
+documentation](https://cloud.google.com/bigtable/docs/creating-instance) to
+create a Google Cloud Platform project and Cloud Bigtable instance if necessary.
+You'll need to reference your project id and instance id to run the
+application.
+
+
+## Running the application
 
 First, set your [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
 
@@ -23,20 +79,29 @@ Install the dependencies with pip.
 $ pip install -r requirements.txt
 ```
 
-Run the application. Replace the command-line parameters with values for your cluster.
+Run the application. Replace the command-line parameters with values for your instance.
 
 ```
-$ python main.py my-project my-cluster us-central1-c
+$ python main.py my-project my-instance
 ```
 
 You will see output resembling the following:
 
 ```
-Create table Hello-Bigtable-1234
+Create table Hello-Bigtable
 Write some greetings to the table
 Scan for all greetings:
         greeting0: Hello World!
         greeting1: Hello Cloud Bigtable!
         greeting2: Hello HappyBase!
-Delete table Hello-Bigtable-1234
+Delete table Hello-Bigtable
 ```
+
+
+## Cleaning up
+
+To avoid incurring extra charges to your Google Cloud Platform account, remove
+the resources created for this sample.
+
+- [Delete the Cloud Bigtable
+  instance](https://cloud.google.com/bigtable/docs/deleting-instance).

--- a/bigtable/hello/main.py
+++ b/bigtable/hello/main.py
@@ -29,17 +29,17 @@ import argparse
 from gcloud import bigtable
 
 
-def main(project_id, cluster_id, zone, table_id):
+def main(project_id, instance_id, table_id):
     # [START connecting_to_bigtable]
     # The client must be created with admin=True because it will create a
     # table.
     with bigtable.Client(project=project_id, admin=True) as client:
-        cluster = client.cluster(zone, cluster_id)
+        instance = client.instance(instance_id)
         # [END connecting_to_bigtable]
 
         # [START creating_a_table]
         print('Creating the {} table.'.format(table_id))
-        table = cluster.table(table_id)
+        table = instance.table(table_id)
         table.create()
         column_family_id = 'cf1'
         cf1 = table.column_family(column_family_id)
@@ -107,13 +107,11 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('project_id', help='Your Cloud Platform project ID.')
     parser.add_argument(
-        'cluster', help='ID of the Cloud Bigtable cluster to connect to.')
-    parser.add_argument(
-        'zone', help='Zone that contains the Cloud Bigtable cluster.')
+        'instance_id', help='ID of the Cloud Bigtable instance to connect to.')
     parser.add_argument(
         '--table',
         help='Table to create and destroy.',
         default='Hello-Bigtable')
 
     args = parser.parse_args()
-    main(args.project_id, args.cluster, args.zone, args.table)
+    main(args.project_id, args.instance_id, args.table)

--- a/bigtable/hello/main_test.py
+++ b/bigtable/hello/main_test.py
@@ -33,8 +33,7 @@ def test_main(cloud_config, capsys):
         random.randrange(TABLE_NAME_RANGE))
     main(
         cloud_config.project,
-        cloud_config.bigtable_cluster,
-        cloud_config.bigtable_zone,
+        cloud_config.bigtable_instance,
         table_name)
 
     out, _ = capsys.readouterr()

--- a/bigtable/hello/requirements.txt
+++ b/bigtable/hello/requirements.txt
@@ -1,1 +1,1 @@
-gcloud[grpc]==0.16.0
+gcloud[grpc]==0.17.0

--- a/bigtable/hello_happybase/README.md
+++ b/bigtable/hello_happybase/README.md
@@ -1,19 +1,77 @@
-# Cloud Bigtable Hello World (HappyBase)
+# Cloud Bigtable Hello World via the HappyBase API
 
 This is a simple application that demonstrates using the [Google Cloud Client
-Library][gcloud-python] to connect to and interact with Cloud Bigtable.
+Library HappyBase package][gcloud-python-happybase], an implementation of the [HappyBase
+API][happybase] to connect to and interact with Cloud Bigtable.
 
-[gcloud-python]: https://github.com/GoogleCloudPlatform/gcloud-python
+<!-- auto-doc-link -->
+These samples are used on the following documentation page:
+
+> https://cloud.google.com/bigtable/docs/samples-python-hello-happybase
+
+<!-- end-auto-doc-link -->
+
+[gcloud-python-happybase]: https://googlecloudplatform.github.io/gcloud-python/stable/happybase-package.html
+[happybase]: http://happybase.readthedocs.io/en/stable/
+[sample-docs]: https://cloud.google.com/bigtable/docs/samples-python-hello-happybase
 
 
-## Provision a cluster
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
-Follow the instructions in the [user documentation](https://cloud.google.com/bigtable/docs/creating-cluster)
-to create a Google Cloud Platform project and Cloud Bigtable cluster if necessary.
-You'll need to reference your project ID, zone and cluster ID to run the application.
+- [Downloading the sample](#downloading-the-sample)
+- [Costs](#costs)
+- [Provisioning an instance](#provisioning-an-instance)
+- [Running the application](#running-the-application)
+- [Cleaning up](#cleaning-up)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
-## Run the application
+## Downloading the sample
+
+Download the sample app and navigate into the app directory:
+
+1.  Clone the [Python samples
+    repository](https://github.com/GoogleCloudPlatform/python-docs-samples), to
+    your local machine:
+
+        git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+
+    Alternatively, you can [download the
+    sample](https://github.com/GoogleCloudPlatform/python-docs-samples/archive/master.zip)
+    as a zip file and extract it.
+
+2.  Change to the sample directory.
+
+        cd python-docs-samples/bigtable/hello_happybase
+
+
+## Costs
+
+This sample uses billable components of Cloud Platform, including:
+
++   Google Cloud Bigtable
+
+Use the [Pricing Calculator][bigtable-pricing] to generate a cost estimate
+based on your projected usage.  New Cloud Platform users might be eligible for
+a [free trial][free-trial].
+
+[bigtable-pricing]: https://cloud.google.com/products/calculator/#id=1eb47664-13a2-4be1-9d16-6722902a7572
+[free-trial]: https://cloud.google.com/free-trial
+
+
+## Provisioning an instance
+
+Follow the instructions in the [user
+documentation](https://cloud.google.com/bigtable/docs/creating-instance) to
+create a Google Cloud Platform project and Cloud Bigtable instance if necessary.
+You'll need to reference your project id and instance id to run the
+application.
+
+
+## Running the application
 
 First, set your [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials)
 
@@ -23,45 +81,29 @@ Install the dependencies with pip.
 $ pip install -r requirements.txt
 ```
 
-Run the application. Replace the command-line parameters with values for your cluster.
+Run the application. Replace the command-line parameters with values for your instance.
 
 ```
-$ python main.py my-project my-cluster us-central1-c
+$ python main.py my-project my-instance
 ```
 
 You will see output resembling the following:
 
 ```
-Create table Hello-Bigtable-1234
+Create table Hello-Bigtable
 Write some greetings to the table
 Scan for all greetings:
         greeting0: Hello World!
         greeting1: Hello Cloud Bigtable!
         greeting2: Hello HappyBase!
-Delete table Hello-Bigtable-1234
+Delete table Hello-Bigtable
 ```
 
-## Understanding the code
 
-The [application](main.py) uses the [Google Cloud Bigtable HappyBase
-package][Bigtable HappyBase], an implementation of the [HappyBase][HappyBase]
-library, to make calls to Cloud Bigtable. It demonstrates several basic
-concepts of working with Cloud Bigtable via this API:
+## Cleaning up
 
-[Bigtable HappyBase]: https://googlecloudplatform.github.io/gcloud-python/stable/happybase-package.html
-[HappyBase]: http://happybase.readthedocs.io/en/latest/index.html
+To avoid incurring extra charges to your Google Cloud Platform account, remove
+the resources created for this sample.
 
-- Creating a [Connection][HappyBase Connection] to a Cloud Bigtable
-  [Cluster][Cluster API].
-- Using the [Connection][HappyBase Connection] interface to create, disable and
-  delete a [Table][HappyBase Table].
-- Using the Connection to get a Table.
-- Using the Table to write rows via a [put][HappyBase Table Put] and scan
-  across multiple rows using [scan][HappyBase Table Scan].
-
-[Cluster API]: https://googlecloudplatform.github.io/gcloud-python/stable/bigtable-cluster.html
-[HappyBase Connection]: https://googlecloudplatform.github.io/gcloud-python/stable/happybase-connection.html
-[HappyBase Table]: https://googlecloudplatform.github.io/gcloud-python/stable/happybase-table.html
-[HappyBase Table Put]: https://googlecloudplatform.github.io/gcloud-python/stable/happybase-table.html#gcloud.bigtable.happybase.table.Table.put
-[HappyBase Table Scan]: https://googlecloudplatform.github.io/gcloud-python/stable/happybase-table.html#gcloud.bigtable.happybase.table.Table.scan
-
+- [Delete the Cloud Bigtable
+  instance](https://cloud.google.com/bigtable/docs/deleting-instance).

--- a/bigtable/hello_happybase/main.py
+++ b/bigtable/hello_happybase/main.py
@@ -30,13 +30,13 @@ from gcloud import bigtable
 from gcloud.bigtable import happybase
 
 
-def main(project_id, cluster_id, zone, table_name):
+def main(project_id, instance_id, table_name):
     # [START connecting_to_bigtable]
     # The client must be created with admin=True because it will create a
     # table.
     client = bigtable.Client(project=project_id, admin=True)
-    cluster = client.cluster(zone, cluster_id)
-    connection = happybase.Connection(cluster=cluster)
+    instance = client.instance(instance_id)
+    connection = happybase.Connection(instance=instance)
     # [END connecting_to_bigtable]
 
     try:
@@ -104,13 +104,11 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('project_id', help='Your Cloud Platform project ID.')
     parser.add_argument(
-        'cluster', help='ID of the Cloud Bigtable cluster to connect to.')
-    parser.add_argument(
-        'zone', help='Zone that contains the Cloud Bigtable cluster.')
+        'instance_id', help='ID of the Cloud Bigtable instance to connect to.')
     parser.add_argument(
         '--table',
         help='Table to create and destroy.',
         default='Hello-Bigtable')
 
     args = parser.parse_args()
-    main(args.project_id, args.cluster, args.zone, args.table)
+    main(args.project_id, args.instance_id, args.table)

--- a/bigtable/hello_happybase/main_test.py
+++ b/bigtable/hello_happybase/main_test.py
@@ -33,8 +33,7 @@ def test_main(cloud_config, capsys):
         random.randrange(TABLE_NAME_RANGE))
     main(
         cloud_config.project,
-        cloud_config.bigtable_cluster,
-        cloud_config.bigtable_zone,
+        cloud_config.bigtable_instance,
         table_name)
 
     out, _ = capsys.readouterr()

--- a/bigtable/hello_happybase/requirements.txt
+++ b/bigtable/hello_happybase/requirements.txt
@@ -1,1 +1,1 @@
-gcloud[grpc]==0.16.0
+gcloud[grpc]==0.17.0

--- a/conftest.py
+++ b/conftest.py
@@ -29,8 +29,7 @@ def cloud_config():
         project=os.environ.get('GCLOUD_PROJECT'),
         storage_bucket=os.environ.get('CLOUD_STORAGE_BUCKET'),
         client_secrets=os.environ.get('GOOGLE_CLIENT_SECRETS'),
-        bigtable_cluster=os.environ.get('BIGTABLE_CLUSTER'),
-        bigtable_zone=os.environ.get('BIGTABLE_ZONE'))
+        bigtable_instance=os.environ.get('BIGTABLE_CLUSTER'))
 
 
 def get_resource_path(resource, local_path):

--- a/scripts/prepare-testing-project.sh
+++ b/scripts/prepare-testing-project.sh
@@ -44,4 +44,4 @@ echo "Creating pubsub resources."
 gcloud alpha pubsub topics create gae-mvm-pubsub-topic
 
 echo "To finish setup, follow this link to enable APIs."
-echo "https://console.cloud.google.com/flows/enableapi?project=${GCLOUD_PROJECT}&apiid=bigtable,bigtableclusteradmin,bigtabletableadmin,bigquery,cloudmonitoring,compute_component,datastore,datastore.googleapis.com,dataproc,dns,plus,pubsub,logging,storage_api,vision.googleapis.com"
+echo "https://console.cloud.google.com/flows/enableapi?project=${GCLOUD_PROJECT}&apiid=bigtable.googleapis.com,bigtableadmin.googleapis.com,bigquery,cloudmonitoring,compute_component,datastore,datastore.googleapis.com,dataproc,dns,plus,pubsub,logging,storage_api,vision.googleapis.com"

--- a/scripts/resources/docs-links.json
+++ b/scripts/resources/docs-links.json
@@ -364,5 +364,11 @@
   "/appengine/docs/python/memcache/examples": [
     "appengine/memcache/snippets/snippets.py", 
     "appengine/memcache/guestbook/main.py"
+  ],
+  "/bigtable/docs/samples-python-hello": [
+    "bigtable/hello/main.py"
+  ],
+  "/bigtable/docs/samples-python-hello-happybase": [
+    "bigtable/hello_happybase/main.py"
   ]
 }


### PR DESCRIPTION
Table of Contents generated with:

    doctoc --title '**Table of Contents**' bigtable

Needs to wait for next gcloud-python launch so that https://github.com/GoogleCloudPlatform/gcloud-python/pull/1932 can go in. Tested locally on the bigtable-v2 branch of gcloud-python with a
previous version of grpcio.