### PR TITLE
Update requirements.txt due to broken dependency

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
@@ -1,2 +1,2 @@
-google-endpoints==2.4.1
+google-endpoints==2.4.2
 google-endpoints-api-management==1.3.0


### PR DESCRIPTION
google-endpoints 2.4.1 contained a bug which made it impossible to complete the tutorial. We want everyone to be using 2.4.2 as soon as possible.