### PR TITLE
BigQuery: Moves BigQuery tutorial for Dataproc to python-docs-samples

### DIFF
--- a/bigquery/cloud-client/natality_tutorial.py
+++ b/bigquery/cloud-client/natality_tutorial.py
@@ -21,11 +21,9 @@ def run_natality_tutorial():
 
     In the code below, the following actions are taken:
     * A new dataset is created "natality_regression."
-    * A new table "regression_input" is created to hold the inputs for our
-        linear regression.
     * A query is run against the public dataset,
         bigquery-public-data.samples.natality, selecting only the data of
-        interest to the regression, the output of which is stored in the
+        interest to the regression, the output of which is stored in a new
         "regression_input" table.
     * The output table is moved over the wire to the user's default project via
         the built-in BigQuery Connector for Spark that bridges BigQuery and

--- a/bigquery/cloud-client/natality_tutorial.py
+++ b/bigquery/cloud-client/natality_tutorial.py
@@ -53,9 +53,6 @@ def run_natality_tutorial():
     # Set the destination table to the table reference created above.
     job_config.destination = table_ref
 
-    # BigQuery can auto-detect the schema based on the source table.
-    job_config.autodetect = True
-
     # Set up a query in Standard SQL, which is the default for the BigQuery
     # Python client library.
     # The query selects the fields of interest.

--- a/bigquery/cloud-client/natality_tutorial.py
+++ b/bigquery/cloud-client/natality_tutorial.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def run_natality_tutorial():
+    # [START bigquery_query_natality_tutorial]
+    """Create a Google BigQuery linear regression input table.
+
+    In the code below, the following actions are taken:
+    * A new dataset is created "natality_regression."
+    * A new table "regression_input" is created to hold the inputs for our
+        linear regression.
+    * A query is run against the public dataset,
+        bigquery-public-data.samples.natality, selecting only the data of
+        interest to the regression, the output of which is stored in the
+        "regression_input" table.
+    * The output table is moved over the wire to the user's default project via
+        the built-in BigQuery Connector for Spark that bridges BigQuery and
+        Cloud Dataproc.
+    """
+
+    from google.cloud import bigquery
+
+    # Create a new Google BigQuery client using Google Cloud Platform project
+    # defaults.
+    client = bigquery.Client()
+
+    # The name for the new dataset.
+    dataset_id = 'natality_regression'
+
+    # Prepare a reference to the new dataset.
+    dataset_ref = client.dataset(dataset_id)
+    dataset = bigquery.Dataset(dataset_ref)
+
+    # Create the new BigQuery dataset.
+    dataset = client.create_dataset(dataset)
+
+    # In the new BigQuery dataset, create a new table.
+    table_ref = dataset.table('regression_input')
+    # The table needs a schema before it can be created and accept data.
+    # Create an ordered list of the columns using SchemaField objects.
+    schema = [
+        bigquery.SchemaField('weight_pounds', 'float'),
+        bigquery.SchemaField('mother_age', 'integer'),
+        bigquery.SchemaField('father_age', 'integer'),
+        bigquery.SchemaField('gestation_weeks', 'integer'),
+        bigquery.SchemaField('weight_gain_pounds', 'integer'),
+        bigquery.SchemaField('apgar_5min', 'integer'),
+    ]
+
+    # Assign the schema to the table and create the table in BigQuery.
+    table = bigquery.Table(table_ref, schema=schema)
+    table = client.create_table(table)
+
+    # Set up a query in Standard SQL, which is the default for the BigQuery
+    # Python client library.
+    # The query selects the fields of interest.
+    query = """
+        SELECT weight_pounds, mother_age, father_age, gestation_weeks,
+        weight_gain_pounds, apgar_5min
+        FROM `bigquery-public-data.samples.natality`
+        WHERE weight_pounds is not null
+        and mother_age is not null and father_age is not null
+        and gestation_weeks is not null
+        and weight_gain_pounds is not null
+        and apgar_5min is not null
+    """
+    # Configure the query job.
+    job_config = bigquery.QueryJobConfig()
+    # Set the output table to the table created above.
+    dest_dataset_ref = client.dataset('natality_regression')
+    dest_table_ref = dest_dataset_ref.table('regression_input')
+    job_config.destination = dest_table_ref
+
+    # Run the query.
+    query_job = client.query(query, job_config=job_config)
+    query_job.result()  # Waits for the query to finish
+    # [END bigquery_query_natality_tutorial]
+
+
+if __name__ == '__main__':
+    run_natality_tutorial()

