### PR TITLE
Create better service name template in app.yaml

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/README.md
+++ b/appengine/standard/endpoints-frameworks-v2/echo/README.md
@@ -24,7 +24,7 @@ The command returns several lines of information, including a line similar to th
 
    Service Configuration [2016-08-01r0] uploaded for service "echo-api.endpoints.[YOUR-PROJECT-ID].cloud.goog"
 
-Open the `app.yaml` file and in the `env_variables` section, replace [YOUR-PROJECT-ID] in `echo-api.endpoints.[YOUR-PROJECT-ID].cloud.goog` with your project ID. This is your Endpoints service name. Then replace `2016-08-01r0` with your uploaded service management configuration.
+Open the `app.yaml` file and in the `env_variables` section, replace [YOUR-PROJECT-ID] in `[YOUR-PROJECT-ID].appspot.com` with your project ID. This is your Endpoints service name. Then replace `2016-08-01r0` with your uploaded service management configuration.
 
 Then, deploy the sample using `gcloud`:
 

--- a/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
+++ b/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
@@ -28,5 +28,5 @@ libraries:
 env_variables:
   # The following values are to be replaced by information from the output of
   # 'gcloud service-management deploy swagger.json' command.
-  ENDPOINTS_SERVICE_NAME: YOUR-PROJECT-ID.appspot.com
+  ENDPOINTS_SERVICE_NAME: [YOUR-PROJECT-ID].appspot.com
   ENDPOINTS_SERVICE_VERSION: 2016-08-01r0


### PR DESCRIPTION
Endpoints Frameworks apps on GAE standard must use the appspot.com domain name; users will have to change the line anyway, but this way fewer changes are required.

Reopened version of #1021 