### PR TITLE
BigQuery: Adds authorized view tutorial

### DIFF
--- a/bigquery/cloud-client/authorized_view_tutorial.py
+++ b/bigquery/cloud-client/authorized_view_tutorial.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2018 Google Inc. All Rights Reserved.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigquery/cloud-client/authorized_view_tutorial.py
+++ b/bigquery/cloud-client/authorized_view_tutorial.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def run_authorized_view_tutorial():
+    # Note to user: This is a group email for testing purposes. Replace with
+    # your own group email address when running this code.
+    analyst_group_email = 'example-analyst-group@google.com'
+
+    # [START bigquery_authorized_view_tutorial]
+    # Create a source dataset
+    # [START bigquery_avt_create_source_dataset]
+    from google.cloud import bigquery
+
+    client = bigquery.Client()
+    source_dataset_id = 'github_source_data'
+
+    source_dataset = bigquery.Dataset(client.dataset(source_dataset_id))
+    # Specify the geographic location where the dataset should reside.
+    source_dataset.location = 'US'
+    source_dataset = client.create_dataset(source_dataset)  # API request
+    # [END bigquery_avt_create_source_dataset]
+
+    # Populate a source table
+    # [START bigquery_avt_create_source_table]
+    source_table_id = 'github_contributors'
+    job_config = bigquery.QueryJobConfig()
+    job_config.destination = source_dataset.table(source_table_id)
+    sql = """
+        SELECT commit, author, committer, repo_name
+        FROM `bigquery-public-data.github_repos.commits`
+        LIMIT 1000
+    """
+    query_job = client.query(
+        sql,
+        # Location must match that of the dataset(s) referenced in the query
+        # and of the destination table.
+        location='US',
+        job_config=job_config)  # API request - starts the query
+
+    query_job.result()  # Waits for the query to finish
+    # [END bigquery_avt_create_source_table]
+
+    # Create a separate dataset to store your view
+    # [START bigquery_avt_create_shared_dataset]
+    shared_dataset_id = 'shared_views'
+    shared_dataset = bigquery.Dataset(client.dataset(shared_dataset_id))
+    shared_dataset.location = 'US'
+    shared_dataset = client.create_dataset(shared_dataset)  # API request
+    # [END bigquery_avt_create_shared_dataset]
+
+    # Create the view in the new dataset
+    # [START bigquery_avt_create_view]
+    shared_view_id = 'github_analyst_view'
+    view = bigquery.Table(shared_dataset.table(shared_view_id))
+    sql_template = """
+        SELECT
+            commit, author.name as author,
+            committer.name as committer, repo_name
+        FROM
+            `{}.{}.{}`
+    """
+    view.view_query = sql_template.format(
+        client.project, source_dataset_id, source_table_id)
+    view = client.create_table(view)  # API request
+    # [END bigquery_avt_create_view]
+
+    # Assign access controls to the dataset containing the view
+    # [START bigquery_avt_shared_dataset_access]
+    # analyst_group_email = 'data_analysts@example.com'
+    access_entries = shared_dataset.access_entries
+    access_entries.append(
+        bigquery.AccessEntry('READER', 'groupByEmail', analyst_group_email)
+    )
+    shared_dataset.access_entries = access_entries
+    shared_dataset = client.update_dataset(
+        shared_dataset, ['access_entries'])  # API request
+    # [END bigquery_avt_shared_dataset_access]
+
+    # Authorize the view to access the source dataset
+    # [START bigquery_avt_source_dataset_access]
+    access_entries = source_dataset.access_entries
+    access_entries.append(
+        bigquery.AccessEntry(None, 'view', view.reference.to_api_repr())
+    )
+    source_dataset.access_entries = access_entries
+    source_dataset = client.update_dataset(
+        source_dataset, ['access_entries'])  # API request
+    # [START bigquery_avt_source_dataset_access]
+    # [END bigquery_authorized_view_tutorial]
+    return (source_dataset, shared_dataset)
+
+
+if __name__ == '__main__':
+    run_authorized_view_tutorial()

--- a/bigquery/cloud-client/authorized_view_tutorial_test.py
+++ b/bigquery/cloud-client/authorized_view_tutorial_test.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google Inc. All Rights Reserved.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bigquery/cloud-client/authorized_view_tutorial_test.py
+++ b/bigquery/cloud-client/authorized_view_tutorial_test.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from google.cloud import bigquery
+
+import authorized_view_tutorial
+
+
+@pytest.fixture(scope='module')
+def client():
+    return bigquery.Client()
+
+
+@pytest.fixture
+def to_delete(client):
+    doomed = []
+    yield doomed
+    for item in doomed:
+        if isinstance(item, (bigquery.Dataset, bigquery.DatasetReference)):
+            client.delete_dataset(item, delete_contents=True)
+        elif isinstance(item, (bigquery.Table, bigquery.TableReference)):
+            client.delete_table(item)
+        else:
+            item.delete()
+
+
+def test_authorized_view_tutorial(client, to_delete):
+    source_dataset, shared_dataset = (
+        authorized_view_tutorial.run_authorized_view_tutorial())
+    to_delete.extend([source_dataset, shared_dataset])
+
+    analyst_email = 'example-analyst-group@google.com'
+    analyst_entries = [entry for entry in shared_dataset.access_entries
+                       if entry.entity_id == analyst_email]
+    assert len(analyst_entries) == 1
+    assert analyst_entries[0].role == 'READER'
+
+    authorized_view_entries = [entry for entry in source_dataset.access_entries
+                               if entry.entity_type == 'view']
+    expected_view_ref = {
+        'projectId': client.project,
+        'datasetId': 'shared_views',
+        'tableId': 'github_analyst_view',
+    }
+    assert len(authorized_view_entries) == 1
+    assert authorized_view_entries[0].entity_id == expected_view_ref

--- a/bigquery/cloud-client/authorized_view_tutorial_test.py
+++ b/bigquery/cloud-client/authorized_view_tutorial_test.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 from google.cloud import bigquery
+import pytest
 
 import authorized_view_tutorial
 

--- a/bigquery/cloud-client/requirements.txt
+++ b/bigquery/cloud-client/requirements.txt
@@ -1,3 +1,3 @@
-google-cloud-bigquery==0.31.0
+google-cloud-bigquery==1.3.0
 google-auth-oauthlib==0.2.0
 pytz==2018.3


### PR DESCRIPTION
Python version of [authorized view tutorial](https://cloud.google.com/bigquery/docs/share-access-views)

I'm open to ideas on phrasing region tags. My intent was to have sections to match up with the tutorial, but also have a region tag that encompassed the whole thing so I could show it at the end of the tutorial.