### PR TITLE
fix echo_api_key

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/main.py
+++ b/appengine/standard/endpoints-frameworks-v2/echo/main.py
@@ -69,16 +69,15 @@ class EchoApi(remote.Service):
 
     @endpoints.method(
         # This method takes a ResourceContainer defined above.
-        ECHO_RESOURCE,
+        message_types.VoidMessage,
         # This method returns an Echo message.
         EchoResponse,
-        path='echo',
-        http_method='POST',
+        path='echo/getApiKey',
+        http_method='GET',
         name='echo_api_key',
         api_key_required=True)
     def echo_api_key(self, request):
-        output_content = ' '.join([request.content] * request.n)
-        return EchoResponse(content=output_content)
+        return EchoResponse(content=request.get_unrecognized_field_info('key'))
 
     @endpoints.method(
         # This method takes an empty request body.


### PR DESCRIPTION
echo_api_key was not implemented correctly (looks like a cut and paste bug).
I discover this when trying to follow the[ instructions  on how to implement cloud endpoints on AppEngine standard](https://cloud.google.com/endpoints/docs/frameworks/python/quickstart-frameworks-python). and the following command failed:
   `python lib/endpoints/endpointscfg.py get_swagger_spec main.EchoApi --hostname your-service.appspot.com`

with:
   `endpoints.api_exceptions.ApiConfigurationError: POST path "echo" used multiple times, in classes EchoApi and EchoApi`
