### PR TITLE
Delete unused Datastore region tags / samples.

### DIFF
--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -467,25 +467,9 @@ def keys_only_query(client):
     query.keys_only()
     # [END datastore_keys_only_query]
 
-    # [START datastore_run_keys_only_query]
     keys = list([entity.key for entity in query.fetch(limit=10)])
-    # [END datastore_run_keys_only_query]
 
     return keys
-
-
-def distinct_query(client):
-    # Create the entity that we're going to query.
-    upsert(client)
-
-    # [START datastore_distinct_query]
-    query = client.query(kind='Task')
-    query.distinct_on = ['category', 'priority']
-    query.order = ['category', 'priority']
-    query.projection = ['category', 'priority']
-    # [END datastore_distinct_query]
-
-    return list(query.fetch())
 
 
 def distinct_on_query(client):

--- a/datastore/cloud-client/snippets_test.py
+++ b/datastore/cloud-client/snippets_test.py
@@ -192,12 +192,6 @@ class TestDatastoreSnippets:
         assert keys
 
     @eventually_consistent.mark
-    def test_distinct_query(self, client):
-        tasks = snippets.distinct_query(client)
-        client.entities_to_delete.extend(tasks)
-        assert tasks
-
-    @eventually_consistent.mark
     def test_distinct_on_query(self, client):
         tasks = snippets.distinct_on_query(client)
         client.entities_to_delete.extend(tasks)

--- a/datastore/cloud-client/tasks.py
+++ b/datastore/cloud-client/tasks.py
@@ -74,7 +74,6 @@ def delete_task(client, task_id):
 # [END datastore_delete_entity]
 
 
-# [START datastore_format_results]
 def format_tasks(tasks):
     lines = []
     for task in tasks:
@@ -87,7 +86,6 @@ def format_tasks(tasks):
             task.key.id, task['description'], status))
 
     return '\n'.join(lines)
-# [END datastore_format_results]
 
 
 def new_command(client, args):


### PR DESCRIPTION
These samples/region tags aren't used on cloud.google.com, so I'm deleting them.

Related:

- googleapis/nodejs-datastore#110
- GoogleCloudPlatform/java-docs-samples#1138
- GoogleCloudPlatform/php-docs-samples#631
- GoogleCloudPlatform/dotnet-docs-samples#569
- GoogleCloudPlatform/ruby-docs-samples#292
- GoogleCloudPlatform/golang-samples#516