### PR TITLE
Fix broken datastore test_cursor_paging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ junit.xml
 credentials.dat
 .nox
 .vscode/
+*sponge_log.xml

--- a/datastore/cloud-client/snippets_test.py
+++ b/datastore/cloud-client/snippets_test.py
@@ -147,7 +147,6 @@ class TestDatastoreSnippets:
             assert len(page_one) == 5
             assert len(page_two)
             assert cursor_one
-            assert cursor_two
 
     @eventually_consistent.mark
     def test_property_filter(self, client):


### PR DESCRIPTION
When there are only 6 entities being retrieved, and the page size is 5,
then the second page will not have a next cursor because all entities
have been retrieved.

Also, ignore *sponge_log.xml which are test log files.