### PR TITLE
make_iap_request: Replace base URL with client ID

### DIFF
--- a/iap/iap_test.py
+++ b/iap/iap_test.py
@@ -28,6 +28,8 @@ import validate_jwt
 # The project must have the service account used by this test added as a
 # member of the project.
 REFLECT_SERVICE_HOSTNAME = 'gcp-devrel-iap-reflect.appspot.com'
+IAP_CLIENT_ID = ('320431926067-ldm6839p8l2sei41nlsfc632l4d0v2u1'
+                 '.apps.googleusercontent.com')
 
 
 @flaky
@@ -37,7 +39,8 @@ def test_main(capsys):
     # the JWT in order to expose it to this test.  Thus, this test
     # exercises both make_iap_request and validate_jwt.
     iap_jwt = make_iap_request.make_iap_request(
-        'https://{}/'.format(REFLECT_SERVICE_HOSTNAME))
+        'https://{}/'.format(REFLECT_SERVICE_HOSTNAME),
+        IAP_CLIENT_ID)
     iap_jwt = iap_jwt.split(': ').pop()
     jwt_validation_result = validate_jwt.validate_iap_jwt(
         'https://{}'.format(REFLECT_SERVICE_HOSTNAME), iap_jwt)

--- a/iap/make_iap_request.py
+++ b/iap/make_iap_request.py
@@ -24,30 +24,22 @@ import google.oauth2.credentials
 import google.oauth2.service_account
 import requests
 import requests_toolbelt.adapters.appengine
-from six.moves import urllib_parse as urlparse
 
 
 IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
 OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'
 
 
-def make_iap_request(url):
+def make_iap_request(url, client_id):
     """Makes a request to an application protected by Identity-Aware Proxy.
 
     Args:
       url: The Identity-Aware Proxy-protected URL to fetch.
+      client_id: The client ID used by Identity-Aware Proxy.
 
     Returns:
       The page body, or raises an exception if the page couldn't be retrieved.
     """
-    # Take the input URL and remove everything except the protocol, domain,
-    # and port. Examples:
-    #   https://foo.example.com/ => https://foo.example.com
-    #   https://example.com:8443/foo/bar?quuz=quux#lorem =>
-    #       https://example.com:8443
-    base_url = urlparse.urlunparse(
-        urlparse.urlparse(url)._replace(path='', query='', fragment=''))
-
     # Figure out what environment we're running in and get some preliminary
     # information about the service account.
     bootstrap_credentials, _ = google.auth.default(
@@ -90,7 +82,7 @@ def make_iap_request(url):
     # and email acquired from the bootstrap credentials.
     service_account_credentials = google.oauth2.service_account.Credentials(
         signer, signer_email, token_uri=OAUTH_TOKEN_URI, additional_claims={
-            'target_audience': base_url
+            'target_audience': client_id
         })
 
     # service_account_credentials gives us a JWT signed by the service


### PR DESCRIPTION
Client ID is the preferred thing to use for the aud claim.
  --msachs@, IAP TLM