### PR TITLE
Use unittest.TestCase assertions

### DIFF
--- a/appengine/standard/localtesting/env_vars_test.py
+++ b/appengine/standard/localtesting/env_vars_test.py
@@ -32,8 +32,8 @@ class EnvVarsTestCase(unittest.TestCase):
         self.testbed.deactivate()
 
     def testEnvVars(self):
-        assert os.environ['APPLICATION_ID'] == 'your-app-id'
-        assert os.environ['MY_CONFIG_SETTING'] == 'example'
+        self.assertEqual(os.environ['APPLICATION_ID'], 'your-app-id')
+        self.assertEqual(os.environ['MY_CONFIG_SETTING'], 'example')
 # [END env_example]
 
 if __name__ == '__main__':

--- a/appengine/standard/localtesting/login_test.py
+++ b/appengine/standard/localtesting/login_test.py
@@ -41,11 +41,11 @@ class LoginTestCase(unittest.TestCase):
 
     # [START test]
     def testLogin(self):
-        assert not users.get_current_user()
+        self.assertFalse(users.get_current_user())
         self.loginUser()
-        assert users.get_current_user().email() == 'user@example.com'
+        self.assertEquals(users.get_current_user().email(), 'user@example.com')
         self.loginUser(is_admin=True)
-        assert users.is_current_user_admin()
+        self.assertTrue(users.is_current_user_admin())
     # [END test]
 # [END login_example]
 

--- a/appengine/standard/localtesting/task_queue_test.py
+++ b/appengine/standard/localtesting/task_queue_test.py
@@ -40,8 +40,8 @@ class TaskQueueTestCase(unittest.TestCase):
     def testTaskAddedToQueue(self):
         taskqueue.Task(name='my_task', url='/url/of/my/task/').add()
         tasks = self.taskqueue_stub.get_filtered_tasks()
-        assert len(tasks) == 1
-        assert tasks[0].name == 'my_task'
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].name, 'my_task')
 # [END taskqueue]
 
     # [START filtering]
@@ -51,27 +51,27 @@ class TaskQueueTestCase(unittest.TestCase):
 
         # All tasks
         tasks = self.taskqueue_stub.get_filtered_tasks()
-        assert len(tasks) == 2
+        self.assertEqual(len(tasks), 2)
 
         # Filter by name
         tasks = self.taskqueue_stub.get_filtered_tasks(name='task_one')
-        assert len(tasks) == 1
-        assert tasks[0].name == 'task_one'
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].name, 'task_one')
 
         # Filter by URL
         tasks = self.taskqueue_stub.get_filtered_tasks(url='/url/of/task/1/')
-        assert len(tasks) == 1
-        assert tasks[0].name == 'task_one'
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].name, 'task_one')
 
         # Filter by queue
         tasks = self.taskqueue_stub.get_filtered_tasks(queue_names='queue-1')
-        assert len(tasks) == 1
-        assert tasks[0].name == 'task_one'
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].name, 'task_one')
 
         # Multiple queues
         tasks = self.taskqueue_stub.get_filtered_tasks(
             queue_names=['queue-1', 'queue-2'])
-        assert len(tasks) == 2
+        self.assertEqual(len(tasks), 2)
     # [END filtering]
 
     # [START deferred]
@@ -79,10 +79,10 @@ class TaskQueueTestCase(unittest.TestCase):
         deferred.defer(operator.add, 1, 2)
 
         tasks = self.taskqueue_stub.get_filtered_tasks()
-        assert len(tasks) == 1
+        self.assertEqual(len(tasks), 1)
 
         result = deferred.run(tasks[0].payload)
-        assert result == 3
+        self.assertEqual(result, 3)
     # [END deferred]
 
 if __name__ == '__main__':


### PR DESCRIPTION
While inside a class that inherits from unittest.TestCase it makes sense to use provided by TestCase assertion methods instead of pure Python's assertion()