### PR TITLE
remove empty input_uri

### DIFF
--- a/video/cloud-client/analyze/analyze.py
+++ b/video/cloud-client/analyze/analyze.py
@@ -187,7 +187,7 @@ def analyze_labels_file(path):
         input_content = movie.read()
 
     operation = video_client.annotate_video(
-        '', features=features, input_content=input_content)
+        features=features, input_content=input_content)
     print('\nProcessing video for label annotations:')
 
     result = operation.result(timeout=90)


### PR DESCRIPTION
The client library was updated to make the `input_uri` optional.