### PR TITLE
Allow ListShelves method to be called without API key

### DIFF
--- a/endpoints/bookstore-grpc/api_config.yaml
+++ b/endpoints/bookstore-grpc/api_config.yaml
@@ -34,3 +34,12 @@ name: bookstore.<MY_PROJECT_ID>.appspot.com
 title: Bookstore gRPC API
 apis:
 - name: endpoints.examples.bookstore.Bookstore
+
+#
+# API usage restrictions.
+#
+usage:
+  rules:
+  # ListShelves methods can be called without an API Key.
+  - selector: endpoints.examples.bookstore.Bookstore.ListShelves
+    allow_unregistered_calls: true


### PR DESCRIPTION
This simplifies our quickstart such that reader does not need to go
through an extra step to create an API key before calling this API.