### PR TITLE
Fix broken link to core Client service account helper.

### DIFF
--- a/bigquery/cloud-client/auth_snippets.py
+++ b/bigquery/cloud-client/auth_snippets.py
@@ -35,8 +35,7 @@ def explicit():
 
     # Explicitly use service account credentials by specifying the private key
     # file. All clients in google-cloud-python have this helper, see
-    # https://google-cloud-python.readthedocs.io/en/latest/core/modules.html
-    #   #google.cloud.client.Client.from_service_account_json
+    # https://googlecloudplatform.github.io/google-cloud-python/latest/core/auth.html#service-accounts
     bigquery_client = bigquery.Client.from_service_account_json(
         'service_account.json')
 


### PR DESCRIPTION
I'm also updating the links at https://cloud.google.com/bigquery/docs/authentication/service-account-file#bigquery-authentication-service-account-file-python