--- a/bigquery/cloud-client/natality_tutorial.py
+++ b/bigquery/cloud-client/natality_tutorial.py
@@ -38,52 +38,43 @@ def run_natality_tutorial():
     # defaults.
     client = bigquery.Client()
 
-    # The name for the new dataset.
-    dataset_id = 'natality_regression'
-
-    # Prepare a reference to the new dataset.
-    dataset_ref = client.dataset(dataset_id)
+    # Prepare a reference to a new dataset for storing the query results.
+    dataset_ref = client.dataset('natality_regression')
     dataset = bigquery.Dataset(dataset_ref)
 
     # Create the new BigQuery dataset.
     dataset = client.create_dataset(dataset)
 
-    # In the new BigQuery dataset, create a new table.
+    # In the new BigQuery dataset, create a reference to a new table for
+    # storing the query results.
     table_ref = dataset.table('regression_input')
-    # The table needs a schema before it can be created and accept data.
-    # Create an ordered list of the columns using SchemaField objects.
-    schema = [
-        bigquery.SchemaField('weight_pounds', 'float'),
-        bigquery.SchemaField('mother_age', 'integer'),
-        bigquery.SchemaField('father_age', 'integer'),
-        bigquery.SchemaField('gestation_weeks', 'integer'),
-        bigquery.SchemaField('weight_gain_pounds', 'integer'),
-        bigquery.SchemaField('apgar_5min', 'integer'),
-    ]
 
-    # Assign the schema to the table and create the table in BigQuery.
-    table = bigquery.Table(table_ref, schema=schema)
-    table = client.create_table(table)
+    # Configure the query job.
+    job_config = bigquery.QueryJobConfig()
+
+    # Set the destination table to the table reference created above.
+    job_config.destination = table_ref
+
+    # BigQuery can auto-detect the schema based on the source table.
+    job_config.autodetect = True
 
     # Set up a query in Standard SQL, which is the default for the BigQuery
     # Python client library.
     # The query selects the fields of interest.
     query = """
-        SELECT weight_pounds, mother_age, father_age, gestation_weeks,
-        weight_gain_pounds, apgar_5min
-        FROM `bigquery-public-data.samples.natality`
-        WHERE weight_pounds is not null
-        and mother_age is not null and father_age is not null
-        and gestation_weeks is not null
-        and weight_gain_pounds is not null
-        and apgar_5min is not null
+        SELECT
+            weight_pounds, mother_age, father_age, gestation_weeks,
+            weight_gain_pounds, apgar_5min
+        FROM
+            `bigquery-public-data.samples.natality`
+        WHERE
+            weight_pounds IS NOT NULL
+            AND mother_age IS NOT NULL
+            AND father_age IS NOT NULL
+            AND gestation_weeks IS NOT NULL
+            AND weight_gain_pounds IS NOT NULL
+            AND apgar_5min IS NOT NULL
     """
-    # Configure the query job.
-    job_config = bigquery.QueryJobConfig()
-    # Set the output table to the table created above.
-    dest_dataset_ref = client.dataset('natality_regression')
-    dest_table_ref = dest_dataset_ref.table('regression_input')
-    job_config.destination = dest_table_ref
 
     # Run the query.
     query_job = client.query(query, job_config=job_config)

--- a/bigquery/cloud-client/natality_tutorial_test.py
+++ b/bigquery/cloud-client/natality_tutorial_test.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud import bigquery
+from google.cloud import exceptions
+
+import natality_tutorial
+
+
+def dataset_exists(dataset, client):
+    try:
+        client.get_dataset(dataset)
+        return True
+    except exceptions.NotFound:
+        return False
+
+
+def test_natality_tutorial():
+    client = bigquery.Client()
+    dataset_ref = client.dataset('natality_regression')
+    assert not dataset_exists(dataset_ref, client)
+
+    natality_tutorial.run_natality_tutorial()
+
+    assert dataset_exists(dataset_ref, client)
+    client.delete_dataset(dataset_ref, delete_contents=True)

--- a/bigquery/cloud-client/natality_tutorial_test.py
+++ b/bigquery/cloud-client/natality_tutorial_test.py
@@ -34,4 +34,9 @@ def test_natality_tutorial():
     natality_tutorial.run_natality_tutorial()
 
     assert dataset_exists(dataset_ref, client)
+
+    table = client.get_table(
+        bigquery.Table(dataset_ref.table('regression_input')))
+    assert table.num_rows > 0
+
     client.delete_dataset(dataset_ref, delete_contents=True)


### PR DESCRIPTION
Adds BigQuery portion of [Dataproc tutorial](https://cloud.google.com/dataproc/docs/tutorials/bigquery-sparkml) to this repo so it can be regularly tested (previously hard coded in the docs).