### PR TITLE
Fixes python version flag & bad import in context manager

### DIFF
--- a/endpoints/bookstore-grpc/Dockerfile
+++ b/endpoints/bookstore-grpc/Dockerfile
@@ -5,7 +5,7 @@ FROM gcr.io/google_appengine/python
 
 # Create a virtualenv for dependencies. This isolates these packages from
 # system-level packages.
-RUN virtualenv -p python3.5 /env
+RUN virtualenv -p python3.6 /env
 
 # Setting these environment variables are the same as running
 # source /env/bin/activate.

--- a/endpoints/bookstore-grpc/Dockerfile
+++ b/endpoints/bookstore-grpc/Dockerfile
@@ -5,11 +5,11 @@ FROM gcr.io/google_appengine/python
 
 # Create a virtualenv for dependencies. This isolates these packages from
 # system-level packages.
-RUN virtualenv /env
+RUN virtualenv -p python3.5 /env
 
 # Setting these environment variables are the same as running
 # source /env/bin/activate.
-ENV VIRTUAL_ENV -p python3.5 /env
+ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
 
 ADD . /bookstore/

--- a/endpoints/bookstore-grpc/status.py
+++ b/endpoints/bookstore-grpc/status.py
@@ -14,7 +14,7 @@
 
 from contextlib import contextmanager
 
-import status
+import grpc
 
 
 @contextmanager
@@ -23,6 +23,6 @@ def context(grpc_context):
     try:
         yield
     except KeyError as key_error:
-        grpc_context.code(status.Code.NOT_FOUND)
+        grpc_context.code(grpc.StatusCode.NOT_FOUND)
         grpc_context.details(
             'Unable to find the item keyed by {}'.format(key_error))


### PR DESCRIPTION
Adds the `-p python3.5` flag to virtualenv creation step, as currently the flag is being added to an env var (a typo I believe) and the python binary ends up being `python 2.7`. 

Fixes a bad import in status context manager.