### PR TITLE
Fixed Initialize Firebase section and add snippet

### DIFF
--- a/appengine/standard/firebase/firenotes/frontend/main.js
+++ b/appengine/standard/firebase/firenotes/frontend/main.js
@@ -19,7 +19,7 @@ $(function(){
   // backend's app.yaml file.
   var backendHostUrl = '<your-backend-url>';
 
-  // [START config]
+  // [START gae_firenotes_config]
   // Obtain the following from the "Add Firebase to your web app" dialogue
   // Initialize Firebase
   var config = {
@@ -30,7 +30,7 @@ $(function(){
     storageBucket: "<BUCKET>.appspot.com",
     messagingSenderId: "<MESSAGING_SENDER_ID>"
   };
-  // [END config]
+  // [END gae_firenotes_config]
   
   // This is passed into the backend to authenticate the user.
   var userIdToken = null;

--- a/appengine/standard/firebase/firenotes/frontend/main.js
+++ b/appengine/standard/firebase/firenotes/frontend/main.js
@@ -19,15 +19,19 @@ $(function(){
   // backend's app.yaml file.
   var backendHostUrl = '<your-backend-url>';
 
+  // [START config]
+  // Obtain the following from the "Add Firebase to your web app" dialogue
   // Initialize Firebase
-  // TODO: Replace with your project's customized code snippet
   var config = {
     apiKey: "<API_KEY>",
     authDomain: "<PROJECT_ID>.firebaseapp.com",
     databaseURL: "https://<DATABASE_NAME>.firebaseio.com",
+    projectId: "<PROJECT_ID>",
     storageBucket: "<BUCKET>.appspot.com",
+    messagingSenderId: "<MESSAGING_SENDER_ID>"
   };
-
+  // [END config]
+  
   // This is passed into the backend to authenticate the user.
   var userIdToken = null;
 


### PR DESCRIPTION
RE: https://cloud.google.com/appengine/docs/standard/python/authenticating-users-firebase-appengine#adding_the_firebase_authentication_user_interface
This fails because the projectId and messagingSenderId are missing. I have also added snippet anchors to include snippet in the doc.