### PR TITLE
Changed read_write_transaction minimum amount to 300,000

### DIFF
--- a/spanner/cloud-client/snippets.py
+++ b/spanner/cloud-client/snippets.py
@@ -320,7 +320,7 @@ def read_write_transaction(instance_id, database_id):
 
         transfer_amount = 200000
 
-        if second_album_budget < transfer_amount:
+        if second_album_budget < 300000:
             # Raising an exception will automatically roll back the
             # transaction.
             raise ValueError(


### PR DESCRIPTION
Fixing bug.

Documentation says we should only transfer if the second album budget has a minimum value of $300,000.