### PR TITLE
Use logging on the PythonOperator in simple.py

### DIFF
--- a/composer/workflows/simple.py
+++ b/composer/workflows/simple.py
@@ -47,7 +47,8 @@ with models.DAG(
     # [END composer_simple_define_dag]
     # [START composer_simple_operators]
     def greeting():
-        print('Hello World!')
+        import logging
+        logging.info('Hello World!')
 
     # An instance of an operator is called a task. In this case, the
     # hello_python task calls the "greeting" Python function.


### PR DESCRIPTION
This allows Airflow to surface the 'Hello World!' output, as PythonOperator does not include STDOUT in its logs.

[Fix #1662]