### PR TITLE
Remove mention of going to / for the Endpoints sample.

### DIFF
--- a/appengine/flexible/endpoints/README.md
+++ b/appengine/flexible/endpoints/README.md
@@ -25,8 +25,6 @@ Run the application:
 $ python main.py
 ```
 
-In your web browser, go to the following address: http://localhost:8080.
-
 ### Using the echo client
 
 With the app running locally, you can execute the simple echo client using:


### PR DESCRIPTION
Since index.html has been removed, going to / is no longer a valid step.
Instead, the user should jump straight to calling the echo method.