### PR TITLE
Update Endpoints sample container ports.

### DIFF
--- a/endpoints/getting-started/Dockerfile.custom
+++ b/endpoints/getting-started/Dockerfile.custom
@@ -9,4 +9,4 @@ ADD . /app
 WORKDIR /app
 
 RUN pip install -r requirements.txt
-ENTRYPOINT ["gunicorn", "-b", ":8081", "main:app"]
+ENTRYPOINT ["gunicorn", "-b", ":8080", "main:app"]

--- a/endpoints/getting-started/container-engine.yaml
+++ b/endpoints/getting-started/container-engine.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 8081
     protocol: TCP
     name: http
   selector:
@@ -42,15 +42,15 @@ spec:
       - name: esp
         image: b.gcr.io/endpoints/endpoints-runtime:0.3
         args: [
-          "-p", "8080",
-          "-a", "127.0.0.1:8081",
+          "-p", "8081",
+          "-a", "127.0.0.1:8080",
           "-s", "SERVICE_NAME",
           "-v", "SERVICE_VERSION",
         ]
       # [END esp]
         ports:
-        - containerPort: 8080
+        - containerPort: 8081
       - name: echo
         image: gcr.io/google-samples/echo-python:1.0
         ports:
-        - containerPort: 8081
+        - containerPort: 8080


### PR DESCRIPTION
Need to switch ports for GKE config to match other languages.

`gcr.io/google-samples/echo-python:1.0` is updated.