### PR TITLE
Generate datastore grpc client outside request handler

### DIFF
--- a/appengine/flexible/datastore/main.py
+++ b/appengine/flexible/datastore/main.py
@@ -21,7 +21,7 @@ from google.cloud import datastore
 
 
 app = Flask(__name__)
-
+ds = datastore.Client()
 
 def is_ipv6(addr):
     """Checks if a given address is an IPv6 address."""
@@ -35,8 +35,6 @@ def is_ipv6(addr):
 # [START example]
 @app.route('/')
 def index():
-    ds = datastore.Client()
-
     user_ip = request.remote_addr
 
     # Keep only the first two octets of the IP address.


### PR DESCRIPTION
Generating a datastore grpc client for each request is not required and can lead to auth issues.
Here is one of the auth issues in question: https://github.com/GoogleCloudPlatform/google-cloud-python/issues/3085

Also note the following issue which is causing the client to need resetting every 30 mins: https://github.com/GoogleCloudPlatform/google-cloud-python/issues/2896. This will hopefully be fixed soon.