### PR TITLE
[Storage] Define additional properties in create bucket snippet

### DIFF
--- a/storage/cloud-client/snippets.py
+++ b/storage/cloud-client/snippets.py
@@ -31,9 +31,11 @@ from google.cloud import storage
 def create_bucket(bucket_name):
     """Creates a new bucket."""
     storage_client = storage.Client()
-    bucket = storage_client.create_bucket(bucket_name)
-    print('Bucket {} created'.format(bucket.name))
-
+    bucket = storage_client.bucket(bucket_name)
+    bucket.location = 'ASIA'
+    bucket.storage_class = 'COLDLINE'
+    bucket.create()
+    print('Bucket {} created.'.format(bucket.name))
 
 def delete_bucket(bucket_name):
     """Deletes a bucket. The bucket must be empty."""

--- a/storage/cloud-client/snippets.py
+++ b/storage/cloud-client/snippets.py
@@ -37,6 +37,7 @@ def create_bucket(bucket_name):
     bucket.create()
     print('Bucket {} created.'.format(bucket.name))
 
+
 def delete_bucket(bucket_name):
     """Deletes a bucket. The bucket must be empty."""
     storage_client = storage.Client()


### PR DESCRIPTION
Users are confused by the `Client.create_bucket()` method as it doesn't support additional properties that would normally be used. This PR is to update the method to use `Bucket.create()` instead.