### PR TITLE
Fixed return object from `subscriber.subscribe()`

### DIFF
--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -255,13 +255,13 @@ def listen_for_errors(project, subscription_name):
         print('Received message: {}'.format(message))
         message.ack()
 
-    subscription = subscriber.subscribe(subscription_path, callback=callback)
+    future = subscriber.subscribe(subscription_path, callback=callback)
 
     # Blocks the thread while messages are coming in through the stream. Any
     # exceptions that crop up on the thread will be set on the future.
     try:
         # When timeout is unspecified, the result method waits indefinitely.
-        subscription.future.result(timeout=30)
+        future.result(timeout=30)
     except Exception as e:
         print(
             'Listening for messages on {} threw an Exception: {}.'.format(


### PR DESCRIPTION
Our January [update](https://github.com/GoogleCloudPlatform/python-docs-samples/commit/1bfa44503843ab921c5c2bd7f552d784c5bfee3e#diff-7ff914278985719ef067729ad18ee87c) to this line of code seems to have missed this. 