### PR TITLE
Update app.yaml to use connection name

### DIFF
--- a/appengine/flexible/cloudsql/app.yaml
+++ b/appengine/flexible/cloudsql/app.yaml
@@ -10,12 +10,12 @@ env_variables:
     # Replace user, password, database, project, and instance with the values obtained
     # when configuring your Cloud SQL instance.
     SQLALCHEMY_DATABASE_URI: >-
-      mysql+pymysql://USER:PASSWORD@/DATABASE?unix_socket=/cloudsql/PROJECT:REGION:INSTANCE
+      mysql+pymysql://USER:PASSWORD@/DATABASE?unix_socket=/cloudsql/INSTANCE_CONNECTION_NAME
 #[END env]
 
 #[START cloudsql_settings]
 # Replace project and instance with the values obtained  when configuring your
 # Cloud SQL instance.
 beta_settings:
-    cloud_sql_instances: PROJECT:REGION:INSTANCE
+    cloud_sql_instances: INSTANCE_CONNECTION_NAME
 #[END cloudsql_settings]


### PR DESCRIPTION
We've moved away from concatenating project:region:instance and towards using the instance connection name, which is now available not only from the console but also from gcloud. I'm in the process of adding the text to go along with this change, but already the proxy invocation uses this so we're no worse off if we publish this change.

Thanks!