### PR TITLE
Functions: Use the documented way to fetch current GCP project ID.

### DIFF
--- a/functions/helloworld/sample_pubsub_test_system.py
+++ b/functions/helloworld/sample_pubsub_test_system.py
@@ -22,7 +22,7 @@ import uuid
 from google.cloud import pubsub_v1
 import pytest
 
-PROJECT = getenv('GCLOUD_PROJECT')
+PROJECT = getenv('GCP_PROJECT')
 TOPIC = getenv('TOPIC')
 
 assert PROJECT is not None

--- a/functions/helloworld/sample_storage_test_system.py
+++ b/functions/helloworld/sample_storage_test_system.py
@@ -22,7 +22,7 @@ import uuid
 from google.cloud import storage
 import pytest
 
-PROJECT = getenv('GCLOUD_PROJECT')
+PROJECT = getenv('GCP_PROJECT')
 BUCKET = getenv('BUCKET')
 
 assert PROJECT is not None


### PR DESCRIPTION
The document at https://cloud.google.com/functions/docs/env-var suggests using `env['GCP_PROJECT']` for current project ID, as `env['GCLOUD_PROJECT']` is deprecated/legacy.