### PR TITLE
Bugfix for list-datasets

### DIFF
--- a/bigquery/cloud-client/snippets.py
+++ b/bigquery/cloud-client/snippets.py
@@ -186,7 +186,7 @@ if __name__ == '__main__':
         'list-datasets', help=list_datasets.__doc__)
 
     create_dataset_parser = subparsers.add_parser(
-        'list-datasets', help=list_datasets.__doc__)
+        'create_dataset', help=create_dataset.__doc__)
     create_dataset_parser.add_argument('dataset_id')
 
     list_tables_parser = subparsers.add_parser(


### PR DESCRIPTION
"python bigquery_setup.py --project 'qlouder-gcp-playground' list-datasets" resulted in:
usage: bigquery_setup.py list-datasets [-h] dataset_id
bigquery_setup.py list-datasets: error: too few arguments

There was a fault in the create_dataset_parser .