### PR TITLE
Fix region handling and allow to use an existing cluster.

### DIFF
--- a/dataproc/README.md
+++ b/dataproc/README.md
@@ -35,14 +35,19 @@ To run list_clusters.py:
     python list_clusters.py <YOUR-PROJECT-ID> --region=us-central1
 
 
-To run create_cluster_and_submit_job, first create a GCS bucket, from the Cloud Console or with
+To run submit_job_to_cluster.py, first create a GCS bucket, from the Cloud Console or with
 gsutil:
 
     gsutil mb gs://<your-input-bucket-name>
     
-Then run:
+Then, if you want to rely on an existing cluster, run:
     
-    python create_cluster_and_submit_job.py --project_id=<your-project-id> --zone=us-central1-b --cluster_name=testcluster --gcs_bucket=<your-input-bucket-name>
+    python submit_job_to_cluster.py --project_id=<your-project-id> --zone=us-central1-b --cluster_name=testcluster --gcs_bucket=<your-input-bucket-name>
+    
+Otherwise, if you want the script to create a new cluster for you:
+
+    python submit_job_to_cluster.py --project_id=<your-project-id> --zone=us-central1-b --cluster_name=testcluster --gcs_bucket=<your-input-bucket-name> --create_new_cluster
+
 
 This will setup a cluster, upload the PySpark file, submit the job, print the result, then
 delete the cluster.

--- a/dataproc/dataproc_e2e_test.py
+++ b/dataproc/dataproc_e2e_test.py
@@ -20,7 +20,7 @@ import os
 
 from gcp_devrel.testing.flaky import flaky
 
-import create_cluster_and_submit_job
+import submit_job_to_cluster
 
 PROJECT = os.environ['GCLOUD_PROJECT']
 BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
@@ -30,6 +30,6 @@ ZONE = 'us-central1-b'
 
 @flaky
 def test_e2e():
-    output = create_cluster_and_submit_job.main(
+    output = submit_job_to_cluster.main(
         PROJECT, ZONE, CLUSTER_NAME, BUCKET)
     assert b"['Hello,', 'dog', 'elephant', 'panther', 'world!']" in output


### PR DESCRIPTION
This PR is related to [PR#1029](https://github.com/GoogleCloudPlatform/python-docs-samples/pull/1029): forwarding the region `global` to all the possible operations (list clusters, create clusters,...) doesn't work anymore. Since the `zone` parameter is required, the region is inferred from the `zone` and properly forwarded to all the dependent functions. This change also adds the chance to use directly an existing cluster when the `--create_new_cluster` flag is missing. Given the option of using an existing cluster, the script `create_cluster_and_submit_job.py` has been renamed to `submit_job_to_cluster.py`.