### PR TITLE
Remove ipython Python 2 modifier from requirements.txt

### DIFF
--- a/bigquery/cloud-client/requirements.txt
+++ b/bigquery/cloud-client/requirements.txt
@@ -1,6 +1,5 @@
 google-cloud-bigquery[pandas]==1.3.0
 google-auth-oauthlib==0.2.0
-ipython==5.5; python_version < "3"
-ipython; python_version > "3"
+ipython
 matplotlib
 pytz==2018.3


### PR DESCRIPTION
If ipython has tagged their packages correctly, then the modifier is not necessary. Sending a PR to check. Bug 113341391.