### PR TITLE
Updated memcache error checking to handle large object exception

### DIFF
--- a/appengine/standard/memcache/guestbook/app.yaml
+++ b/appengine/standard/memcache/guestbook/app.yaml
@@ -3,7 +3,6 @@
 # https://developers.google.com/appengine/docs/python/config/appconfig
 # for details.
 
-version: 1
 runtime: python27
 api_version: 1
 threadsafe: yes

--- a/appengine/standard/memcache/guestbook/main.py
+++ b/appengine/standard/memcache/guestbook/main.py
@@ -86,14 +86,12 @@ class MainPage(webapp2.RequestHandler):
         if greetings is None:
             greetings = self.render_greetings(guestbook_name)
             try:
-                added = memcache.add('{}:greetings'.format(guestbook_name),
-                                     greetings, 10)
+                added = memcache.add(
+                    '{}:greetings'.format(guestbook_name), greetings, 10)
                 if not added:
                     logging.error('Memcache set failed.')
             except ValueError:
                 logging.error('Memcache set failed - data larger than 1MB')
-            except Exception as e:
-                logging.error('Memcache set failed - {}'.format(e))
         return greetings
     # [END check_memcache]
 

--- a/appengine/standard/memcache/guestbook/main.py
+++ b/appengine/standard/memcache/guestbook/main.py
@@ -85,8 +85,11 @@ class MainPage(webapp2.RequestHandler):
         greetings = memcache.get('{}:greetings'.format(guestbook_name))
         if greetings is None:
             greetings = self.render_greetings(guestbook_name)
-            if not memcache.add('{}:greetings'.format(guestbook_name),
-                                greetings, 10):
+            try:
+                if not memcache.add('{}:greetings'.format(guestbook_name),
+                                    greetings, 10):
+                    logging.error('Memcache set failed.')
+            except:
                 logging.error('Memcache set failed.')
         return greetings
     # [END check_memcache]

--- a/appengine/standard/memcache/guestbook/main.py
+++ b/appengine/standard/memcache/guestbook/main.py
@@ -86,11 +86,14 @@ class MainPage(webapp2.RequestHandler):
         if greetings is None:
             greetings = self.render_greetings(guestbook_name)
             try:
-                if not memcache.add('{}:greetings'.format(guestbook_name),
-                                    greetings, 10):
+                added = memcache.add('{}:greetings'.format(guestbook_name),
+                                     greetings, 10)
+                if not added:
                     logging.error('Memcache set failed.')
-            except:
-                logging.error('Memcache set failed.')
+            except ValueError:
+                logging.error('Memcache set failed - data larger than 1MB')
+            except Exception as e:
+                logging.error('Memcache set failed - {}'.format(e))
         return greetings
     # [END check_memcache]
 


### PR DESCRIPTION
See bug #33780149 on buganizer.

For some reason memcache.add throws an exception for objects larger than 1 MB rather than simpling returning False. Thus, I changed the sample code to use try/except around memcache.add, while preserving the check to see if memcache.add returned True or False. The boolean returned does seem to be necessary since it is False when memcache already has an entry for a given key.

Also got rid of 'version: 1' from the app.yaml so that 'gcloud app deploy' works.