### PR TITLE
Composer: add simple workflow example. Use 1.10beta instead of git.

### DIFF
--- a/composer/workflows/requirements.txt
+++ b/composer/workflows/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/apache/incubator-airflow.git#egg=project[gcp_api]
+https://dist.apache.org/repos/dist/dev/incubator/airflow/1.10.0beta1/apache-airflow-1.10.0b1+incubating.tar.gz#egg=apache-airflow[gcp_api]

--- a/composer/workflows/simple.py
+++ b/composer/workflows/simple.py
@@ -1,0 +1,58 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An example DAG demonstrating simple Apache Airflow operators."""
+
+# [START composer_simple]
+from __future__ import print_function
+
+import datetime
+
+from airflow import models
+from airflow.operators import bash_operator
+from airflow.operators import python_operator
+
+
+default_dag_args = {
+    # The start_date describes when a DAG is valid / can be run. Set this to a
+    # fixed point in time rather than dynamically, since it is evaluated every
+    # time a DAG is parsed. See:
+    # https://airflow.apache.org/faq.html#what-s-the-deal-with-start-date
+    'start_date': datetime.datetime(2018, 1, 1),
+}
+
+# Define a DAG (directed acyclic graph) of tasks.
+# Any task you create within the context manager is automatically added to the
+# DAG object.
+with models.DAG(
+        'simple_greeting',
+        default_args=default_dag_args) as dag:
+    def greeting():
+        print('Hello World!')
+
+    # An instance of an operator is called a task. In this case, the
+    # hello_python task calls the "greeting" Python function.
+    hello_python = python_operator.PythonOperator(
+        task_id='hello',
+        python_callable=greeting)
+
+    # Likewise, the goodbye_bash task calls a Bash script.
+    goodbye_bash = bash_operator.BashOperator(
+        task_id='bye',
+        bash_command='echo Goodbye.')
+
+    # Define the order in which the tasks complete by using the >> and <<
+    # operators. In this example, hello_python executes before goodbye_bash.
+    hello_python >> goodbye_bash
+# [END composer_simple]

--- a/composer/workflows/simple_test.py
+++ b/composer/workflows/simple_test.py
@@ -1,0 +1,23 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_dag_import():
+    """Test that the DAG file can be successfully imported.
+
+    This tests that the DAG can be parsed, but does not run it in an Airflow
+    environment. This is a recommended sanity check by the official Airflow
+    docs: https://airflow.incubator.apache.org/tutorial.html#testing
+    """
+    from . import simple # noqa


### PR DESCRIPTION
The `composer_simple` sample is intended to demonstrate the concepts of
constructing Apache Airflow DAGs rather than any specific set of
operators.

By using the 1.10beta instead of git for the dependency, we have a
stabler package than building on master. Also, this will be easier for
Travis to cache.

CC @wwlian (Adding this sample per your request in CL 194867947)