### PR TITLE
add resource constraints to flexible environment sample apps

### DIFF
--- a/appengine/flexible/analytics/app.yaml
+++ b/appengine/flexible/analytics/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10  
+
 #[START env]
 env_variables:
     GA_TRACKING_ID: your-tracking-id

--- a/appengine/flexible/cloudsql/app.yaml
+++ b/appengine/flexible/cloudsql/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+
 #[START env]
 env_variables:
     # Replace user, password, database, project, and instance with the values obtained

--- a/appengine/flexible/datastore/app.yaml
+++ b/appengine/flexible/datastore/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10  
+
 # [START env_variables]
 env_variables:
     GCLOUD_PROJECT: your-project-id

--- a/appengine/flexible/disk/app.yaml
+++ b/appengine/flexible/disk/app.yaml
@@ -4,3 +4,11 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   python_version: 3
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/django_cloudsql/app.yaml
+++ b/appengine/flexible/django_cloudsql/app.yaml
@@ -8,5 +8,12 @@ beta_settings:
 
 runtime_config:
   python_version: 3
-# [END runtime]
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+# [END runtime]

--- a/appengine/flexible/endpoints/app.yaml
+++ b/appengine/flexible/endpoints/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+
 beta_settings:
   # Enable Google Cloud Endpoints API management.
   use_endpoints_api_management: true

--- a/appengine/flexible/extending_runtime/app.yaml
+++ b/appengine/flexible/extending_runtime/app.yaml
@@ -1,2 +1,10 @@
 runtime: custom
 vm: true
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/extending_runtime_compat/app.yaml
+++ b/appengine/flexible/extending_runtime_compat/app.yaml
@@ -6,3 +6,11 @@ api_version: 1
 handlers:
 - url: .*  # This regex directs all routes to main.app
   script: main.app
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/hello_world/app.yaml
+++ b/appengine/flexible/hello_world/app.yaml
@@ -4,3 +4,11 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   python_version: 3
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/hello_world_compat/app.yaml
+++ b/appengine/flexible/hello_world_compat/app.yaml
@@ -3,6 +3,14 @@ vm: true
 threadsafe: true
 api_version: 1
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+
 handlers:
 - url: .*  # This regex directs all routes to main.app
   script: main.app

--- a/appengine/flexible/hello_world_django/app.yaml
+++ b/appengine/flexible/hello_world_django/app.yaml
@@ -4,3 +4,11 @@ entrypoint: gunicorn -b :$PORT project_name.wsgi
 
 runtime_config:
   python_version: 3
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/kinto/app.yaml
+++ b/appengine/flexible/kinto/app.yaml
@@ -26,6 +26,10 @@ vm_health_check:
 manual_scaling:
     instances: 1
 
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
 
 # Temporary setting to keep gcloud from uploading the virtualenv
 skip_files:

--- a/appengine/flexible/mailgun/app.yaml
+++ b/appengine/flexible/mailgun/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10  
+
 # [START env_variables]
 env_variables:
     MAILGUN_DOMAIN_NAME: your-mailgun-domain-name

--- a/appengine/flexible/mailjet/app.yaml
+++ b/appengine/flexible/mailjet/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+  
 # [START env_variables]
 env_variables:
     MAILJET_API_KEY: your-mailjet-api-key

--- a/appengine/flexible/memcache/app.yaml
+++ b/appengine/flexible/memcache/app.yaml
@@ -4,3 +4,11 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   python_version: 3
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/multiple_services/gateway-service/app.yaml
+++ b/appengine/flexible/multiple_services/gateway-service/app.yaml
@@ -8,3 +8,8 @@ runtime_config:
 
 manual_scaling:
   instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/multiple_services/static-service/app.yaml
+++ b/appengine/flexible/multiple_services/static-service/app.yaml
@@ -8,3 +8,8 @@ runtime_config:
 
 manual_scaling:
   instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/numpy/app.yaml
+++ b/appengine/flexible/numpy/app.yaml
@@ -4,3 +4,11 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   python_version: 3
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/pubsub/app.yaml
+++ b/appengine/flexible/pubsub/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10  
+
 #[START env]
 env_variables:
     GCLOUD_PROJECT: your-project-id

--- a/appengine/flexible/redis/app.yaml
+++ b/appengine/flexible/redis/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10  
+
 # [START env_variables]
 env_variables:
     REDIS_HOST: your-redis-host

--- a/appengine/flexible/scipy/app.yaml
+++ b/appengine/flexible/scipy/app.yaml
@@ -4,3 +4,11 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   python_version: 3
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/sendgrid/app.yaml
+++ b/appengine/flexible/sendgrid/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10  
+
 # [START env_variables]
 env_variables:
     SENDGRID_API_KEY: your-sendgrid-api-key

--- a/appengine/flexible/static_files/app.yaml
+++ b/appengine/flexible/static_files/app.yaml
@@ -4,3 +4,11 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   python_version: 3
+
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10

--- a/appengine/flexible/storage/app.yaml
+++ b/appengine/flexible/storage/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+
 #[START env]
 env_variables:
     GCLOUD_PROJECT: your-project-id

--- a/appengine/flexible/twilio/app.yaml
+++ b/appengine/flexible/twilio/app.yaml
@@ -5,6 +5,14 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+
 # [START env_variables]
 env_variables:
     TWILIO_ACCOUNT_SID: your-account-sid

--- a/appengine/flexible/websockets/app.yaml
+++ b/appengine/flexible/websockets/app.yaml
@@ -9,6 +9,14 @@ entrypoint: gunicorn -b :$PORT -b :65080 -k flask_sockets.worker main:app
 runtime_config:
   python_version: 2
 
+manual_scaling:
+  instances: 1
+
+resources:
+  cpu: .5
+  memory_gb: 0.18
+  disk_size_gb: 10
+
 # [START network]
 network:
   forwarded_ports:


### PR DESCRIPTION
Incorporated suggestions from this Google Cloud blog post:
https://medium.com/google-cloud/three-simple-steps-to-save-costs-when-prototyping-with-app-engine-flexible-environment-104fc6736495#.pw75mqa53

Changed `app.yaml` files to use only 1 instance and switch to smaller CPU to save users money if they deploy these apps.  Added the following:
```YAML
manual_scaling:
  instances: 1

resources:
  cpu: .5
  memory_gb: 0.18
  disk_size_gb: 10
```