### PR TITLE
Change the listening port from 9000 to 80

### DIFF
--- a/endpoints/kubernetes/grpc-bookstore.yaml
+++ b/endpoints/kubernetes/grpc-bookstore.yaml
@@ -19,7 +19,8 @@ metadata:
 spec:
   ports:
   # Port that accepts gRPC and JSON/HTTP2 requests over HTTP.
-  - port: 9000
+  - port: 80
+    targetPort: 9000
     protocol: TCP
     name: http2
   selector:


### PR DESCRIPTION
This makes our Quickstarts consistent such that port 80 is used in both
examples on GCE and GKE.