### PR TITLE
Add DLP code samples for custom info types

### DIFF
--- a/appengine/standard/firebase/firenotes/frontend/main.js
+++ b/appengine/standard/firebase/firenotes/frontend/main.js
@@ -19,15 +19,19 @@ $(function(){
   // backend's app.yaml file.
   var backendHostUrl = '<your-backend-url>';
 
+  // [START gae_firenotes_config]
+  // Obtain the following from the "Add Firebase to your web app" dialogue
   // Initialize Firebase
-  // TODO: Replace with your project's customized code snippet
   var config = {
     apiKey: "<API_KEY>",
     authDomain: "<PROJECT_ID>.firebaseapp.com",
     databaseURL: "https://<DATABASE_NAME>.firebaseio.com",
+    projectId: "<PROJECT_ID>",
     storageBucket: "<BUCKET>.appspot.com",
+    messagingSenderId: "<MESSAGING_SENDER_ID>"
   };
-
+  // [END gae_firenotes_config]
+  
   // This is passed into the backend to authenticate the user.
   var userIdToken = null;
 

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -66,7 +66,7 @@ def inspect_string(project, content_string, info_types,
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regex}
-    } for i in enumerate(custom_regexes)]
+    } for i, custom_regex in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -154,7 +154,7 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regex}
-    } for i in enumerate(custom_regexes)]
+    } for i, custom_regex in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -267,7 +267,7 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regex}
-    } for i in enumerate(custom_regexes)]
+    } for i, custom_regex in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -413,7 +413,7 @@ def inspect_datastore(project, datastore_project, kind,
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regex}
-    } for i in enumerate(custom_regexes)]
+    } for i, custom_regex in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -564,7 +564,7 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regex}
-    } for i in enumerate(custom_regexes)]
+    } for i, custom_regex in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -58,15 +58,15 @@ def inspect_string(project, content_string, info_types,
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
+            'word_list': {'words': custom_dict.split(',')}
         }
-    } for i in range(len(custom_dictionaries))]
+    } for i, custom_dict in enumerate(custom_dictionaries)]
     if custom_regexes is None:
         custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
+        'regex': {'pattern': custom_regex}
+    } for i in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -146,15 +146,15 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
+            'word_list': {'words': custom_dict.split(',')}
         }
-    } for i in range(len(custom_dictionaries))]
+    } for i, custom_dict in enumerate(custom_dictionaries)]
     if custom_regexes is None:
         custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
+        'regex': {'pattern': custom_regex}
+    } for i in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -259,15 +259,15 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
+            'word_list': {'words': custom_dict.split(',')}
         }
-    } for i in range(len(custom_dictionaries))]
+    } for i, custom_dict in enumerate(custom_dictionaries)]
     if custom_regexes is None:
         custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
+        'regex': {'pattern': custom_regex}
+    } for i in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -405,15 +405,15 @@ def inspect_datastore(project, datastore_project, kind,
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
+            'word_list': {'words': custom_dict.split(',')}
         }
-    } for i in range(len(custom_dictionaries))]
+    } for i, custom_dict in enumerate(custom_dictionaries)]
     if custom_regexes is None:
         custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
+        'regex': {'pattern': custom_regex}
+    } for i in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
@@ -556,15 +556,15 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
+            'word_list': {'words': custom_dict.split(',')}
         }
-    } for i in range(len(custom_dictionaries))]
+    } for i, custom_dict in enumerate(custom_dictionaries)]
     if custom_regexes is None:
         custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
+        'regex': {'pattern': custom_regex}
+    } for i in enumerate(custom_regexes)]
     custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -675,7 +675,8 @@ if __name__ == '__main__':
     parser_string.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.',
