### PR TITLE
updating Mailjet code samples for Send API v3.1

### DIFF
--- a/appengine/flexible/mailjet/README.md
+++ b/appengine/flexible/mailjet/README.md
@@ -1,6 +1,6 @@
 # Python Mailjet email sample for Google App Engine Flexible
 
-This sample demonstrates how to use [Mailjet](https://www.mailgun.com) on [Google App Engine Flexible](https://cloud.google.com/appengine/docs/flexible/).
+This sample demonstrates how to use [Mailjet](https://www.mailjet.com) on [Google App Engine Flexible](https://cloud.google.com/appengine/docs/flexible/).
 
 ## Setup
 
@@ -17,7 +17,7 @@ Refer to the [top-level README](../README.md) for instructions on running and de
 You can run the application locally and send emails from your local machine. You
 will need to set environment variables before starting your application:
 
-    $ export MAILGUN_API_KEY=[your-mailgun-api-key]
-    $ export MAILGUN_API_SECRET=[your-mailgun-secret]
-    $ export MAILGUN_SENDER=[your-sender-address]
+    $ export MAILJET_API_KEY=[your-mailjet-api-key]
+    $ export MAILJET_API_SECRET=[your-mailjet-secret]
+    $ export MAILJET_SENDER=[your-sender-address]
     $ python main.py

--- a/appengine/flexible/mailjet/main.py
+++ b/appengine/flexible/mailjet/main.py
@@ -36,18 +36,18 @@ def send_message(to):
     data = {
   'Messages': [
                 {
-                "From": {
-                        "Email": MAILJET_SENDER,
-                        "Name": 'App Engine Flex Mailjet Sample'
-                },
-                "To": [
-                        {
-                        "Email": to
-                        }
-                ],
-                "Subject": 'Example email.',
-                "TextPart": 'This is an example email.',
-                "HTMLPart": 'This is an <i>example</i> email.'
+                        "From": {
+                                "Email": MAILJET_SENDER,
+                                "Name": 'App Engine Flex Mailjet Sample'
+                        },
+                        "To": [
+                                {
+                                        "Email": to
+                                }
+                        ],
+                        "Subject": 'Example email.',
+                        "TextPart": 'This is an example email.',
+                        "HTMLPart": 'This is an <i>example</i> email.'
                 }
         ]
 }

--- a/appengine/flexible/mailjet/main.py
+++ b/appengine/flexible/mailjet/main.py
@@ -34,23 +34,19 @@ def send_message(to):
         auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3.1')
 
     data = {
-          'Messages': [
-                        {
-                            "From": {
-                                    "Email": MAILJET_SENDER,
-                                    "Name": 'App Engine Flex Mailjet Sample'
-                            },
-                            "To": [
-                                    {
-                                            "Email": to
-                                    }
-                            ],
-                            "Subject": 'Example email.',
-                            "TextPart": 'This is an example email.',
-                            "HTMLPart": 'This is an <i>example</i> email.'
-                        }
-                    ]
-            }
+        'Messages': [{
+            "From": {
+                    "Email": MAILJET_SENDER,
+                    "Name": 'App Engine Flex Mailjet Sample'
+            },
+            "To": [{
+                "Email": to
+            }],
+            "Subject": 'Example email.',
+            "TextPart": 'This is an example email.',
+            "HTMLPart": 'This is an <i>example</i> email.'
+        }]
+    }
 
     result = client.send.create(data=data)
 

--- a/appengine/flexible/mailjet/main.py
+++ b/appengine/flexible/mailjet/main.py
@@ -34,23 +34,23 @@ def send_message(to):
         auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3.1')
 
     data = {
-  'Messages': [
-                {
-                        "From": {
-                                "Email": MAILJET_SENDER,
-                                "Name": 'App Engine Flex Mailjet Sample'
-                        },
-                        "To": [
-                                {
-                                        "Email": to
-                                }
-                        ],
-                        "Subject": 'Example email.',
-                        "TextPart": 'This is an example email.',
-                        "HTMLPart": 'This is an <i>example</i> email.'
-                }
-        ]
-}
+          'Messages': [
+                        {
+                            "From": {
+                                    "Email": MAILJET_SENDER,
+                                    "Name": 'App Engine Flex Mailjet Sample'
+                            },
+                            "To": [
+                                    {
+                                            "Email": to
+                                    }
+                            ],
+                            "Subject": 'Example email.',
+                            "TextPart": 'This is an example email.',
+                            "HTMLPart": 'This is an <i>example</i> email.'
+                        }
+                    ]
+            }
 
     result = client.send.create(data=data)
 

--- a/appengine/flexible/mailjet/main.py
+++ b/appengine/flexible/mailjet/main.py
@@ -31,16 +31,26 @@ app = Flask(__name__)
 # [START send_message]
 def send_message(to):
     client = mailjet_rest.Client(
-        auth=(MAILJET_API_KEY, MAILJET_API_SECRET))
+        auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3.1')
 
     data = {
-        'FromEmail': MAILJET_SENDER,
-        'FromName': 'App Engine Flex Mailjet Sample',
-        'Subject': 'Example email.',
-        'Text-part': 'This is an example email.',
-        'Html-part': 'This is an <i>example</i> email.',
-        'Recipients': [{'Email': to}]
-    }
+  'Messages': [
+                {
+                "From": {
+                        "Email": MAILJET_SENDER,
+                        "Name": 'App Engine Flex Mailjet Sample'
+                },
+                "To": [
+                        {
+                        "Email": to
+                        }
+                ],
+                "Subject": 'Example email.',
+                "TextPart": 'This is an example email.',
+                "HTMLPart": 'This is an <i>example</i> email.'
+                }
+        ]
+}
 
     result = client.send.create(data=data)
 

