### PR TITLE
updated Quickstart terminal print out and tests

### DIFF
--- a/dlp/quickstart.py
+++ b/dlp/quickstart.py
@@ -72,7 +72,12 @@ def quickstart():
             except AttributeError:
                 pass
             print('Info type: {}'.format(finding.info_type.name))
-            print('Likelihood: {}'.format(finding.likelihood))
+            # Convert likelihood value to string respresentation.
+            likelihood = (google.cloud.dlp.types.Finding.DESCRIPTOR
+                          .fields_by_name['likelihood']
+                          .enum_type.values_by_number[finding.likelihood]
+                          .name)
+            print('Likelihood: {}'.format(likelihood))
     else:
         print('No findings.')
     # [END quickstart]

--- a/dlp/quickstart_test.py
+++ b/dlp/quickstart_test.py
@@ -19,4 +19,5 @@ def test_quickstart(capsys):
     quickstart.quickstart()
 
     out, _ = capsys.readouterr()
-    assert 'US_MALE_NAME' in out
+    assert 'FIRST_NAME' in out
+    assert 'LAST_NAME' in out


### PR DESCRIPTION
Likelihood, in the findings protobuf, is stored as a number. This converts the likelihood score to the string representation, ie likely, very likely, unlikely... Tests have also been updated for new info types. 