+             ' to search for as custom info types. Each string is a comma '
+             'delimited list of words representing a distinct dictionary.',
         default=None)
     parser_string.add_argument(
         '--custom_regexes', action='append',
@@ -714,7 +715,8 @@ if __name__ == '__main__':
     parser_file.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.',
+             ' to search for as custom info types. Each string is a comma '
+             'delimited list of words representing a distinct dictionary.',
         default=None)
     parser_file.add_argument(
         '--custom_regexes', action='append',
@@ -772,7 +774,8 @@ if __name__ == '__main__':
     parser_gcs.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.',
+             ' to search for as custom info types. Each string is a comma '
+             'delimited list of words representing a distinct dictionary.',
         default=None)
     parser_gcs.add_argument(
         '--custom_regexes', action='append',
@@ -826,7 +829,8 @@ if __name__ == '__main__':
     parser_datastore.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.',
+             ' to search for as custom info types. Each string is a comma '
+             'delimited list of words representing a distinct dictionary.',
         default=None)
     parser_datastore.add_argument(
         '--custom_regexes', action='append',
@@ -886,7 +890,8 @@ if __name__ == '__main__':
     parser_bigquery.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.',
+             ' to search for as custom info types. Each string is a comma '
+             'delimited list of words representing a distinct dictionary.',
         default=None)
     parser_bigquery.add_argument(
         '--custom_regexes', action='append',

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -16,7 +16,6 @@
 local file or a file on Google Cloud Storage."""
 
 from __future__ import print_function
-from builtins import range
 
 import argparse
 import os

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -54,7 +54,7 @@ def inspect_string(project, content_string, info_types,
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
     custom_info_types = build_custom_info_types(custom_dictionaries,
-                                                custom_info_types)
+                                                custom_regexes)
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -53,8 +53,21 @@ def inspect_string(project, content_string, info_types,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    custom_info_types = build_custom_info_types(custom_dictionaries,
-                                                custom_info_types)
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -128,8 +141,21 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    custom_info_types = build_custom_info_types(custom_dictionaries,
-                                                custom_regexes)
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -228,8 +254,21 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    custom_info_types = build_custom_info_types(custom_dictionaries,
-                                                custom_regexes)
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -361,8 +400,21 @@ def inspect_datastore(project, datastore_project, kind,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    custom_info_types = build_custom_info_types(custom_dictionaries,
-                                                custom_regexes)
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -499,8 +551,21 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    custom_info_types = build_custom_info_types(custom_dictionaries,
-                                                custom_regexes)
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -584,24 +649,6 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
               'subscription provided is subscribed to the topic provided.')
 
 # [END dlp_inspect_bigquery]
-
-
-def build_custom_info_types(custom_dictionaries, custom_regexes):
-    if custom_dictionaries is None:
-        custom_dictionaries = []
-    dictionaries = [{
-        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
-        'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
-        }
-    } for i in range(len(custom_dictionaries))]
-    if custom_regexes is None:
-        custom_regexes = []
-    regexes = [{
-        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
-    return dictionaries + regexes
 
 
 if __name__ == '__main__':

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -53,21 +53,8 @@ def inspect_string(project, content_string, info_types,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    if custom_dictionaries is None:
-        custom_dictionaries = []
-    dictionaries = [{
-        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
-        'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
-        }
-    } for i in range(len(custom_dictionaries))]
-    if custom_regexes is None:
-        custom_regexes = []
-    regexes = [{
-        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
-    custom_info_types = dictionaries + regexes
+    custom_info_types = build_custom_info_types(custom_dictionaries,
+                                                custom_info_types)
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -141,21 +128,8 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    if custom_dictionaries is None:
-        custom_dictionaries = []
-    dictionaries = [{
-        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
-        'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
-        }
-    } for i in range(len(custom_dictionaries))]
-    if custom_regexes is None:
-        custom_regexes = []
-    regexes = [{
-        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
-    custom_info_types = dictionaries + regexes
+    custom_info_types = build_custom_info_types(custom_dictionaries,
+                                                custom_regexes)
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -254,21 +228,8 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    if custom_dictionaries is None:
-        custom_dictionaries = []
-    dictionaries = [{
-        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
-        'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
-        }
-    } for i in range(len(custom_dictionaries))]
-    if custom_regexes is None:
-        custom_regexes = []
-    regexes = [{
-        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
-    custom_info_types = dictionaries + regexes
+    custom_info_types = build_custom_info_types(custom_dictionaries,
+                                                custom_regexes)
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -400,21 +361,8 @@ def inspect_datastore(project, datastore_project, kind,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    if custom_dictionaries is None:
-        custom_dictionaries = []
-    dictionaries = [{
-        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
-        'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
-        }
-    } for i in range(len(custom_dictionaries))]
-    if custom_regexes is None:
-        custom_regexes = []
-    regexes = [{
-        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
-    custom_info_types = dictionaries + regexes
+    custom_info_types = build_custom_info_types(custom_dictionaries,
+                                                custom_regexes)
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -551,21 +499,8 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
 
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
-    if custom_dictionaries is None:
-        custom_dictionaries = []
-    dictionaries = [{
-        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
-        'dictionary': {
-            'word_list': {'words': custom_dictionaries[i].split(',')}
-        }
-    } for i in range(len(custom_dictionaries))]
-    if custom_regexes is None:
-        custom_regexes = []
-    regexes = [{
-        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
-        'regex': {'pattern': custom_regexes[i]}
-    } for i in range(len(custom_regexes))]
-    custom_info_types = dictionaries + regexes
+    custom_info_types = build_custom_info_types(custom_dictionaries,
+                                                custom_regexes)
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
@@ -649,6 +584,24 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
               'subscription provided is subscribed to the topic provided.')
 
 # [END dlp_inspect_bigquery]
+
+
+def build_custom_info_types(custom_dictionaries, custom_regexes):
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    return dictionaries + regexes
 
 
 if __name__ == '__main__':

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -16,6 +16,7 @@
 local file or a file on Google Cloud Storage."""
 
 from __future__ import print_function
+from builtins import range
 
 import argparse
 import os

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -54,7 +54,7 @@ def inspect_string(project, content_string, info_types,
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
     custom_info_types = build_custom_info_types(custom_dictionaries,
-                                                custom_regexes)
+                                                custom_info_types)
 
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -23,6 +23,7 @@ import os
 
 # [START dlp_inspect_string]
 def inspect_string(project, content_string, info_types,
+                   custom_dictionaries=None, custom_regexes=None,
                    min_likelihood=None, max_findings=None, include_quote=True):
     """Uses the Data Loss Prevention API to analyze strings for protected data.
     Args:
@@ -50,10 +51,29 @@ def inspect_string(project, content_string, info_types,
     # dictionaries (protos are also accepted).
     info_types = [{'name': info_type} for info_type in info_types]
 
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+      custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+      custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
+
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
     inspect_config = {
         'info_types': info_types,
+        'custom_info_types': custom_info_types,
         'min_likelihood': min_likelihood,
         'include_quote': include_quote,
         'limits': {'max_findings_per_request': max_findings},
@@ -85,6 +105,7 @@ def inspect_string(project, content_string, info_types,
 
 # [START dlp_inspect_file]
 def inspect_file(project, filename, info_types, min_likelihood=None,
+                 custom_dictionaries=None, custom_regexes=None,
                  max_findings=None, include_quote=True, mime_type=None):
     """Uses the Data Loss Prevention API to analyze a file for protected data.
     Args:
@@ -118,10 +139,29 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
         info_types = ['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS']
     info_types = [{'name': info_type} for info_type in info_types]
 
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+      custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+      custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
+
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
     inspect_config = {
         'info_types': info_types,
+        'custom_info_types': custom_info_types,
         'min_likelihood': min_likelihood,
         'limits': {'max_findings_per_request': max_findings},
     }
@@ -168,8 +208,9 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
 
 # [START dlp_inspect_gcs]
 def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
-                     info_types, min_likelihood=None, max_findings=None,
-                     timeout=300):
+                     info_types, custom_dictionaries=None,
+                     custom_regexes=None, min_likelihood=None,
+                     max_findings=None, timeout=300):
     """Uses the Data Loss Prevention API to analyze a file on GCS.
     Args:
         project: The Google Cloud project id to use as a parent resource.
@@ -211,10 +252,29 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
         info_types = ['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS']
     info_types = [{'name': info_type} for info_type in info_types]
 
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+      custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+      custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
+
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
     inspect_config = {
         'info_types': info_types,
+        'custom_info_types': custom_info_types,
         'min_likelihood': min_likelihood,
         'limits': {'max_findings_per_request': max_findings},
     }
@@ -293,8 +353,10 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
 
 # [START dlp_inspect_datastore]
 def inspect_datastore(project, datastore_project, kind,
-                      topic_id, subscription_id, info_types, namespace_id=None,
-                      min_likelihood=None, max_findings=None, timeout=300):
+                      topic_id, subscription_id, info_types,
+                      custom_dictionaries=None, custom_regexes=None,
+                      namespace_id=None, min_likelihood=None,
+                      max_findings=None, timeout=300):
     """Uses the Data Loss Prevention API to analyze Datastore data.
     Args:
         project: The Google Cloud project id to use as a parent resource.
