### PR TITLE
Update deprecated commands for `gcloud service-management`

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/README.md
+++ b/appengine/standard/endpoints-frameworks-v2/echo/README.md
@@ -18,7 +18,7 @@ Remember to replace [YOUR-PROJECT-ID] with your project ID.
 
 To set up OAuth2, replace `your-oauth-client-id.com` under `audiences` in the annotation for `get_user_email` with your OAuth2 client ID. If you want to use Google OAuth2 Playground, use `407408718192.apps.googleusercontent.com` as your audience. To generate a JWT, go to the following address: `https://developers.google.com/oauthplayground`.
 
-Deploy the generated swagger spec to Google Cloud Service Management: `gcloud alpha service-management deploy echo-v1_swagger.json`
+Deploy the generated swagger spec to Google Cloud Service Management: `gcloud endpoints services deploy echo-v1_swagger.json`
 
 The command returns several lines of information, including a line similar to the following:
 

--- a/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
+++ b/appengine/standard/endpoints-frameworks-v2/echo/app.yaml
@@ -28,7 +28,7 @@ libraries:
 # [START env_vars]
 env_variables:
   # The following values are to be replaced by information from the output of
-  # 'gcloud service-management deploy swagger.json' command.
+  # 'gcloud endpoints services deploy swagger.json' command.
   ENDPOINTS_SERVICE_NAME: YOUR-PROJECT-ID.appspot.com
   ENDPOINTS_SERVICE_VERSION: 2016-08-01r0
  # [END env_vars]

--- a/appengine/standard/endpoints-frameworks-v2/quickstart/app.yaml
+++ b/appengine/standard/endpoints-frameworks-v2/quickstart/app.yaml
@@ -23,6 +23,6 @@ libraries:
 
 env_variables:
   # The following values are to be replaced by information from the output of
-  # 'gcloud service-management deploy swagger.json' command.
+  # 'gcloud endpoints services deploy swagger.json' command.
   ENDPOINTS_SERVICE_NAME: greeting-api.endpoints.[YOUR-PROJECT-ID].cloud.goog
   ENDPOINTS_SERVICE_VERSION: 2016-08-01r0

--- a/codelabs/flex_and_vision/README.md
+++ b/codelabs/flex_and_vision/README.md
@@ -40,9 +40,9 @@ Change directory to the sample code location:
 
 Enable the APIs:
 
-    gcloud service-management enable vision.googleapis.com
-    gcloud service-management enable storage-component.googleapis.com
-    gcloud service-management enable datastore.googleapis.com
+    gcloud services enable vision.googleapis.com
+    gcloud services enable storage-component.googleapis.com
+    gcloud services enable datastore.googleapis.com
 
 Create a Service Account to access the Google Cloud APIs when testing locally:
 

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -42,14 +42,14 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
 1. Deploy your service config to Service Management:
 
     ```bash
-    gcloud service-management deploy out.pb api_config.yaml
+    gcloud endpoints services deploy out.pb api_config.yaml
     # The Config ID should be printed out, looks like: 2017-02-01r0, remember this
 
     # Set your project ID as a variable to make commands easier:
     GCLOUD_PROJECT=<Your Project ID>
 
     # Print out your Config ID again, in case you missed it:
-    gcloud service-management configs list --service hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
+    gcloud endpoints configs list --service hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
     ```
 
 1. Also get an API key from the Console's API Manager for use in the
@@ -58,7 +58,7 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
 1. Enable the Cloud Build API:
 
     ```bash
-    gcloud service-management enable cloudbuild.googleapis.com
+    gcloud services enable cloudbuild.googleapis.com
     ```
 
 1. Build a docker image for your gRPC server, and store it in your Registry:
@@ -74,7 +74,7 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
 1. Enable the Compute Engine API:
 
     ```bash
-    gcloud service-management enable compute-component.googleapis.com
+    gcloud services enable compute-component.googleapis.com
     ```
 
 1. Create your instance and ssh in:
@@ -150,7 +150,7 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
    GCLOUD_PROJECT with your project ID.
 
    ```bash
-   gcloud service-management configs list --service hellogrpc.endpoints.GCLOUD_PROJECT.cloud.goog
+   gcloud endpoints configs list --service hellogrpc.endpoints.GCLOUD_PROJECT.cloud.goog
    ```
 
 1. Deploy to GKE:

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -7,6 +7,6 @@ runtime_config:
 
 endpoints_api_service:
   # The following values are to be replaced by information from the output of
-  # 'gcloud service-management deploy openapi.yaml' command.
+  # 'gcloud endpoints services deploy openapi.yaml' command.
   name: ENDPOINTS SERVICE-NAME
   config_id: ENDPOINTS CONFIG-ID


### PR DESCRIPTION
@inklesspen 
 - `gcloud service-management deploy` becomes `gcloud endpoints deploy`
 - `gcloud service-management enable` becomes `gcloud services enable`
 - `gcloud service-management configs` becomes `gcloud endpoints configs`