### PR TITLE
Add type to port argument

### DIFF
--- a/iot/api-client/mqtt_example/cloudiot_mqtt_example.py
+++ b/iot/api-client/mqtt_example/cloudiot_mqtt_example.py
@@ -127,7 +127,10 @@ def parse_command_line_args():
             default='mqtt.googleapis.com',
             help='MQTT bridge hostname.')
     parser.add_argument(
-            '--mqtt_bridge_port', default=8883, help='MQTT bridge port.')
+            '--mqtt_bridge_port',
+            default=8883,
+            type=int,
+            help='MQTT bridge port.')
 
     return parser.parse_args()
 


### PR DESCRIPTION
Fixes [this issue](https://github.com/GoogleCloudPlatform/python-docs-samples/issues/1141).