### PR TITLE
Remove old parameter enable_word_time_offsets

### DIFF
--- a/speech/cloud-client/transcribe_async.py
+++ b/speech/cloud-client/transcribe_async.py
@@ -71,8 +71,7 @@ def transcribe_gcs(gcs_uri):
     config = types.RecognitionConfig(
         encoding=enums.RecognitionConfig.AudioEncoding.FLAC,
         sample_rate_hertz=16000,
-        language_code='en-US',
-        enable_word_time_offsets=True)
+        language_code='en-US')
 
     operation = client.long_running_recognize(config, audio)
 


### PR DESCRIPTION
enable_word_time_offsets=True was present for an older version of this sample.
This sample no longer processes word time offsets in the recognize response.