### PR TITLE
BigQuery: rewrite simple app tutorial.

### DIFF
--- a/bigquery/cloud-client/requirements.txt
+++ b/bigquery/cloud-client/requirements.txt
@@ -1,3 +1,5 @@
+# [START bigquery_simple_app_pkgs]
 google-cloud-bigquery==0.28.0
+# [END bigquery_simple_app_pkgs]
 google-auth-oauthlib==0.2.0
 pytz==2017.3

--- a/bigquery/cloud-client/simple_app.py
+++ b/bigquery/cloud-client/simple_app.py
@@ -16,20 +16,25 @@
 
 """Simple application that performs a query with BigQuery."""
 # [START all]
-# [START create_client]
+# [START bigquery_simple_app_deps]
 from google.cloud import bigquery
+# [END bigquery_simple_app_deps]
 
 
-def query_shakespeare():
+def query_stackoverflow():
+    # [START create_client]
     client = bigquery.Client()
     # [END create_client]
     # [START run_query]
     query_job = client.query("""
-        #standardSQL
-        SELECT corpus AS title, COUNT(*) AS unique_words
-        FROM `bigquery-public-data.samples.shakespeare`
-        GROUP BY title
-        ORDER BY unique_words DESC
+        SELECT
+          CONCAT(
+            'https://stackoverflow.com/questions/',
+            CAST(id as STRING)) as url,
+          view_count
+        FROM `bigquery-public-data.stackoverflow.posts_questions`
+        WHERE tags like '%google-bigquery%'
+        ORDER BY view_count DESC
         LIMIT 10""")
 
     results = query_job.result()  # Waits for job to complete.
@@ -37,10 +42,10 @@ def query_shakespeare():
 
     # [START print_results]
     for row in results:
-        print("{}: {}".format(row.title, row.unique_words))
+        print("{} : {} views".format(row.url, row.view_count))
     # [END print_results]
 
 
 if __name__ == '__main__':
-    query_shakespeare()
+    query_stackoverflow()
 # [END all]

--- a/bigquery/cloud-client/simple_app_test.py
+++ b/bigquery/cloud-client/simple_app_test.py
@@ -15,7 +15,7 @@
 import simple_app
 
 
-def test_query_shakespeare(capsys):
-    simple_app.query_shakespeare()
+def test_query_stackoverflow(capsys):
+    simple_app.query_stackoverflow()
     out, _ = capsys.readouterr()
-    assert 'hamlet' in out
+    assert 'views' in out


### PR DESCRIPTION
- Add region tags for needed dependencies.
- Use more relevant query from public datasets.