### PR TITLE
Change to endpoints managed rollout

### DIFF
--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -49,13 +49,10 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
 
     ```bash
     gcloud endpoints services deploy api_descriptor.pb api_config.yaml
-    # The Config ID should be printed out, looks like: 2017-02-01r0, remember this
 
     # Set your project ID as a variable to make commands easier:
     GCLOUD_PROJECT=<Your Project ID>
 
-    # Print out your Config ID again, in case you missed it:
-    gcloud endpoints configs list --service hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
     ```
 
 1. Also get an API key from the Console's API Manager for use in the

--- a/endpoints/getting-started-grpc/README.md
+++ b/endpoints/getting-started-grpc/README.md
@@ -95,7 +95,6 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
     ```bash
     GCLOUD_PROJECT=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
     SERVICE_NAME=hellogrpc.endpoints.${GCLOUD_PROJECT}.cloud.goog
-    SERVICE_CONFIG_ID=<Your Config ID>
     ```
 
 1. Pull your credentials to access Container Registry, and run your gRPC server
@@ -114,7 +113,7 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
         --link=grpc-hello:grpc-hello \
         gcr.io/endpoints-release/endpoints-runtime:1 \
         --service=${SERVICE_NAME} \
-        --version=${SERVICE_CONFIG_ID} \
+        --rollout_strategy=managed \
         --http2_port=9000 \
         --backend=grpc://grpc-hello:50051
     ```
@@ -146,18 +145,10 @@ Cloud account and [SDK](https://cloud.google.com/sdk/) configured.
     gcloud container clusters create my-cluster --zone=us-central1-a
     ```
 
-1. Edit `deployment.yaml`. Replace `SERVICE_NAME`, `SERVICE_CONFIG_ID`,
-   and `GCLOUD_PROJECT` with your values:
+1. Edit `deployment.yaml`. Replace `SERVICE_NAME` and `GCLOUD_PROJECT` with your values:
 
    `SERVICE_NAME` is equal to hellogrpc.endpoints.GCLOUD_PROJECT.cloud.goog,
    replacing GCLOUD_PROJECT with your project ID.
-
-   `SERVICE_CONFIG_ID` can be found by running the following command, replacing
-   GCLOUD_PROJECT with your project ID.
-
-   ```bash
-   gcloud endpoints configs list --service hellogrpc.endpoints.GCLOUD_PROJECT.cloud.goog
-   ```
 
 1. Deploy to GKE:
 

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           "--http2_port=9000",
           "--backend=grpc://127.0.0.1:50051",
           "--service=SERVICE_NAME",
-          "--rollout_strategy==managed",
+          "--rollout_strategy=managed",
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started-grpc/deployment.yaml
+++ b/endpoints/getting-started-grpc/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           "--http2_port=9000",
           "--backend=grpc://127.0.0.1:50051",
           "--service=SERVICE_NAME",
-          "--version=SERVICE_CONFIG_ID",
+          "--rollout_strategy==managed",
         ]
         ports:
           - containerPort: 9000

--- a/endpoints/getting-started/app.yaml
+++ b/endpoints/getting-started/app.yaml
@@ -10,5 +10,5 @@ endpoints_api_service:
   # The following values are to be replaced by information from the output of
   # 'gcloud endpoints services deploy openapi-appengine.yaml' command.
   name: ENDPOINTS-SERVICE-NAME
-  config_id: ENDPOINTS-CONFIG-ID
+  rollout_strategy: managed
  # [END configuration]

--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           "--http_port=8081",
           "--backend=127.0.0.1:8080",
           "--service=SERVICE_NAME",
-          "--version=SERVICE_CONFIG_ID",
+          "--rollout_strategy=managed",
         ]
       # [END esp]
         ports:

--- a/endpoints/kubernetes/grpc-bookstore.yaml
+++ b/endpoints/kubernetes/grpc-bookstore.yaml
@@ -44,7 +44,7 @@ spec:
         args: [
           "--http2_port=9000",
           "--service=SERVICE_NAME",
-          "--version=SERVICE_CONFIG_ID",
+          "--rollout_strategy=managed",
           "--backend=grpc://127.0.0.1:8000"
         ]
         ports:


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag:
**--version=SERVICE_CONFIG_ID**