### PR TITLE
Added securityDef region tag to openapi.yaml for documentation purposes

### DIFF
--- a/endpoints/getting-started/openapi.yaml
+++ b/endpoints/getting-started/openapi.yaml
@@ -107,12 +107,14 @@ definitions:
       email:
         type: "string"
 
+# [START securityDef]
 securityDefinitions:
   # This section configures basic authentication with an API key.
   api_key:
     type: "apiKey"
     name: "key"
     in: "query"
+# [END securityDef]
   # This section configures authentication using Google API Service Accounts
   # to sign a json web token. This is mostly used for server-to-server
   # communication.


### PR DESCRIPTION
We need to do this so that we can update https://cloud.google.com/endpoints/docs/restricting-api-access-with-api-keys-openapi to point to the endpoints/getting-started sample rather than the soon-to-be-deprecated appengine/flexible/endpoints sample.