### PR TITLE
Keeping user's costs low when using the hello world

### DIFF
--- a/appengine/flexible/hello_world/app.yaml
+++ b/appengine/flexible/hello_world/app.yaml
@@ -4,3 +4,14 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   python_version: 3
+
+# This sample incurs costs to run on the App Engine flexible environment. 
+# The settings below are to reduce costs during testing and are not appropriate
+# for production use. For more information, see:
+# https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml
+automatic_scaling:
+  max_num_instances: 1
+resources:
+  cpu: 1
+  memory_gb: 0.5
+  disk_size_gb: 10


### PR DESCRIPTION
A few people have found painfully if they left the sample running with the default settings they incurred an unexpected charge. This keeps costs low for those kicking the tires on App Engine.