@@ -336,10 +398,29 @@ def inspect_datastore(project, datastore_project, kind,
         info_types = ['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS']
     info_types = [{'name': info_type} for info_type in info_types]
 
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+      custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+      custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
+
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
     inspect_config = {
         'info_types': info_types,
+        'custom_info_types': custom_info_types,
         'min_likelihood': min_likelihood,
         'limits': {'max_findings_per_request': max_findings},
     }
@@ -424,6 +505,7 @@ def inspect_datastore(project, datastore_project, kind,
 # [START dlp_inspect_bigquery]
 def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
                      topic_id, subscription_id, info_types,
+                     custom_dictionaries=None, custom_regexes=None,
                      min_likelihood=None, max_findings=None, timeout=300):
     """Uses the Data Loss Prevention API to analyze BigQuery data.
     Args:
@@ -467,10 +549,29 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
         info_types = ['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS']
     info_types = [{'name': info_type} for info_type in info_types]
 
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+      custom_dictionaries = []
+    dictionaries = [{
+        'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
+        'dictionary': {
+            'word_list': {'words': custom_dictionaries[i].split(',')}
+        }
+    } for i in range(len(custom_dictionaries))]
+    if custom_regexes is None:
+      custom_regexes = []
+    regexes = [{
+        'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
+        'regex': {'pattern': custom_regexes[i]}
+    } for i in range(len(custom_regexes))]
+    custom_info_types = dictionaries + regexes
+
     # Construct the configuration dictionary. Keys which are None may
     # optionally be omitted entirely.
     inspect_config = {
         'info_types': info_types,
+        'custom_info_types': custom_info_types,
         'min_likelihood': min_likelihood,
         'limits': {'max_findings_per_request': max_findings},
     }
@@ -572,6 +673,16 @@ if __name__ == '__main__':
              'If unspecified, the three above examples will be used.',
         default=['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS'])
     parser_string.add_argument(
+        '--custom_dictionaries', action='append',
+        help='Strings representing comma-delimited lists of dictionary words'
+             ' to search for as custom info types.'
+        default=None)
+    parser_string.add_argument(
+        '--custom_regexes', action='append',
+        help='Strings representing regex patterns to search for as custom '
+             ' info types.'
+        default=None)
+    parser_string.add_argument(
         '--min_likelihood',
         choices=['LIKELIHOOD_UNSPECIFIED', 'VERY_UNLIKELY', 'UNLIKELY',
                  'POSSIBLE', 'LIKELY', 'VERY_LIKELY'],
@@ -600,6 +711,16 @@ if __name__ == '__main__':
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
              'If unspecified, the three above examples will be used.',
         default=['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS'])
+    parser_file.add_argument(
+        '--custom_dictionaries', action='append',
+        help='Strings representing comma-delimited lists of dictionary words'
+             ' to search for as custom info types.'
+        default=None)
+    parser_file.add_argument(
+        '--custom_regexes', action='append',
+        help='Strings representing regex patterns to search for as custom '
+             ' info types.'
+        default=None)
     parser_file.add_argument(
         '--min_likelihood',
         choices=['LIKELIHOOD_UNSPECIFIED', 'VERY_UNLIKELY', 'UNLIKELY',
@@ -649,6 +770,16 @@ if __name__ == '__main__':
              'If unspecified, the three above examples will be used.',
         default=['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS'])
     parser_gcs.add_argument(
+        '--custom_dictionaries', action='append',
+        help='Strings representing comma-delimited lists of dictionary words'
+             ' to search for as custom info types.'
+        default=None)
+    parser_gcs.add_argument(
+        '--custom_regexes', action='append',
+        help='Strings representing regex patterns to search for as custom '
+             ' info types.'
+        default=None)
+    parser_gcs.add_argument(
         '--min_likelihood',
         choices=['LIKELIHOOD_UNSPECIFIED', 'VERY_UNLIKELY', 'UNLIKELY',
                  'POSSIBLE', 'LIKELY', 'VERY_LIKELY'],
@@ -692,6 +823,16 @@ if __name__ == '__main__':
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
              'If unspecified, the three above examples will be used.',
         default=['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS'])
+    parser_datastore.add_argument(
+        '--custom_dictionaries', action='append',
+        help='Strings representing comma-delimited lists of dictionary words'
+             ' to search for as custom info types.'
+        default=None)
+    parser_datastore.add_argument(
+        '--custom_regexes', action='append',
+        help='Strings representing regex patterns to search for as custom '
+             ' info types.'
+        default=None)
     parser_datastore.add_argument(
         '--namespace_id',
         help='The Datastore namespace to use, if applicable.')
@@ -743,6 +884,16 @@ if __name__ == '__main__':
              'If unspecified, the three above examples will be used.',
         default=['FIRST_NAME', 'LAST_NAME', 'EMAIL_ADDRESS'])
     parser_bigquery.add_argument(
+        '--custom_dictionaries', action='append',
+        help='Strings representing comma-delimited lists of dictionary words'
+             ' to search for as custom info types.'
+        default=None)
+    parser_bigquery.add_argument(
+        '--custom_regexes', action='append',
+        help='Strings representing regex patterns to search for as custom '
+             ' info types.'
+        default=None)
+    parser_bigquery.add_argument(
         '--min_likelihood',
         choices=['LIKELIHOOD_UNSPECIFIED', 'VERY_UNLIKELY', 'UNLIKELY',
                  'POSSIBLE', 'LIKELY', 'VERY_LIKELY'],
@@ -762,12 +913,16 @@ if __name__ == '__main__':
     if args.content == 'string':
         inspect_string(
             args.project, args.item, args.info_types,
+            custom_dictionaries=args.custom_dictionaries,
+            custom_regexes=args.custom_regexes,
             min_likelihood=args.min_likelihood,
             max_findings=args.max_findings,
             include_quote=args.include_quote)
     elif args.content == 'file':
         inspect_file(
             args.project, args.filename, args.info_types,
+            custom_dictionaries=args.custom_dictionaries,
+            custom_regexes=args.custom_regexes,
             min_likelihood=args.min_likelihood,
             max_findings=args.max_findings,
             include_quote=args.include_quote,
@@ -777,6 +932,8 @@ if __name__ == '__main__':
             args.project, args.bucket, args.filename,
             args.topic_id, args.subscription_id,
             args.info_types,
+            custom_dictionaries=args.custom_dictionaries,
+            custom_regexes=args.custom_regexes,
             min_likelihood=args.min_likelihood,
             max_findings=args.max_findings,
             timeout=args.timeout)
@@ -785,6 +942,8 @@ if __name__ == '__main__':
             args.project, args.datastore_project, args.kind,
             args.topic_id, args.subscription_id,
             args.info_types,
+            custom_dictionaries=args.custom_dictionaries,
+            custom_regexes=args.custom_regexes,
             namespace_id=args.namespace_id,
             min_likelihood=args.min_likelihood,
             max_findings=args.max_findings,
@@ -794,6 +953,8 @@ if __name__ == '__main__':
             args.project, args.bigquery_project, args.dataset_id,
             args.table_id, args.topic_id, args.subscription_id,
             args.info_types,
+            custom_dictionaries=args.custom_dictionaries,
+            custom_regexes=args.custom_regexes,
             min_likelihood=args.min_likelihood,
             max_findings=args.max_findings,
             timeout=args.timeout)

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -54,7 +54,7 @@ def inspect_string(project, content_string, info_types,
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
     if custom_dictionaries is None:
-      custom_dictionaries = []
+        custom_dictionaries = []
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
@@ -62,7 +62,7 @@ def inspect_string(project, content_string, info_types,
         }
     } for i in range(len(custom_dictionaries))]
     if custom_regexes is None:
-      custom_regexes = []
+        custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regexes[i]}
@@ -142,7 +142,7 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
     if custom_dictionaries is None:
-      custom_dictionaries = []
+        custom_dictionaries = []
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
@@ -150,7 +150,7 @@ def inspect_file(project, filename, info_types, min_likelihood=None,
         }
     } for i in range(len(custom_dictionaries))]
     if custom_regexes is None:
-      custom_regexes = []
+        custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regexes[i]}
@@ -255,7 +255,7 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
     if custom_dictionaries is None:
-      custom_dictionaries = []
+        custom_dictionaries = []
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
@@ -263,7 +263,7 @@ def inspect_gcs_file(project, bucket, filename, topic_id, subscription_id,
         }
     } for i in range(len(custom_dictionaries))]
     if custom_regexes is None:
-      custom_regexes = []
+        custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regexes[i]}
@@ -401,7 +401,7 @@ def inspect_datastore(project, datastore_project, kind,
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
     if custom_dictionaries is None:
-      custom_dictionaries = []
+        custom_dictionaries = []
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
@@ -409,7 +409,7 @@ def inspect_datastore(project, datastore_project, kind,
         }
     } for i in range(len(custom_dictionaries))]
     if custom_regexes is None:
-      custom_regexes = []
+        custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regexes[i]}
@@ -552,7 +552,7 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
     # Prepare custom_info_types by parsing the dictionary word lists and
     # regex patterns.
     if custom_dictionaries is None:
-      custom_dictionaries = []
+        custom_dictionaries = []
     dictionaries = [{
         'info_type': {'name': 'CUSTOM_DICTIONARY_{}'.format(i)},
         'dictionary': {
@@ -560,7 +560,7 @@ def inspect_bigquery(project, bigquery_project, dataset_id, table_id,
         }
     } for i in range(len(custom_dictionaries))]
     if custom_regexes is None:
-      custom_regexes = []
+        custom_regexes = []
     regexes = [{
         'info_type': {'name': 'CUSTOM_REGEX_{}'.format(i)},
         'regex': {'pattern': custom_regexes[i]}

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -676,12 +676,12 @@ if __name__ == '__main__':
     parser_string.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.'
+             ' to search for as custom info types.',
         default=None)
     parser_string.add_argument(
         '--custom_regexes', action='append',
         help='Strings representing regex patterns to search for as custom '
-             ' info types.'
+             ' info types.',
         default=None)
     parser_string.add_argument(
         '--min_likelihood',
@@ -715,12 +715,12 @@ if __name__ == '__main__':
     parser_file.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.'
+             ' to search for as custom info types.',
         default=None)
     parser_file.add_argument(
         '--custom_regexes', action='append',
         help='Strings representing regex patterns to search for as custom '
-             ' info types.'
+             ' info types.',
         default=None)
     parser_file.add_argument(
         '--min_likelihood',
@@ -773,12 +773,12 @@ if __name__ == '__main__':
     parser_gcs.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.'
+             ' to search for as custom info types.',
         default=None)
     parser_gcs.add_argument(
         '--custom_regexes', action='append',
         help='Strings representing regex patterns to search for as custom '
-             ' info types.'
+             ' info types.',
         default=None)
     parser_gcs.add_argument(
         '--min_likelihood',
@@ -827,12 +827,12 @@ if __name__ == '__main__':
     parser_datastore.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.'
+             ' to search for as custom info types.',
         default=None)
     parser_datastore.add_argument(
         '--custom_regexes', action='append',
         help='Strings representing regex patterns to search for as custom '
-             ' info types.'
+             ' info types.',
         default=None)
     parser_datastore.add_argument(
         '--namespace_id',
@@ -887,12 +887,12 @@ if __name__ == '__main__':
     parser_bigquery.add_argument(
         '--custom_dictionaries', action='append',
         help='Strings representing comma-delimited lists of dictionary words'
-             ' to search for as custom info types.'
+             ' to search for as custom info types.',
         default=None)
     parser_bigquery.add_argument(
         '--custom_regexes', action='append',
         help='Strings representing regex patterns to search for as custom '
-             ' info types.'
+             ' info types.',
         default=None)
     parser_bigquery.add_argument(
         '--min_likelihood',

--- a/dlp/inspect_content_test.py
+++ b/dlp/inspect_content_test.py
@@ -169,6 +169,7 @@ def test_inspect_string(capsys):
     assert 'Info type: FIRST_NAME' in out
     assert 'Info type: EMAIL_ADDRESS' in out
 
+
 def test_inspect_string_with_custom_info_types(capsys):
     test_string = 'My name is Gary Smith and my email is gary@example.com'
     dictionaries = ['Gary Smith']
@@ -211,6 +212,7 @@ def test_inspect_file(capsys):
 
     out, _ = capsys.readouterr()
     assert 'Info type: EMAIL_ADDRESS' in out
+
 
 def test_inspect_file_with_custom_info_types(capsys):
     test_filepath = os.path.join(RESOURCE_DIRECTORY, 'test.txt')
@@ -269,6 +271,7 @@ def test_inspect_gcs_file(bucket, topic_id, subscription_id, capsys):
     out, _ = capsys.readouterr()
     assert 'Info type: EMAIL_ADDRESS' in out
 
+
 @flaky
 def test_inspect_gcs_file_with_custom_info_types(bucket, topic_id, subscription_id, capsys):
     dictionaries = ['gary@somedomain.com']
@@ -287,6 +290,7 @@ def test_inspect_gcs_file_with_custom_info_types(bucket, topic_id, subscription_
     out, _ = capsys.readouterr()
     assert 'Info type: CUSTOM_DICTIONARY_0' in out
     assert 'Info type: CUSTOM_REGEX_0' in out
+
 
 @flaky
 def test_inspect_gcs_file_no_results(

--- a/dlp/inspect_content_test.py
+++ b/dlp/inspect_content_test.py
@@ -273,7 +273,8 @@ def test_inspect_gcs_file(bucket, topic_id, subscription_id, capsys):
 
 
 @flaky
-def test_inspect_gcs_file_with_custom_info_types(bucket, topic_id, subscription_id, capsys):
+def test_inspect_gcs_file_with_custom_info_types(bucket, topic_id,
+                                                 subscription_id, capsys):
     dictionaries = ['gary@somedomain.com']
     regexes = ['\\(\\d{3}\\) \\d{3}-\\d{4}']
 

--- a/dlp/inspect_content_test.py
+++ b/dlp/inspect_content_test.py
@@ -169,6 +169,23 @@ def test_inspect_string(capsys):
     assert 'Info type: FIRST_NAME' in out
     assert 'Info type: EMAIL_ADDRESS' in out
 
+def test_inspect_string_with_custom_info_types(capsys):
+    test_string = 'My name is Gary Smith and my email is gary@example.com'
+    dictionaries = ['Gary Smith']
+    regexes = ['\\w+@\\w+.com']
+
+    inspect_content.inspect_string(
+        GCLOUD_PROJECT,
+        test_string,
+        [],
+        custom_dictionaries=dictionaries,
+        custom_regexes=regexes,
+        include_quote=True)
+
+    out, _ = capsys.readouterr()
+    assert 'Info type: CUSTOM_DICTIONARY_0' in out
+    assert 'Info type: CUSTOM_REGEX_0' in out
+
 
 def test_inspect_string_no_results(capsys):
     test_string = 'Nothing to see here'
@@ -194,6 +211,23 @@ def test_inspect_file(capsys):
 
     out, _ = capsys.readouterr()
     assert 'Info type: EMAIL_ADDRESS' in out
+
+def test_inspect_file_with_custom_info_types(capsys):
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, 'test.txt')
+    dictionaries = ['gary@somedomain.com']
+    regexes = ['\\(\\d{3}\\) \\d{3}-\\d{4}']
+
+    inspect_content.inspect_file(
+        GCLOUD_PROJECT,
+        test_filepath,
+        [],
+        custom_dictionaries=dictionaries,
+        custom_regexes=regexes,
+        include_quote=True)
+
+    out, _ = capsys.readouterr()
+    assert 'Info type: CUSTOM_DICTIONARY_0' in out
+    assert 'Info type: CUSTOM_REGEX_0' in out
 
 
 def test_inspect_file_no_results(capsys):
@@ -235,6 +269,24 @@ def test_inspect_gcs_file(bucket, topic_id, subscription_id, capsys):
     out, _ = capsys.readouterr()
     assert 'Info type: EMAIL_ADDRESS' in out
 
+@flaky
+def test_inspect_gcs_file_with_custom_info_types(bucket, topic_id, subscription_id, capsys):
+    dictionaries = ['gary@somedomain.com']
+    regexes = ['\\(\\d{3}\\) \\d{3}-\\d{4}']
+
+    inspect_content.inspect_gcs_file(
+        GCLOUD_PROJECT,
+        bucket.name,
+        'test.txt',
+        topic_id,
+        subscription_id,
+        [],
+        custom_dictionaries=dictionaries,
+        custom_regexes=regexes)
+
+    out, _ = capsys.readouterr()
+    assert 'Info type: CUSTOM_DICTIONARY_0' in out
+    assert 'Info type: CUSTOM_REGEX_0' in out
 
 @flaky
 def test_inspect_gcs_file_no_results(

--- a/monitoring/api/v3/uptime-check-client/snippets.py
+++ b/monitoring/api/v3/uptime-check-client/snippets.py
@@ -42,6 +42,22 @@ def create_uptime_check_config(project_name, host_name=None,
 # [END monitoring_uptime_check_create]
 
 
+# [START monitoring_uptime_check_update]
+def update_uptime_check_config(config_name, new_display_name=None,
+                               new_http_check_path=None):
+    client = monitoring_v3.UptimeCheckServiceClient()
+    config = client.get_uptime_check_config(config_name)
+    field_mask = monitoring_v3.types.FieldMask()
+    if new_display_name:
+        field_mask.paths.append('display_name')
+        config.display_name = new_display_name
+    if new_http_check_path:
+        field_mask.paths.append('http_check.path')
+        config.http_check.path = new_http_check_path
+    client.update_uptime_check_config(config, field_mask)
+# [END monitoring_uptime_check_update]
+
+
 # [START monitoring_uptime_check_list_configs]
 def list_uptime_check_configs(project_name):
     client = monitoring_v3.UptimeCheckServiceClient()
@@ -153,6 +169,23 @@ if __name__ == '__main__':
         required=True,
     )
 
+    update_uptime_check_config_parser = subparsers.add_parser(
+        'update-uptime-check-config',
+        help=update_uptime_check_config.__doc__
+    )
+    update_uptime_check_config_parser.add_argument(
+        '-m', '--name',
+        required=True,
+    )
+    update_uptime_check_config_parser.add_argument(
+        '-d', '--display_name',
+        required=False,
+    )
+    update_uptime_check_config_parser.add_argument(
+        '-p', '--uptime_check_path',
+        required=False,
+    )
+
     args = parser.parse_args()
 
     if args.command == 'list-uptime-check-configs':
@@ -170,3 +203,11 @@ if __name__ == '__main__':
 
     elif args.command == 'delete-uptime-check-config':
         delete_uptime_check_config(args.name)
+
+    elif args.command == 'update-uptime-check-config':
+        if not args.display_name and not args.uptime_check_path:
+            print('Nothing to update.  Pass --display_name or '
+                  '--uptime_check_path.')
+        else:
+            update_uptime_check_config(args.name, args.display_name,
+                                       args.uptime_check_path)

--- a/monitoring/api/v3/uptime-check-client/snippets_test.py
+++ b/monitoring/api/v3/uptime-check-client/snippets_test.py
@@ -58,6 +58,20 @@ def test_create_and_delete(capsys):
         pass
 
 
+def test_update_uptime_config(capsys):
+    # create and delete happen in uptime fixture.
+    new_display_name = random_name(10)
+    new_uptime_check_path = '/' + random_name(10)
+    with UptimeFixture() as fixture:
+        snippets.update_uptime_check_config(
+            fixture.config.name, new_display_name, new_uptime_check_path)
+        out, _ = capsys.readouterr()
+        snippets.get_uptime_check_config(fixture.config.name)
+        out, _ = capsys.readouterr()
+        assert new_display_name in out
+        assert new_uptime_check_path in out
+
+
 def test_get_uptime_check_config(capsys, uptime):
     snippets.get_uptime_check_config(uptime.config.name)
     out, _ = capsys.readouterr()


### PR DESCRIPTION
The DLP team is in the process of expanding code samples to include features that we have launched since the initial samples were written.

In this pull request, I updated inspect_content.py to include dictionary and regex based custom info types, and added some tests in inspect_content_test.java. Also updated deid.py and deid_test.py to fix issues with the tests since launching the V2 API.