### PR TITLE
Latest version of Werkzeug raises ImportError

### DIFF
--- a/appengine/standard/flask/tutorial/requirements.txt
+++ b/appengine/standard/flask/tutorial/requirements.txt
@@ -1,1 +1,2 @@
+Werkzeug==0.12.2
 Flask==0.12.2

--- a/appengine/standard/flask/tutorial/requirements.txt
+++ b/appengine/standard/flask/tutorial/requirements.txt
@@ -1,2 +1,4 @@
-Werkzeug==0.12.2
 Flask==0.12.2
+# v0.13 uses tempfile.SpooledTemporaryFile which is not supported in the app
+# engine sandbox. See https://cloud.google.com/appengine/docs/standard/python/runtime#customized-libraries-in-python-version-27
+Werkzeug<=0.13


### PR DESCRIPTION
The latest version of Werkzeug (0.13) released on December 7th raises an ImportError when Flask is imported on app engine.

```ImportError: cannot import name SpooledTemporaryFile```

App engine standard does not support SpooledTemporaryFile, so we should explicitly instruct users to install Werkzeug==0.12.2 (last working version).