### PR TITLE
Changed region tags in sample

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/main.py
+++ b/appengine/standard/endpoints-frameworks-v2/echo/main.py
@@ -39,10 +39,11 @@ ECHO_RESOURCE = endpoints.ResourceContainer(
 # [END messages]
 
 
-# [START echo_api]
+# [START echo_api_class]
 @endpoints.api(name='echo', version='v1')
 class EchoApi(remote.Service):
 
+    # [START echo_api_method]
     @endpoints.method(
         # This method takes a ResourceContainer defined above.
         ECHO_RESOURCE,
@@ -54,6 +55,7 @@ class EchoApi(remote.Service):
     def echo(self, request):
         output_content = ' '.join([request.content] * request.n)
         return EchoResponse(content=output_content)
+    # [END echo_api_method]
 
     @endpoints.method(
         # This method takes a ResourceContainer defined above.
@@ -98,7 +100,7 @@ class EchoApi(remote.Service):
         if not user:
             raise endpoints.UnauthorizedException
         return EchoResponse(content=user.email())
-# [END echo_api]
+# [END echo_api_class]
 
 
 # [START api_server]


### PR DESCRIPTION
Currently none of the Endpoints Frameworks docs are using the "echo_api" region tag in this sample. I would like to show just a small snippet of code, so I added the "echo_api_method" region tag. In case we want to show the entire class in the docs, I've renamed the "echo_api" region tag to "echo_api_class".