### PR TITLE
Update example_startup_script.sh

### DIFF
--- a/iap/example_startup_script.sh
+++ b/iap/example_startup_script.sh
@@ -1,3 +1,4 @@
+apt-get -y update
 apt-get -y install git
 apt-get -y install virtualenv
 git clone https://github.com/GoogleCloudPlatform/python-docs-samples


### PR DESCRIPTION
On latest Debian 9 image on GCP this startup script fails with this error:

Nov 30 17:03:33 localhost startup-script: INFO startup-script: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?