### PR TITLE
Require latest Endpoints Framework version

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
@@ -1,2 +1,2 @@
 google-endpoints==2.3.1
-google-endpoints-api-management==1.2.1
+google-endpoints-api-management==1.3.0


### PR DESCRIPTION
Given that users may go on to make real apps from this sample, we should keep to the latest known-good versions.