### PR TITLE
Bump spanner stale read from 10 to 15 seconds.

### DIFF
--- a/spanner/cloud-client/snippets.py
+++ b/spanner/cloud-client/snippets.py
@@ -120,14 +120,14 @@ def read_data(instance_id, database_id):
 
 
 def read_stale_data(instance_id, database_id):
-    """Reads sample data from the database. The data is exactly 10 seconds
+    """Reads sample data from the database. The data is exactly 15 seconds
     stale."""
     import datetime
 
     spanner_client = spanner.Client()
     instance = spanner_client.instance(instance_id)
     database = instance.database(database_id)
-    staleness = datetime.timedelta(seconds=10)
+    staleness = datetime.timedelta(seconds=15)
 
     with database.snapshot(exact_staleness=staleness) as snapshot:
         keyset = spanner.KeySet(all_=True)

--- a/spanner/cloud-client/snippets_test.py
+++ b/spanner/cloud-client/snippets_test.py
@@ -79,7 +79,7 @@ def test_read_stale_data(temporary_database, capsys):
     out, _ = capsys.readouterr()
 
     # It shouldn't be in the output because it was *just* inserted by the
-    # temporary database fixture and this sample reads 10 seconds into the
+    # temporary database fixture and this sample reads 15 seconds into the
     # past.
     assert 'Total Junk' not in out
 


### PR DESCRIPTION
At the request of the spanner team.