### PR TITLE
Remove  mysqlclient==1.3.12 as it is not mandatory

### DIFF
--- a/container_engine/django_tutorial/requirements.txt
+++ b/container_engine/django_tutorial/requirements.txt
@@ -1,5 +1,4 @@
 Django==2.0.3
-mysqlclient==1.3.12
 wheel==0.30.0
 gunicorn==19.7.1
 psycopg2==2.7.4


### PR DESCRIPTION
And it could make troubles. For example on my side I got a `OSError: mysql_config not found` error.