### PR TITLE
The square bracket in app.yaml upsets the YAML parser

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
+++ b/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
@@ -28,5 +28,5 @@ libraries:
 env_variables:
   # The following values are to be replaced by information from the output of
   # 'gcloud service-management deploy swagger.json' command.
-  ENDPOINTS_SERVICE_NAME: [YOUR-PROJECT-ID].appspot.com
+  ENDPOINTS_SERVICE_NAME: YOUR-PROJECT-ID.appspot.com
   ENDPOINTS_SERVICE_VERSION: 2016-08-01r0


### PR DESCRIPTION
When people following this doc [1], they will run into this error because of the extra square bracket in the app.yaml file.

```sh
python lib/endpoints/endpointscfg.py get_openapi_spec main.EchoApi --hostname xxx.appspot.com
```
```sh
No handlers could be found for logger "oauth2client.contrib.multistore_file"
Traceback (most recent call last):
  File "lib/endpoints/endpointscfg.py", line 633, in <module>
    main(sys.argv)
  File "lib/endpoints/endpointscfg.py", line 629, in main
    args.callback(args)
  File "lib/endpoints/endpointscfg.py", line 487, in _GenOpenApiSpecCallback
    application_path=args.application)
  File "lib/endpoints/endpointscfg.py", line 332, in _GenOpenApiSpec
runtime: python27
    application_path=application_path)
  File "lib/endpoints/endpointscfg.py", line 200, in GenApiConfig
    app_yaml_hostname = _GetAppYamlHostname(application_path)
  File "lib/endpoints/endpointscfg.py", line 235, in _GetAppYamlHostname
    config = yaml.safe_load(app_yaml_file.read())
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/__init__.py", line 93, in safe_load
    return load(stream, SafeLoader)
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/__init__.py", line 71, in load
    return loader.get_single_data()
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/constructor.py", line 37, in get_single_data
    node = self.get_single_node()
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/composer.py", line 133, in compose_mapping_node
    item_value = self.compose_node(node, item_key)
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
runtime: python27
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/Users/nmiu/tools/google-cloud-sdk/platform/google_appengine/lib/yaml-3.10/yaml/parser.py", line 439, in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block mapping
  in "<string>", line 31, column 3:
      ENDPOINTS_SERVICE_NAME: [YOUR-PR ...
      ^
expected <block end>, but found '<scalar>'
  in "<string>", line 31, column 44:
     ... _SERVICE_NAME: [YOUR-PROJECT-ID].appspot.com
                                         ^
```

[1] https://cloud.google.com/endpoints/docs/frameworks/python/get-started-frameworks-python#before-you-begin