### PR TITLE
Change Endpoints Frameworks samples to import from endpoints

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/main.py
+++ b/appengine/standard/endpoints-frameworks-v2/echo/main.py
@@ -17,9 +17,9 @@ Endpoints."""
 
 # [START imports]
 import endpoints
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
 # [END imports]
 
 

--- a/appengine/standard/endpoints-frameworks-v2/echo/main_test.py
+++ b/appengine/standard/endpoints-frameworks-v2/echo/main_test.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import endpoints
+from endpoints import message_types
 import mock
-from protorpc import message_types
 import pytest
 
 import main

--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
@@ -1,2 +1,2 @@
-google-endpoints==3.0.0
-google-endpoints-api-management==1.5.1
+google-endpoints==4.4.0
+google-endpoints-api-management==1.8.0

--- a/appengine/standard/endpoints-frameworks-v2/iata/main.py
+++ b/appengine/standard/endpoints-frameworks-v2/iata/main.py
@@ -17,9 +17,9 @@ Google Cloud Endpoints Frameworks for Python."""
 
 # [START imports]
 import endpoints
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
 
 from data import AIRPORTS
 # [END imports]

--- a/appengine/standard/endpoints-frameworks-v2/iata/requirements.txt
+++ b/appengine/standard/endpoints-frameworks-v2/iata/requirements.txt
@@ -1,2 +1,2 @@
-google-endpoints==3.0.0
-google-endpoints-api-management==1.5.1
+google-endpoints==4.4.0
+google-endpoints-api-management==1.8.0

--- a/appengine/standard/endpoints-frameworks-v2/quickstart/main.py
+++ b/appengine/standard/endpoints-frameworks-v2/quickstart/main.py
@@ -17,9 +17,9 @@ Endpoints."""
 
 # [START imports]
 import endpoints
-from protorpc import message_types
-from protorpc import messages
-from protorpc import remote
+from endpoints import message_types
+from endpoints import messages
+from endpoints import remote
 # [END imports]
 
 

--- a/appengine/standard/endpoints-frameworks-v2/quickstart/main_test.py
+++ b/appengine/standard/endpoints-frameworks-v2/quickstart/main_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from endpoints import message_types
 import mock
-from protorpc import message_types
 
 import main
 


### PR DESCRIPTION
Instead of importing from `protorpc`, import from `endpoints`.

Additionally, I updated the requirements.txt files because dpebot stopped doing it for some reason.