### PR TITLE
Document usage of useLegacySQL parameter in BigQuery samples.

### DIFF
--- a/bigquery/api/async_query.py
+++ b/bigquery/api/async_query.py
@@ -15,10 +15,6 @@
 
 """Command-line application to perform an asynchronous query in BigQuery.
 
-This sample is used on this page:
-
-    https://cloud.google.com/bigquery/querying-data#asyncqueries
-
 For more information, see the README.md under /bigquery.
 """
 
@@ -32,7 +28,9 @@ from oauth2client.client import GoogleCredentials
 
 
 # [START async_query]
-def async_query(bigquery, project_id, query, batch=False, num_retries=5):
+def async_query(
+        bigquery, project_id, query,
+        batch=False, num_retries=5, use_legacy_sql=False):
     # Generate a unique job ID so retries
     # don't accidentally duplicate query
     job_data = {
@@ -43,7 +41,10 @@ def async_query(bigquery, project_id, query, batch=False, num_retries=5):
         'configuration': {
             'query': {
                 'query': query,
-                'priority': 'BATCH' if batch else 'INTERACTIVE'
+                'priority': 'BATCH' if batch else 'INTERACTIVE',
+                # Set to False to use standard SQL syntax. See:
+                # https://cloud.google.com/bigquery/sql-reference/enabling-standard-sql
+                'useLegacySQL': use_legacy_sql
             }
         }
     }
@@ -77,7 +78,9 @@ def poll_job(bigquery, job):
 
 
 # [START run]
-def main(project_id, query_string, batch, num_retries, interval):
+def main(
+        project_id, query_string, batch, num_retries, interval,
+        use_legacy_sql):
     # [START build_service]
     # Grab the application's default credentials from the environment.
     credentials = GoogleCredentials.get_application_default()
@@ -92,7 +95,8 @@ def main(project_id, query_string, batch, num_retries, interval):
         project_id,
         query_string,
         batch,
-        num_retries)
+        num_retries,
+        use_legacy_sql)
 
     poll_job(bigquery, query_job)
 
@@ -130,6 +134,11 @@ if __name__ == '__main__':
         help='How often to poll the query for completion (seconds).',
         type=int,
         default=1)
+    parser.add_argument(
+        '-l', '--use_legacy_sql',
+        help='Use legacy BigQuery SQL syntax instead of standard SQL syntax.',
+        type=bool,
+        default=False)
 
     args = parser.parse_args()
 
@@ -138,5 +147,6 @@ if __name__ == '__main__':
         args.query,
         args.batch,
         args.num_retries,
-        args.poll_interval)
+        args.poll_interval,
+        args.use_legacy_sql)
 # [END main]

--- a/bigquery/api/async_query_test.py
+++ b/bigquery/api/async_query_test.py
@@ -26,7 +26,27 @@ def test_async_query(cloud_config, capsys):
         query_string=query,
         batch=False,
         num_retries=5,
-        interval=1)
+        interval=1,
+        use_legacy_sql=True)
+
+    out, _ = capsys.readouterr()
+    value = out.strip().split('\n').pop()
+
+    assert json.loads(value) is not None
+
+
+def test_async_query_standard_sql(cloud_config, capsys):
+    query = (
+        'SELECT corpus FROM publicdata.samples.shakespeare '
+        'GROUP BY corpus;')
+
+    main(
+        project_id=cloud_config.project,
+        query_string=query,
+        batch=False,
+        num_retries=5,
+        interval=1,
+        use_legacy_sql=False)
 
     out, _ = capsys.readouterr()
     value = out.strip().split('\n').pop()

--- a/bigquery/api/sync_query.py
+++ b/bigquery/api/sync_query.py
@@ -15,10 +15,6 @@
 
 """Command-line application to perform an synchronous query in BigQuery.
 
-This sample is used on this page:
-
-    https://cloud.google.com/bigquery/querying-data#syncqueries
-
 For more information, see the README.md under /bigquery.
 """
 
@@ -30,10 +26,15 @@ from oauth2client.client import GoogleCredentials
 
 
 # [START sync_query]
-def sync_query(bigquery, project_id, query, timeout=10000, num_retries=5):
+def sync_query(
+        bigquery, project_id, query,
+        timeout=10000, num_retries=5, use_legacy_sql=False):
     query_data = {
         'query': query,
         'timeoutMs': timeout,
+        # Set to False to use standard SQL syntax. See:
+        # https://cloud.google.com/bigquery/sql-reference/enabling-standard-sql
+        'useLegacySQL': use_legacy_sql
     }
     return bigquery.jobs().query(
         projectId=project_id,
@@ -42,7 +43,7 @@ def sync_query(bigquery, project_id, query, timeout=10000, num_retries=5):
 
 
 # [START run]
-def main(project_id, query, timeout, num_retries):
+def main(project_id, query, timeout, num_retries, use_legacy_sql):
     # [START build_service]
     # Grab the application's default credentials from the environment.
     credentials = GoogleCredentials.get_application_default()
@@ -56,7 +57,8 @@ def main(project_id, query, timeout, num_retries):
         project_id,
         query,
         timeout,
-        num_retries)
+        num_retries,
+        use_legacy_sql)
 
     # [START paging]
     # Page through the result set and print all results.
@@ -96,6 +98,11 @@ if __name__ == '__main__':
         help='Number of times to retry in case of 500 error.',
         type=int,
         default=5)
+    parser.add_argument(
+        '-l', '--use_legacy_sql',
+        help='Use legacy BigQuery SQL syntax instead of standard SQL syntax.',
+        type=bool,
+        default=False)
 
     args = parser.parse_args()
 
@@ -103,6 +110,7 @@ if __name__ == '__main__':
         args.project_id,
         args.query,
         args.timeout,
-        args.num_retries)
+        args.num_retries,
+        args.use_legacy_sql)
 
 # [END main]

--- a/bigquery/api/sync_query_test.py
+++ b/bigquery/api/sync_query_test.py
@@ -25,7 +25,26 @@ def test_sync_query(cloud_config, capsys):
         project_id=cloud_config.project,
         query=query,
         timeout=30,
-        num_retries=5)
+        num_retries=5,
+        use_legacy_sql=True)
+
+    out, _ = capsys.readouterr()
+    result = out.split('\n')[0]
+
+    assert json.loads(result) is not None
+
+
+def test_sync_query_standard_sql(cloud_config, capsys):
+    query = (
+        'SELECT corpus FROM publicdata.samples.shakespeare '
+        'GROUP BY corpus;')
+
+    main(
+        project_id=cloud_config.project,
+        query=query,
+        timeout=30,
+        num_retries=5,
+        use_legacy_sql=False)
 
     out, _ = capsys.readouterr()
     result = out.split('\n')[0]


### PR DESCRIPTION
The useLegacySQL parameter must be explicitly set in order to use
standard SQL syntax. This adds usage of that parameter to the query
samples.

I plan to also include this code in the table at
https://cloud.google.com/bigquery/sql-reference/enabling-standard-sql