### PR TITLE
fix endpoint echo sample

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
@@ -1,1 +1,1 @@
-google-endpoints==2.0.5
+google-endpoints==2.0.6


### PR DESCRIPTION
google-endpoints 2.0.5 does not work with new version google-cloud-sdk
on mac, by upgrading to 2.0.6 fixes this sample.