### PR TITLE
Remove application and version from app.yaml

### DIFF
--- a/appengine/standard/bigquery/app.yaml
+++ b/appengine/standard/bigquery/app.yaml
@@ -1,5 +1,3 @@
-application: cloud-samples-tests
-version: 1
 runtime: python27
 api_version: 1
 threadsafe: yes


### PR DESCRIPTION
Removes the application and version fields from the app.yaml to make the project compatible with the newer preferred gcloud based tooling.