### PR TITLE
show entity type name

### DIFF
--- a/language/cloud-client/v1/snippets.py
+++ b/language/cloud-client/v1/snippets.py
@@ -94,10 +94,14 @@ def entities_text(text):
     #   document.type == enums.Document.Type.HTML
     entities = client.analyze_entities(document).entities
 
+    # entity types from enums.Entity.Type
+    entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
+                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
+
     for entity in entities:
         print('=' * 20)
         print(u'{:<16}: {}'.format('name', entity.name))
-        print(u'{:<16}: {}'.format('type', entity.type))
+        print(u'{:<16}: {}'.format('type', entity_type[entity.type]))
         print(u'{:<16}: {}'.format('metadata', entity.metadata))
         print(u'{:<16}: {}'.format('salience', entity.salience))
         print(u'{:<16}: {}'.format('wikipedia_url',
@@ -120,10 +124,14 @@ def entities_file(gcs_uri):
     #   document.type == enums.Document.Type.HTML
     entities = client.analyze_entities(document).entities
 
+    # entity types from enums.Entity.Type
+    entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
+                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
+
     for entity in entities:
         print('=' * 20)
         print(u'{:<16}: {}'.format('name', entity.name))
-        print(u'{:<16}: {}'.format('type', entity.type))
+        print(u'{:<16}: {}'.format('type', entity_type[entity.type]))
         print(u'{:<16}: {}'.format('metadata', entity.metadata))
         print(u'{:<16}: {}'.format('salience', entity.salience))
         print(u'{:<16}: {}'.format('wikipedia_url',

--- a/language/cloud-client/v1/snippets.py
+++ b/language/cloud-client/v1/snippets.py
@@ -96,7 +96,7 @@ def entities_text(text):
 
     # entity types from enums.Entity.Type
     entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
-                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
+                   'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
 
     for entity in entities:
         print('=' * 20)
@@ -126,7 +126,7 @@ def entities_file(gcs_uri):
 
     # entity types from enums.Entity.Type
     entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
-                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
+                   'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
 
     for entity in entities:
         print('=' * 20)

--- a/language/cloud-client/v1beta2/snippets.py
+++ b/language/cloud-client/v1beta2/snippets.py
@@ -92,7 +92,7 @@ def entities_text(text):
     for entity in entities:
         print('=' * 20)
         print(u'{:<16}: {}'.format('name', entity.name))
-        print(u'{:<16}: {}'.format('type', entity.type))
+        print(u'{:<16}: {}'.format('type', entity_type[entity.type]))
         print(u'{:<16}: {}'.format('metadata', entity.metadata))
         print(u'{:<16}: {}'.format('salience', entity.salience))
         print(u'{:<16}: {}'.format('wikipedia_url',
@@ -119,7 +119,7 @@ def entities_file(gcs_uri):
     for entity in entities:
         print('=' * 20)
         print(u'{:<16}: {}'.format('name', entity.name))
-        print(u'{:<16}: {}'.format('type', entity.type))
+        print(u'{:<16}: {}'.format('type', entity_type[entity.type]))
         print(u'{:<16}: {}'.format('metadata', entity.metadata))
         print(u'{:<16}: {}'.format('salience', entity.salience))
         print(u'{:<16}: {}'.format('wikipedia_url',

--- a/language/cloud-client/v1beta2/snippets.py
+++ b/language/cloud-client/v1beta2/snippets.py
@@ -85,6 +85,10 @@ def entities_text(text):
     #   document.type == enums.Document.Type.HTML
     entities = client.analyze_entities(document).entities
 
+    # entity types from enums.Entity.Type
+    entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
+                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
+
     for entity in entities:
         print('=' * 20)
         print(u'{:<16}: {}'.format('name', entity.name))
@@ -107,6 +111,10 @@ def entities_file(gcs_uri):
     # Detects sentiment in the document. You can also analyze HTML with:
     #   document.type == enums.Document.Type.HTML
     entities = client.analyze_entities(document).entities
+
+    # entity types from enums.Entity.Type
+    entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
+                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
 
     for entity in entities:
         print('=' * 20)

--- a/language/cloud-client/v1beta2/snippets.py
+++ b/language/cloud-client/v1beta2/snippets.py
@@ -87,7 +87,7 @@ def entities_text(text):
 
     # entity types from enums.Entity.Type
     entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
-                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
+                   'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
 
     for entity in entities:
         print('=' * 20)
@@ -114,7 +114,7 @@ def entities_file(gcs_uri):
 
     # entity types from enums.Entity.Type
     entity_type = ('UNKNOWN', 'PERSON', 'LOCATION', 'ORGANIZATION',
-                    'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
+                   'EVENT', 'WORK_OF_ART', 'CONSUMER_GOOD', 'OTHER')
 
     for entity in entities:
         print('=' * 20)


### PR DESCRIPTION
This PR updates the analyze entities samples to show the names of entity types (as opposed to just the enums).

before:

```
name            : Golden Gate Bridge
type            : 2
```

after:

```
name            : Golden Gate Bridge
type            : LOCATION
```

