### PR TITLE
add word time offsets to async sample

### DIFF
--- a/speech/cloud-client/requirements.txt
+++ b/speech/cloud-client/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-speech==0.27.0
+google-cloud-speech==0.27.1

--- a/speech/cloud-client/transcribe_async.py
+++ b/speech/cloud-client/transcribe_async.py
@@ -79,7 +79,8 @@ def transcribe_gcs(gcs_uri):
     config = types.RecognitionConfig(
         encoding=enums.RecognitionConfig.AudioEncoding.FLAC,
         sample_rate_hertz=16000,
-        language_code='en-US')
+        language_code='en-US',
+        enable_word_time_offsets=True)
 
     operation = client.long_running_recognize(config, audio)
 
@@ -96,6 +97,12 @@ def transcribe_gcs(gcs_uri):
     for alternative in alternatives:
         print('Transcript: {}'.format(alternative.transcript))
         print('Confidence: {}'.format(alternative.confidence))
+
+        for word_info in alternative.words:
+            print('Word: {}, start_time: {}, end_time: {}'.format(
+                word_info.word,
+                word_info.start_time.seconds + word_info.start_time.nanos * 1e-9,
+                word_info.end_time.seconds + word_info.end_time.nanos * 1e-9))
 # [END def_transcribe_gcs]
 
 

--- a/speech/cloud-client/transcribe_async.py
+++ b/speech/cloud-client/transcribe_async.py
@@ -99,10 +99,13 @@ def transcribe_gcs(gcs_uri):
         print('Confidence: {}'.format(alternative.confidence))
 
         for word_info in alternative.words:
+            word = word_info.word
+            start_time = word_info.start_time
+            end_time = word_info.end_time
             print('Word: {}, start_time: {}, end_time: {}'.format(
-                word_info.word,
-                word_info.start_time.seconds + word_info.start_time.nanos * 1e-9,
-                word_info.end_time.seconds + word_info.end_time.nanos * 1e-9))
+                word,
+                start_time.seconds + start_time.nanos * 1e-9,
+                end_time.seconds + end_time.nanos * 1e-9))
 # [END def_transcribe_gcs]
 
 

--- a/speech/cloud-client/transcribe_async_test.py
+++ b/speech/cloud-client/transcribe_async_test.py
@@ -33,3 +33,13 @@ def test_transcribe_gcs(capsys):
     out, err = capsys.readouterr()
 
     assert re.search(r'how old is the Brooklyn Bridge', out, re.DOTALL | re.I)
+
+
+def test_transcribe_gcs_word_time_offsets(capsys):
+    transcribe_async.transcribe_gcs(
+        'gs://python-docs-samples-tests/speech/audio.flac')
+    out, err = capsys.readouterr()
+
+    time = float(re.search(r'Bridge, start_time: ([0-9.]+)', out, re.DOTALL | re.I).group(1))
+
+    assert  time > 0

--- a/speech/cloud-client/transcribe_async_test.py
+++ b/speech/cloud-client/transcribe_async_test.py
@@ -40,6 +40,7 @@ def test_transcribe_gcs_word_time_offsets(capsys):
         'gs://python-docs-samples-tests/speech/audio.flac')
     out, err = capsys.readouterr()
 
-    time = float(re.search(r'Bridge, start_time: ([0-9.]+)', out, re.DOTALL | re.I).group(1))
+    match = re.search(r'Bridge, start_time: ([0-9.]+)', out, re.DOTALL | re.I)
+    time = float(match.group(1))
 
-    assert  time > 0
+    assert time > 0


### PR DESCRIPTION
This PR updated the async recognize example to show how to modify the recognition config so that the API response includes the additional information of word-level time offsets.