### PR TITLE
Show the need for dealing with network connection issues.

### DIFF
--- a/compute/metadata/main.py
+++ b/compute/metadata/main.py
@@ -38,15 +38,15 @@ def wait_for_maintenance(callback):
 
     while True:
         try:
-          r = requests.get(
-              url,
-              params={'last_etag': last_etag, 'wait_for_change': True},
-              headers=METADATA_HEADERS)
+            r = requests.get(
+                url,
+                params={'last_etag': last_etag, 'wait_for_change': True},
+                headers=METADATA_HEADERS)
         except requests.ConnectionError as e:
-          # Network connection may be reset during maintenance.
-          print('Network error: {0}.  Retrying...'.format(e))
-          time.sleep(1)
-          continue
+            # Network connection may be reset during maintenance.
+            print('Network error: {0}.  Retrying...'.format(e))
+            time.sleep(1)
+            continue
 
         # During maintenance the service can return a 503, so these should
         # be retried.

--- a/compute/metadata/main.py
+++ b/compute/metadata/main.py
@@ -37,14 +37,21 @@ def wait_for_maintenance(callback):
     last_etag = '0'
 
     while True:
-        r = requests.get(
-            url,
-            params={'last_etag': last_etag, 'wait_for_change': True},
-            headers=METADATA_HEADERS)
+        try:
+          r = requests.get(
+              url,
+              params={'last_etag': last_etag, 'wait_for_change': True},
+              headers=METADATA_HEADERS)
+        except requests.ConnectionError as e:
+          # Network connection may be reset during maintenance.
+          print('Network error: {0}.  Retrying...'.format(e))
+          time.sleep(1)
+          continue
 
         # During maintenance the service can return a 503, so these should
         # be retried.
         if r.status_code == 503:
+            print('Service returned 503.  Retrying...')
             time.sleep(1)
             continue
         r.raise_for_status()


### PR DESCRIPTION
The current documentation for accessing the metadata server does
not show how to deal with network issues.  It is possible to see
a "connection reset by peer."  This change explicitly calls that
out.