### PR TITLE
Added headers manually to override error

### DIFF
--- a/appengine/standard/mailgun/main.py
+++ b/appengine/standard/mailgun/main.py
@@ -46,7 +46,8 @@ def send_simple_message(recipient):
         'text': 'Test message from Mailgun'
     }
 
-    resp, content = http.request(url, 'POST', urlencode(data), headers={"Content-Type": "application/x-www-form-urlencoded"})
+    resp, content = http.request(url, 'POST', urlencode(data), 
+                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     if resp.status != 200:
         raise RuntimeError(
@@ -68,7 +69,8 @@ def send_complex_message(recipient):
         'html': '<html>HTML <strong>version</strong> of the body</html>'
     }
 
-    resp, content = http.request(url, 'POST', urlencode(data), headers={"Content-Type": "application/x-www-form-urlencoded"})
+    resp, content = http.request(url, 'POST', urlencode(data), 
+                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     if resp.status != 200:
         raise RuntimeError(

--- a/appengine/standard/mailgun/main.py
+++ b/appengine/standard/mailgun/main.py
@@ -46,7 +46,7 @@ def send_simple_message(recipient):
         'text': 'Test message from Mailgun'
     }
 
-    resp, content = http.request(url, 'POST', urlencode(data))
+    resp, content = http.request(url, 'POST', urlencode(data), headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     if resp.status != 200:
         raise RuntimeError(
@@ -68,7 +68,7 @@ def send_complex_message(recipient):
         'html': '<html>HTML <strong>version</strong> of the body</html>'
     }
 
-    resp, content = http.request(url, 'POST', urlencode(data))
+    resp, content = http.request(url, 'POST', urlencode(data), headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     if resp.status != 200:
         raise RuntimeError(

--- a/appengine/standard/mailgun/main.py
+++ b/appengine/standard/mailgun/main.py
@@ -46,8 +46,9 @@ def send_simple_message(recipient):
         'text': 'Test message from Mailgun'
     }
 
-    resp, content = http.request(url, 'POST', urlencode(data), 
-                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
+    resp, content = http.request(
+        url, 'POST', urlencode(data),
+        headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     if resp.status != 200:
         raise RuntimeError(
@@ -69,8 +70,9 @@ def send_complex_message(recipient):
         'html': '<html>HTML <strong>version</strong> of the body</html>'
     }
 
-    resp, content = http.request(url, 'POST', urlencode(data), 
-                                 headers={"Content-Type": "application/x-www-form-urlencoded"})
+    resp, content = http.request(
+        url, 'POST', urlencode(data), 
+        headers={"Content-Type": "application/x-www-form-urlencoded"})
 
     if resp.status != 200:
         raise RuntimeError(


### PR DESCRIPTION
I was getting the following issue: 
`RuntimeError: Mailgun API error: 400 b'{\n  "message": "\'from\' parameter is missing"\n}'`,

Providing custom header for `Content-Type` was the solution.