### PR TITLE
Typo in BQ Standard SQL samples.

### DIFF
--- a/bigquery/api/async_query.py
+++ b/bigquery/api/async_query.py
@@ -44,7 +44,7 @@ def async_query(
                 'priority': 'BATCH' if batch else 'INTERACTIVE',
                 # Set to False to use standard SQL syntax. See:
                 # https://cloud.google.com/bigquery/sql-reference/enabling-standard-sql
-                'useLegacySQL': use_legacy_sql
+                'useLegacySql': use_legacy_sql
             }
         }
     }

--- a/bigquery/api/async_query_test.py
+++ b/bigquery/api/async_query_test.py
@@ -36,9 +36,7 @@ def test_async_query(cloud_config, capsys):
 
 
 def test_async_query_standard_sql(cloud_config, capsys):
-    query = (
-        'SELECT corpus FROM publicdata.samples.shakespeare '
-        'GROUP BY corpus;')
+    query = 'SELECT [1, 2, 3] AS arr;'  # Only valid in standard SQL
 
     main(
         project_id=cloud_config.project,

--- a/bigquery/api/sync_query.py
+++ b/bigquery/api/sync_query.py
@@ -34,7 +34,7 @@ def sync_query(
         'timeoutMs': timeout,
         # Set to False to use standard SQL syntax. See:
         # https://cloud.google.com/bigquery/sql-reference/enabling-standard-sql
-        'useLegacySQL': use_legacy_sql
+        'useLegacySql': use_legacy_sql
     }
     return bigquery.jobs().query(
         projectId=project_id,

--- a/bigquery/api/sync_query_test.py
+++ b/bigquery/api/sync_query_test.py
@@ -35,9 +35,7 @@ def test_sync_query(cloud_config, capsys):
 
 
 def test_sync_query_standard_sql(cloud_config, capsys):
-    query = (
-        'SELECT corpus FROM publicdata.samples.shakespeare '
-        'GROUP BY corpus;')
+    query = 'SELECT [1, 2, 3] AS arr;'  # Only valid in standard SQL
 
     main(
         project_id=cloud_config.project,


### PR DESCRIPTION
The parameter is useLegacySql not useLegacySQL. See:
https://code.google.com/p/google-bigquery/issues/detail?id=701

I also update the tests to use a query that only works with standard SQL
for those tests.