### PR TITLE
Fix subscription.open get called twice in the client libraries

### DIFF
--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -120,7 +120,7 @@ def listen_for_errors(project, subscription_name):
         print('Received message: {}'.format(message))
         message.ack()
 
-    subscription = client.subscribe(subscription_path, callback=callback)
+    subscription = subscriber.subscribe(subscription_path, callback=callback)
 
     # Blocks the thread while messages are coming in through the stream. Any
     # exceptions that crop up on the thread will be set on the future.

--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -126,7 +126,7 @@ def listen_for_errors(project, subscription_name):
     # exceptions that crop up on the thread will be set on the future.
     future = subscription.open(callback)
     try:
-        future.result()
+        subscription.future.result()
     except Exception as e:
         print(
             'Listening for messages on {} threw an Exception: {}.'.format(

--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -124,7 +124,7 @@ def listen_for_errors(project, subscription_name):
 
     # Blocks the thread while messages are coming in through the stream. Any
     # exceptions that crop up on the thread will be set on the future.
-    future = subscription.open(callback)
+    future = subscription.future(callback)
     try:
         future.result()
     except Exception as e:

--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -120,11 +120,11 @@ def listen_for_errors(project, subscription_name):
         print('Received message: {}'.format(message))
         message.ack()
 
-    subscription = subscriber.subscribe(subscription_path, callback=callback)
+    subscription = client.subscribe(subscription_path, callback=callback)
 
     # Blocks the thread while messages are coming in through the stream. Any
     # exceptions that crop up on the thread will be set on the future.
-    future = subscription.future(callback)
+    future = subscription.open(callback)
     try:
         future.result()
     except Exception as e:

--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -124,7 +124,6 @@ def listen_for_errors(project, subscription_name):
 
     # Blocks the thread while messages are coming in through the stream. Any
     # exceptions that crop up on the thread will be set on the future.
-    future = subscription.open(callback)
     try:
         subscription.future.result()
     except Exception as e:


### PR DESCRIPTION
Current code [1] will make subscription.open get called twice:
1- https://github.com/GoogleCloudPlatform/google-cloud-python/blob/master/pubsub/google/cloud/pubsub_v1/subscriber/client.py
2- https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/pubsub/cloud-client/subscriber.py

[1] https://cloud.google.com/pubsub/docs/pull#listening-for-errors

To fix this, it should use subscription.future instead of calling open()...