### PR TITLE
Correct the usage of the echo-client.py command

### DIFF
--- a/appengine/flexible/endpoints/README.md
+++ b/appengine/flexible/endpoints/README.md
@@ -55,7 +55,7 @@ With the project deployed, you'll need to create an API key to access the API.
 
 With the API key, you can use the echo client to access the API:
 
-    $ python clients/echo-client.py https://YOUR-PROJECT-ID.appspot.com YOUR-API-KEY
+    $ python clients/echo-client.py https://YOUR-PROJECT-ID.appspot.com YOUR-API-KEY helloworld
 
 ### Using the JWT client (with key file)
 


### PR DESCRIPTION
The command requires three arguments while the instruction only
specified two.