### PR TITLE
Tweak doc/help strings for sample tools 

### DIFF
--- a/video/cloud-client/faces/faces.py
+++ b/video/cloud-client/faces/faces.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This application demonstrates how to perform shot change detection with the
-Google Cloud Video Intelligence API.
+"""This application demonstrates how to perform face
+detection with the Google Cloud Video Intelligence API.
 
 For more information, check out the documentation at
 https://cloud.google.com/videointelligence/docs.

--- a/video/cloud-client/faces/faces_test.py
+++ b/video/cloud-client/faces/faces_test.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 import os
-import faces
 import pytest
+import faces
 
 
 BUCKET = os.environ['CLOUD_STORAGE_BUCKET']

--- a/video/cloud-client/labels/labels.py
+++ b/video/cloud-client/labels/labels.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This application demonstrates how to perform basic operations with the
-Google Cloud Video Intelligence API.
+"""This application demonstrates how to detect labels from a video
+based on the image content with the Google Cloud Video Intelligence
+API.
 
 For more information, check out the documentation at
 https://cloud.google.com/videointelligence/docs.

--- a/video/cloud-client/labels/labels_test.py
+++ b/video/cloud-client/labels/labels_test.py
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 import os
-import labels
 import pytest
+import labels
 
 
 BUCKET = os.environ['CLOUD_STORAGE_BUCKET']

--- a/video/cloud-client/quickstart/quickstart.py
+++ b/video/cloud-client/quickstart/quickstart.py
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This application demonstrates label detection on a demo video using the Google Cloud API.
+"""This application demonstrates label detection on a demo video using
+the Google Cloud API.
 
 Usage:
     python quickstart.py
+
 """
 
 

--- a/video/cloud-client/quickstart/quickstart.py
+++ b/video/cloud-client/quickstart/quickstart.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This application demonstrates label detection using the Google Cloud API.
+"""This application demonstrates label detection on a demo video using the Google Cloud API.
 
 Usage:
     python quickstart.py

--- a/video/cloud-client/shotchange/shotchange.py
+++ b/video/cloud-client/shotchange/shotchange.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This application demonstrates how to perform basic operations with the
-Google Cloud Video Intelligence API.
+"""This application demonstrates how to identify all different shots
+in a video using the Google Cloud Video Intelligence API.
 
 For more information, check out the documentation at
 https://cloud.google.com/videointelligence/docs.


### PR DESCRIPTION
I noticed the faces.py example had a copy/paste doc string form the shotchanges.py example. That lead to correcting/tweaking the other doc/help strings for the other python examples.
 