### PR TITLE
Fixes iot_list_registries closing region tag

### DIFF
--- a/iot/api-client/manager/manager.py
+++ b/iot/api-client/manager/manager.py
@@ -276,7 +276,7 @@ def list_registries(service_account_json, project_id, cloud_region):
                     registry.get('name')))
 
     return registries
-# [END iot_list_devices]
+# [END iot_list_registries]
 
 
 # [START iot_create_registry]


### PR DESCRIPTION
See the python snippet for https://cloud.google.com/iot/docs/samples/registry-management-samples#list_registries