### PR TITLE
Make Django 2.0 docker image build

### DIFF
--- a/container_engine/django_tutorial/Dockerfile
+++ b/container_engine/django_tutorial/Dockerfile
@@ -20,8 +20,7 @@
 FROM gcr.io/google_appengine/python
 
 # Create a virtualenv for the application dependencies.
-# # If you want to use Python 3, add the -p python3.4 flag.
-RUN virtualenv /env
+RUN virtualenv -p python3 /env
 ENV PATH /env/bin:$PATH
 
 ADD requirements.txt /app/requirements.txt


### PR DESCRIPTION
Django 2.0 requires python3, update dockerfile to use python3.

related https://github.com/GoogleCloudPlatform/python-docs-samples/pull/1503