### PR TITLE
Add comment about requirement order in endpoints sample.

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
@@ -1,2 +1,6 @@
+# If more requirements are added to an Endpoints project, the
+# google-endpoints and google-endpoints-api-management requirements
+# must remain at the top. See this url for details:
+# https://cloud.google.com/endpoints/docs/known-issues#error_message_importerror_cannot_import_name_locked_file
 google-endpoints==2.4.5
 google-endpoints-api-management==1.3.0


### PR DESCRIPTION
We've seen repeated issues where specifying packages such as `google-api-python-client` before the Frameworks packages causes an invalid version of `oauth2client` to be installed.