### PR TITLE
Create better service name template in app.yaml

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
+++ b/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
@@ -28,5 +28,5 @@ libraries:
 env_variables:
   # The following values are to be replaced by information from the output of
   # 'gcloud service-management deploy swagger.json' command.
-  ENDPOINTS_SERVICE_NAME: echo-api.endpoints.[YOUR-PROJECT-ID].cloud.goog
+  ENDPOINTS_SERVICE_NAME: [YOUR-PROJECT-ID].appspot.com
   ENDPOINTS_SERVICE_VERSION: 2016-08-01r0


### PR DESCRIPTION
Endpoints Frameworks apps on GAE standard must use the appspot.com domain name; users will have to change the line anyway, but this way fewer changes are required.