### PR TITLE
Change 'swagger' to OpenAPI

### DIFF
--- a/endpoints/getting-started/clients/service_to_service_gae_default/main.py
+++ b/endpoints/getting-started/clients/service_to_service_gae_default/main.py
@@ -44,7 +44,7 @@ def generate_jwt():
         'iss': DEFAULT_SERVICE_ACCOUNT,
         'sub': DEFAULT_SERVICE_ACCOUNT,
         # aud must match 'audience' in the security configuration in your
-        # swagger spec.It can be any string.
+        # OpenAPI spec.It can be any string.
         'aud': 'echo.endpoints.sample.google.com',
         "email": DEFAULT_SERVICE_ACCOUNT
     })


### PR DESCRIPTION
It's been over a year now since they renamed this. We can move to use OpenAPI consistently.