### PR TITLE
Translate API no longer requires an API key.

### DIFF
--- a/translate/cloud-client/quickstart.py
+++ b/translate/cloud-client/quickstart.py
@@ -20,11 +20,8 @@ def run_quickstart():
     # Imports the Google Cloud client library
     from google.cloud import translate
 
-    # Your Translate API key
-    api_key = 'YOUR_API_KEY'
-
     # Instantiates a client
-    translate_client = translate.Client(api_key=api_key)
+    translate_client = translate.Client()
 
     # The text to translate
     text = u'Hello, world!'

--- a/translate/cloud-client/quickstart_test.py
+++ b/translate/cloud-client/quickstart_test.py
@@ -13,28 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.cloud import translate
-import mock
-import pytest
 
 import quickstart
 
 
-@pytest.fixture
-def mock_client(cloud_config):
-    original_client_ctor = translate.Client
-
-    def new_client_ctor(api_key):
-        # Strip api_key argument and replace with our api key.
-        return original_client_ctor(cloud_config.api_key)
-
-    with mock.patch(
-            'google.cloud.translate.Client',
-            side_effect=new_client_ctor):
-        yield
-
-
-def test_quickstart(mock_client, capsys):
+def test_quickstart(capsys):
     quickstart.run_quickstart()
     out, _ = capsys.readouterr()
     assert u'Привет мир!' in out

--- a/translate/cloud-client/snippets.py
+++ b/translate/cloud-client/snippets.py
@@ -26,9 +26,9 @@ import argparse
 from google.cloud import translate
 
 
-def detect_language(api_key, text):
+def detect_language(text):
     """Detects the text's language."""
-    translate_client = translate.Client(api_key=api_key)
+    translate_client = translate.Client()
 
     # Text can also be a sequence of strings, in which case this method
     # will return a sequence of results for each text.
@@ -39,9 +39,9 @@ def detect_language(api_key, text):
     print('Language: {}'.format(result['language']))
 
 
-def list_languages(api_key):
+def list_languages():
     """Lists all available languages."""
-    translate_client = translate.Client(api_key=api_key)
+    translate_client = translate.Client()
 
     results = translate_client.get_languages()
 
@@ -49,13 +49,13 @@ def list_languages(api_key):
         print(u'{name} ({language})'.format(**language))
 
 
-def list_languages_with_target(api_key, target):
+def list_languages_with_target(target):
     """Lists all available languages and localizes them to the target language.
 
     Target must be an ISO 639-1 language code.
     See https://g.co/cloud/translate/v2/translate-reference#supported_languages
     """
-    translate_client = translate.Client(api_key=api_key)
+    translate_client = translate.Client()
 
     results = translate_client.get_languages(target_language=target)
 
@@ -63,7 +63,7 @@ def list_languages_with_target(api_key, target):
         print(u'{name} ({language})'.format(**language))
 
 
-def translate_text_with_model(api_key, target, text, model=translate.BASE):
+def translate_text_with_model(target, text, model=translate.BASE):
     """Translates text into the target language.
 
     Make sure your project is whitelisted.
@@ -71,7 +71,7 @@ def translate_text_with_model(api_key, target, text, model=translate.BASE):
     Target must be an ISO 639-1 language code.
     See https://g.co/cloud/translate/v2/translate-reference#supported_languages
     """
-    translate_client = translate.Client(api_key=api_key)
+    translate_client = translate.Client()
 
     # Text can also be a sequence of strings, in which case this method
     # will return a sequence of results for each text.
@@ -86,13 +86,13 @@ def translate_text_with_model(api_key, target, text, model=translate.BASE):
         result['detectedSourceLanguage']))
 
 
-def translate_text(api_key, target, text):
+def translate_text(target, text):
     """Translates text into the target language.
 
     Target must be an ISO 639-1 language code.
     See https://g.co/cloud/translate/v2/translate-reference#supported_languages
     """
-    translate_client = translate.Client(api_key=api_key)
+    translate_client = translate.Client()
 
     # Text can also be a sequence of strings, in which case this method
     # will return a sequence of results for each text.
@@ -110,7 +110,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('api_key', help='Your API key.')
     subparsers = parser.add_subparsers(dest='command')
 
     detect_langage_parser = subparsers.add_parser(
@@ -132,10 +131,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.command == 'detect-language':
-        detect_language(args.api_key, args.text)
+        detect_language(args.text)
     elif args.command == 'list-languages':
-        list_languages(args.api_key)
+        list_languages()
     elif args.command == 'list-languages-with-target':
-        list_languages_with_target(args.api_key, args.target)
+        list_languages_with_target(args.target)
     elif args.command == 'translate-text':
-        translate_text(args.api_key, args.target, args.text)
+        translate_text(args.target, args.text)

--- a/translate/cloud-client/snippets_test.py
+++ b/translate/cloud-client/snippets_test.py
@@ -19,24 +19,24 @@ import snippets
 
 
 def test_detect_language(cloud_config, capsys):
-    snippets.detect_language(cloud_config.api_key, 'Hæ sæta')
+    snippets.detect_language('Hæ sæta')
     out, _ = capsys.readouterr()
     assert 'is' in out
 
 
 def test_list_languages(cloud_config, capsys):
-    snippets.list_languages(cloud_config.api_key)
+    snippets.list_languages()
     out, _ = capsys.readouterr()
     assert 'Icelandic (is)' in out
 
 
 def test_list_languages_with_target(cloud_config, capsys):
-    snippets.list_languages_with_target(cloud_config.api_key, 'is')
+    snippets.list_languages_with_target('is')
     out, _ = capsys.readouterr()
     assert u'íslenska (is)' in out
 
 
 def test_translate_text(cloud_config, capsys):
-    snippets.translate_text(cloud_config.api_key, 'is', 'Hello world')
+    snippets.translate_text('is', 'Hello world')
     out, _ = capsys.readouterr()
     assert u'Halló heimur' in out


### PR DESCRIPTION
See 

- GoogleCloudPlatform/php-docs-samples#248
- GoogleCloudPlatform/ruby-docs-samples#113