### PR TITLE
add another script to generate google id token.

### DIFF
--- a/endpoints/getting-started/clients/google-id-token-client2.py
+++ b/endpoints/getting-started/clients/google-id-token-client2.py
@@ -1,0 +1,54 @@
+import json
+import logging
+import requests
+import time
+
+from pprint import pprint
+
+from google.auth import crypt, jwt
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+# generates a signed JSON Web Token
+
+with open('/usr/local/google/home/ensonic/robco_gob/cloud-robotics/src/bootstrap/robot/robot-credentials.json', 'r') as fh:
+    service_account_info = json.load(fh)
+
+signer = crypt.RSASigner.from_service_account_info(service_account_info)
+
+now = int(time.time())
+payload = {
+    'iat': now,
+    # expires after one hour.
+    'exp': now + 3600,
+    'iss': service_account_info['client_email'],
+    # the URL of the target service.
+    'target_audience': 'https://registry.endpoints.robco-166608.cloud.goog',
+    # Google token endpoints URL, FIXME: use discovery doc
+    'aud': 'https://www.googleapis.com/oauth2/v4/token'
+}
+signed_jwt = jwt.encode(signer, payload)
+
+pprint(signed_jwt)
+
+
+# send the JWT to Google Token endpoints to request Google ID token
+
+params = {
+    'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    'assertion': signed_jwt
+}
+headers = {"Content-Type": "application/x-www-form-urlencoded"}
+response = requests.post('https://www.googleapis.com/oauth2/v4/token', data=params, headers=headers)
+res = response.json()
+
+pprint(res)
+
+# request
+
+headers = {'Authorization': 'Bearer {}'.format(res['id_token'])}
+response = requests.get('https://registry.ensonic.cloudrobotics.com/v1/testauth', headers=headers, verify=False)
+response.raise_for_status()
+print("-- got response --")
+print(response.json())

--- a/endpoints/getting-started/clients/google-id-token-client2.py
+++ b/endpoints/getting-started/clients/google-id-token-client2.py
@@ -40,7 +40,8 @@ params = {
     'assertion': signed_jwt
 }
 headers = {"Content-Type": "application/x-www-form-urlencoded"}
-response = requests.post('https://www.googleapis.com/oauth2/v4/token', data=params, headers=headers)
+response = requests.post('https://www.googleapis.com/oauth2/v4/token',
+                         data=params, headers=headers)
 res = response.json()
 
 pprint(res)
@@ -48,7 +49,8 @@ pprint(res)
 # request
 
 headers = {'Authorization': 'Bearer {}'.format(res['id_token'])}
-response = requests.get('https://YOUR-SERVICE-URL', headers=headers, verify=False)
+response = requests.get('https://YOUR-SERVICE-URL',
+                        headers=headers, verify=False)
 response.raise_for_status()
 print("-- got response --")
 print(response.json())

--- a/endpoints/getting-started/clients/google-id-token-client2.py
+++ b/endpoints/getting-started/clients/google-id-token-client2.py
@@ -12,7 +12,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 # generates a signed JSON Web Token
 
-with open('/usr/local/google/home/ensonic/robco_gob/cloud-robotics/src/bootstrap/robot/robot-credentials.json', 'r') as fh:
+with open('/path/to/service_account.json', 'r') as fh:
     service_account_info = json.load(fh)
 
 signer = crypt.RSASigner.from_service_account_info(service_account_info)
@@ -23,8 +23,8 @@ payload = {
     # expires after one hour.
     'exp': now + 3600,
     'iss': service_account_info['client_email'],
-    # the URL of the target service.
-    'target_audience': 'https://registry.endpoints.robco-166608.cloud.goog',
+    # the URL of the target service
+    "target_audience": 'https://YOUR-TARGET-SERVICE',
     # Google token endpoints URL, FIXME: use discovery doc
     'aud': 'https://www.googleapis.com/oauth2/v4/token'
 }
@@ -48,7 +48,7 @@ pprint(res)
 # request
 
 headers = {'Authorization': 'Bearer {}'.format(res['id_token'])}
-response = requests.get('https://registry.ensonic.cloudrobotics.com/v1/testauth', headers=headers, verify=False)
+response = requests.get('https://YOUR-SERVICE-URL', headers=headers, verify=False)
 response.raise_for_status()
 print("-- got response --")
 print(response.json())


### PR DESCRIPTION
Add another sample python script to generate google ID token.  There are many ways of doing it.  

The existing file google-id-token-client.py is using google_auth_oauthlib.flow package.
This file  google-id-token-client2.py is using google.auth package
