### PR TITLE
Add get_client function

### DIFF
--- a/monitoring/api/v3/api-client/list_resources.py
+++ b/monitoring/api/v3/api-client/list_resources.py
@@ -98,7 +98,7 @@ def list_timeseries(client, project_resource, metric):
 def get_client():
     client = googleapiclient.discovery.build('monitoring', 'v3')
     return client
-    
+
 
 def main(project_id):
     client = googleapiclient.discovery.build('monitoring', 'v3')

--- a/monitoring/api/v3/api-client/list_resources.py
+++ b/monitoring/api/v3/api-client/list_resources.py
@@ -94,6 +94,9 @@ def list_timeseries(client, project_resource, metric):
     response = request.execute()
     print('list_timeseries response:\n{}'.format(pprint.pformat(response)))
 
+def get_client():
+    client = googleapiclient.discovery.build('monitoring', 'v3')
+    return client
 
 def main(project_id):
     client = googleapiclient.discovery.build('monitoring', 'v3')

--- a/monitoring/api/v3/api-client/list_resources.py
+++ b/monitoring/api/v3/api-client/list_resources.py
@@ -94,9 +94,11 @@ def list_timeseries(client, project_resource, metric):
     response = request.execute()
     print('list_timeseries response:\n{}'.format(pprint.pformat(response)))
 
+
 def get_client():
     client = googleapiclient.discovery.build('monitoring', 'v3')
     return client
+    
 
 def main(project_id):
     client = googleapiclient.discovery.build('monitoring', 'v3')


### PR DESCRIPTION
This pertains to issue https://github.com/GoogleCloudPlatform/python-docs-samples/issues/1352

It looks like `list_resources.py` did not have a `get_client` function, so I added it.