### PR TITLE
fix message.payload str casting.

### DIFF
--- a/iot/api-client/end_to_end_example/cloudiot_pubsub_example_mqtt_device.py
+++ b/iot/api-client/end_to_end_example/cloudiot_pubsub_example_mqtt_device.py
@@ -121,7 +121,7 @@ class Device(object):
 
     def on_message(self, unused_client, unused_userdata, message):
         """Callback when the device receives a message on a subscription."""
-        payload = str(message.payload)
+        payload = message.payload
         print('Received message \'{}\' on topic \'{}\' with Qos {}'.format(
             payload, message.topic, str(message.qos)))
 


### PR DESCRIPTION
Env: Python 3.6.4 (default, Jan  6 2018, 11:51:59)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin

cloudiot_pubsub_example_mqtt_device.py.py in iot end_to_end_example contains wrong str casting.
json.loads takes byte parameter, so you don't have to cast for using it.
If you really want to convert byte to string, it should be 

```python3
payload = message.payload.decode()
```

current version produces an error

`
  File "cloudiot_pubsub_example_mqtt_device.py", line 136, in on_message
    data = json.loads(payload)
  File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
`