### PR TITLE
Manually add required padding before base64.b64decode.

### DIFF
--- a/appengine/flexible/endpoints/main.py
+++ b/appengine/flexible/endpoints/main.py
@@ -42,6 +42,11 @@ def auth_info():
     encoded_info = request.headers.get('X-Endpoint-API-UserInfo', None)
 
     if encoded_info:
+        # Add paddings manually if necessary.
+        num_missed_paddings = 4 - len(encoded_info) % 4
+        if num_missed_paddings != 4:
+            encoded_info += b'=' * num_missed_paddings
+
         info_json = base64.b64decode(encoded_info).decode('utf-8')
         user_info = json.loads(info_json)
     else:

--- a/appengine/flexible/endpoints/main.py
+++ b/appengine/flexible/endpoints/main.py
@@ -30,6 +30,14 @@ from six.moves import http_client
 app = Flask(__name__)
 
 
+def _base64_decode(encoded_str):
+    # Add paddings manually if necessary.
+    num_missed_paddings = 4 - len(encoded_str) % 4
+    if num_missed_paddings != 4:
+        encoded_str += b'=' * num_missed_paddings
+    return base64.b64decode(encoded_str).decode('utf-8')
+
+
 @app.route('/echo', methods=['POST'])
 def echo():
     """Simple echo service."""
@@ -42,12 +50,7 @@ def auth_info():
     encoded_info = request.headers.get('X-Endpoint-API-UserInfo', None)
 
     if encoded_info:
-        # Add paddings manually if necessary.
-        num_missed_paddings = 4 - len(encoded_info) % 4
-        if num_missed_paddings != 4:
-            encoded_info += b'=' * num_missed_paddings
-
-        info_json = base64.b64decode(encoded_info).decode('utf-8')
+        info_json = _base64_decode(encoded_info)
         user_info = json.loads(info_json)
     else:
         user_info = {'id': 'anonymous'}


### PR DESCRIPTION
Currently the value of the "X-Endpoint-API-UserInfo" header does not
contain paddings. This causes incorrect padding error when doing
base64.b64decode(). This commit fixes the behavior by manually adding
paddings when necessary.