### PR TITLE
Downgrades Django to 1.11

### DIFF
--- a/appengine/flexible/django_cloudsql/requirements.txt
+++ b/appengine/flexible/django_cloudsql/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.13
+Django<=1.11.13
 wheel==0.31.0
 gunicorn==19.7.1
 psycopg2==2.7.4

--- a/appengine/flexible/django_cloudsql/requirements.txt
+++ b/appengine/flexible/django_cloudsql/requirements.txt
@@ -1,5 +1,4 @@
-Django==2.0.3
-mysqlclient==1.3.12
+Django==1.11.13
 wheel==0.31.0
 gunicorn==19.7.1
 psycopg2==2.7.4


### PR DESCRIPTION
Downgrades Django to 1.11 to close #1451 

Removes unnecessary mysqlclient (tutorial uses postgresql)
