### PR TITLE
Adjusted error handling based on Googler feedback

### DIFF
--- a/bigquery/cloud-client/load_data_from_gcs.py
+++ b/bigquery/cloud-client/load_data_from_gcs.py
@@ -54,7 +54,7 @@ def wait_for_job(job):
         job.reload()
         if job.state == 'DONE':
             if job.error_result:
-                raise RuntimeError(job.error_result)
+                raise RuntimeError(job.errors)
             return
         time.sleep(1)
 


### PR DESCRIPTION
Adjusted error handling for BigQuery sample based on Googler feedback. Job.errors gives you the actual error(s), unlike job.error_result.

Bug #33164873