### PR TITLE
Django_cloudsql config edits

### DIFF
--- a/appengine/flexible/django_cloudsql/mysite/settings.py
+++ b/appengine/flexible/django_cloudsql/mysite/settings.py
@@ -79,15 +79,15 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'polls',
-        'USER': 'root',
-        'PASSWORD': '<your-root-password>',
+        'USER': '<your-database-user>',
+        'PASSWORD': '<your-database-password>',
     }
 }
 # In the flexible environment, you connect to CloudSQL using a unix socket.
 # Locally, you can use the CloudSQL proxy to proxy a localhost connection
 # to the instance
 DATABASES['default']['HOST'] = '/cloudsql/<your-cloudsql-connection-string>'
-if os.getenv('GAE_APPENGINE_HOSTNAME'):
+if os.getenv('GAE_INSTANCE'):
     pass
 else:
     DATABASES['default']['HOST'] = '127.0.0.1'


### PR DESCRIPTION
Tweaked a few placeholder names for variables users should change before testing/deploying. The tutorial is now going to ask them to create a non-root username/password. Also updated environment variable that changed because of flex beta 2.