--- a/appengine/standard/mailjet/main.py
+++ b/appengine/standard/mailjet/main.py
@@ -39,23 +39,19 @@ def send_message(to):
         auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3.1')
 
     data = {
-          'Messages': [
-                        {
-                            "From": {
-                                    "Email": MAILJET_SENDER,
-                                    "Name": 'App Engine Flex Mailjet Sample'
-                            },
-                            "To": [
-                                    {
-                                            "Email": to
-                                    }
-                            ],
-                            "Subject": 'Example email.',
-                            "TextPart": 'This is an example email.',
-                            "HTMLPart": 'This is an <i>example</i> email.'
-                        }
-                    ]
-            }
+        'Messages': [{
+            "From": {
+                "Email": MAILJET_SENDER,
+                "Name": 'App Engine Standard Mailjet Sample'
+            },
+            "To": [{
+                "Email": to
+            }],
+            "Subject": 'Example email.',
+            "TextPart": 'This is an example email.',
+            "HTMLPart": 'This is an <i>example</i> email.'
+        }]
+    }
 
     result = client.send.create(data=data)
 

--- a/appengine/standard/mailjet/main.py
+++ b/appengine/standard/mailjet/main.py
@@ -39,23 +39,23 @@ def send_message(to):
         auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3.1')
 
     data = {
-  'Messages': [
-                {
-                        "From": {
-                                "Email": MAILJET_SENDER,
-                                "Name": 'App Engine Flex Mailjet Sample'
-                        },
-                        "To": [
-                                {
-                                        "Email": to
-                                }
-                        ],
-                        "Subject": 'Example email.',
-                        "TextPart": 'This is an example email.',
-                        "HTMLPart": 'This is an <i>example</i> email.'
-                }
-        ]
-}
+          'Messages': [
+                        {
+                            "From": {
+                                    "Email": MAILJET_SENDER,
+                                    "Name": 'App Engine Flex Mailjet Sample'
+                            },
+                            "To": [
+                                    {
+                                            "Email": to
+                                    }
+                            ],
+                            "Subject": 'Example email.',
+                            "TextPart": 'This is an example email.',
+                            "HTMLPart": 'This is an <i>example</i> email.'
+                        }
+                    ]
+            }
 
     result = client.send.create(data=data)
 

--- a/appengine/standard/mailjet/main.py
+++ b/appengine/standard/mailjet/main.py
@@ -36,16 +36,26 @@ app = Flask(__name__)
 # [START send_message]
 def send_message(to):
     client = mailjet_rest.Client(
-        auth=(MAILJET_API_KEY, MAILJET_API_SECRET))
+        auth=(MAILJET_API_KEY, MAILJET_API_SECRET), version='v3.1')
 
     data = {
-        'FromEmail': MAILJET_SENDER,
-        'FromName': 'App Engine Flex Mailjet Sample',
-        'Subject': 'Example email.',
-        'Text-part': 'This is an example email.',
-        'Html-part': 'This is an <i>example</i> email.',
-        'Recipients': [{'Email': to}]
-    }
+  'Messages': [
+                {
+        "From": {
+                "Email": MAILJET_SENDER,
+                "Name": 'App Engine Flex Mailjet Sample'
+        },
+        "To": [
+                {
+                "Email": to
+                }
+        ],
+        "Subject": 'Example email.',
+        "TextPart": 'This is an example email.',
+        "HTMLPart": 'This is an <i>example</i> email.'
+        }
+        ]
+}
 
     result = client.send.create(data=data)
 

--- a/appengine/standard/mailjet/main.py
+++ b/appengine/standard/mailjet/main.py
@@ -41,19 +41,19 @@ def send_message(to):
     data = {
   'Messages': [
                 {
-        "From": {
-                "Email": MAILJET_SENDER,
-                "Name": 'App Engine Flex Mailjet Sample'
-        },
-        "To": [
-                {
-                "Email": to
+                        "From": {
+                                "Email": MAILJET_SENDER,
+                                "Name": 'App Engine Flex Mailjet Sample'
+                        },
+                        "To": [
+                                {
+                                        "Email": to
+                                }
+                        ],
+                        "Subject": 'Example email.',
+                        "TextPart": 'This is an example email.',
+                        "HTMLPart": 'This is an <i>example</i> email.'
                 }
-        ],
-        "Subject": 'Example email.',
-        "TextPart": 'This is an example email.',
-        "HTMLPart": 'This is an <i>example</i> email.'
-        }
         ]
 }
 


### PR DESCRIPTION
Mailjet Send API v3.1 is being released, so updating the code samples to match the new Send API v3.1 configuration. Reference can be found [here](https://dev.mailjet.com/beta/).

Also readme.md edited to change references from Mailgun to Mailjet.