### PR TITLE
Remove unused region tag

### DIFF
--- a/codelabs/flex_and_vision/main.py
+++ b/codelabs/flex_and_vision/main.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START app]
 from datetime import datetime
 import logging
 import os
@@ -127,4 +126,3 @@ if __name__ == '__main__':
     # This is used when running locally. Gunicorn is used to run the
     # application on Google App Engine. See entrypoint in app.yaml.
     app.run(host='127.0.0.1', port=8080, debug=True)
-# [END app]


### PR DESCRIPTION
I do not believe this region tag is used in the repo or on cloud.google.com, but let me know if I am missing something. I am removing the unused region tag to clean up our sample tracking, which is done by region tag.