### PR TITLE
updates firebaseui version

### DIFF
--- a/appengine/standard/firebase/firenotes/frontend/index.html
+++ b/appengine/standard/firebase/firenotes/frontend/index.html
@@ -10,8 +10,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
   <script src="https://www.gstatic.com/firebasejs/3.2.1/firebase.js"></script>
   <script src="https://www.gstatic.com/firebasejs/3.1.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/3.1.0/firebase-auth.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/ui/live/0.5/firebase-ui-auth.js"></script>
-  <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/live/0.5/firebase-ui-auth.css">
+  <script src="https://www.gstatic.com/firebasejs/ui/live/1.0/firebase-ui-auth.js"></script>
+  <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/live/1.0/firebase-ui-auth.css">
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="/main.js"></script>
   <title>Firenotes</title>


### PR DESCRIPTION
I spent a lot of time messing with this example code, trying to disable account chooser. Finally I realized that `firebaseui.auth.CredentialHelper` was added later. This would have saved me a couple of hours and a lot of frustration.