### PR TITLE
Temperature data load should be a bytes object, not str.

### DIFF
--- a/iot/api-client/end_to_end_example/cloudiot_pubsub_example_server_test.py
+++ b/iot/api-client/end_to_end_example/cloudiot_pubsub_example_server_test.py
@@ -30,7 +30,7 @@ registry_id = 'test-registry-{}'.format(int(time.time()))
 
 def test_config_turn_on(capsys):
     max_temp = 11
-    data = {'temperature': max_temp}
+    data = {b'temperature': max_temp}
 
     Server = example_server.Server(service_account_json)
     Server._update_device_config(
@@ -48,7 +48,7 @@ def test_config_turn_on(capsys):
 
 def test_config_turn_off(capsys):
     min_temp = -1
-    data = {'temperature': min_temp}
+    data = {b'temperature': min_temp}
 
     Server = example_server.Server(service_account_json)
     Server._update_device_config(
@@ -60,3 +60,5 @@ def test_config_turn_off(capsys):
 
     stdout, _ = capsys.readouterr()
     assert 'off' in stdout
+    assert '-1' in stdout
+    assert 'test-device-{}' in stdout


### PR DESCRIPTION
Also add a bit more output in the check for the test_config_turn_off test to make it consistent with the test_config_turn_on output check.