### PR TITLE
Update settings.py

### DIFF
--- a/appengine/flexible/hello_world_django/project_name/settings.py
+++ b/appengine/flexible/hello_world_django/project_name/settings.py
@@ -39,7 +39,7 @@ SECRET_KEY = 'qgw!j*bpxo7g&o1ux-(2ph818ojfj(3c#-#*_8r^8&hq5jg$3@'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition


### PR DESCRIPTION
ALLOWED_HOSTS is also check when DEBUG=True after Django 1.10.3, 1.9.11, and 1.8.16 to prevent a DNS rebinding attack. https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts