### PR TITLE
grpc samples: specify type on --sample_rate to prevent TypeError

### DIFF
--- a/speech/grpc/transcribe.py
+++ b/speech/grpc/transcribe.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         '--encoding', default='FLAC', choices=[
             'LINEAR16', 'FLAC', 'MULAW', 'AMR', 'AMR_WB'],
         help='How the audio file is encoded. See {}#L67'.format(PROTO_URL))
-    parser.add_argument('--sample_rate', default=16000)
+    parser.add_argument('--sample_rate', type=int, default=16000)
 
     args = parser.parse_args()
     main(args.input_uri, args.encoding, args.sample_rate)

--- a/speech/grpc/transcribe_async.py
+++ b/speech/grpc/transcribe_async.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
         help='How the audio file is encoded. See {}#L67'.format(
             'https://github.com/googleapis/googleapis/blob/master/'
             'google/cloud/speech/v1beta1/cloud_speech.proto'))
-    parser.add_argument('--sample_rate', default=16000)
+    parser.add_argument('--sample_rate', type=int, default=16000)
 
     args = parser.parse_args()
     main(args.input_uri, args.encoding, args.sample_rate)


### PR DESCRIPTION
The `--sample_rate` argument in `speech/grpc/transcribe.py` and `speech/grpc/transcribe_async.py` did not specify a type, which meant the value would be treated as a string, resulting in an exception during protobuf conversion:

```bash
$ python transcribe.py --encoding FLAC --sample_rate 16000 gs://path/to/my.flac
Traceback (most recent call last):
  File "transcribe.py", line 95, in <module>
    main(args.input_uri, args.encoding, args.sample_rate)
  File "transcribe.py", line 66, in main
    language_code='en-US',  # a BCP-47 language tag
  File "/Users/zackse/code/python/contrib/python-docs-samples/speech/api-client/env/lib/python2.7/site-packages/google/protobuf/internal/python_message.py", line 535, in init
    _ReraiseTypeErrorWithFieldName(message_descriptor.name, field_name)
  File "/Users/zackse/code/python/contrib/python-docs-samples/speech/api-client/env/lib/python2.7/site-packages/google/protobuf/internal/python_message.py", line 455, in _ReraiseTypeErrorWithFieldName
    six.reraise(type(exc), exc, sys.exc_info()[2])
  File "/Users/zackse/code/python/contrib/python-docs-samples/speech/api-client/env/lib/python2.7/site-packages/google/protobuf/internal/python_message.py", line 533, in init
    setattr(self, field_name, field_value)
  File "/Users/zackse/code/python/contrib/python-docs-samples/speech/api-client/env/lib/python2.7/site-packages/google/protobuf/internal/python_message.py", line 669, in field_setter
    new_value = type_checker.CheckValue(new_value)
  File "/Users/zackse/code/python/contrib/python-docs-samples/speech/api-client/env/lib/python2.7/site-packages/google/protobuf/internal/type_checkers.py", line 132, in CheckValue
    raise TypeError(message)
TypeError: '16000' has type <type 'str'>, but expected one of: (<type 'int'>, <type 'long'>) for field RecognitionConfig.sample_rate
```

Hope this helps. Thanks for this service and the samples!