### PR TITLE
Cut off streaming generator in transcribe_streaming_mic to 20 seconds

### DIFF
--- a/speech/cloud-client/transcribe_streaming_mic.py
+++ b/speech/cloud-client/transcribe_streaming_mic.py
@@ -28,6 +28,8 @@ Example usage:
 # [START import_libraries]
 from __future__ import division
 
+from datetime import datetime
+from datetime import timedelta
 import re
 import sys
 
@@ -86,7 +88,11 @@ class MicrophoneStream(object):
         return None, pyaudio.paContinue
 
     def generator(self):
+        # limit generator to 20 seconds
+        time = datetime.now()
         while not self.closed:
+            if datetime.now() - time > timedelta(seconds=20):
+                break
             # Use a blocking get() to ensure there's at least one chunk of
             # data, and stop iteration if the chunk is None, indicating the
             # end of the audio stream.


### PR DESCRIPTION
Works with python3, python2 still has a bug (different from this)
See [google-cloud-python/4820](https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4820)