### PR TITLE
Test Composer samples on Python 3

### DIFF
--- a/.kokoro/presubmit_tests_composer.cfg
+++ b/.kokoro/presubmit_tests_composer.cfg
@@ -11,5 +11,13 @@ env_vars: {
 
 env_vars: {
     key: "NOX_SESSION"
-    value: "composer and py27 and not appengine"
+    value: "composer and py36 and not appengine"
+}
+
+# Explicitly allow GPL dependencies to let the apache-airflow package
+# installation continue. See:
+# https://github.com/apache/incubator-airflow/pull/3660
+env_vars: {
+    key: "AIRFLOW_GPL_UNIDECODE"
+    value: "yes"
 }

--- a/.kokoro/presubmit_tests_composer.cfg
+++ b/.kokoro/presubmit_tests_composer.cfg
@@ -14,10 +14,10 @@ env_vars: {
     value: "composer and py36 and not appengine"
 }
 
-# Explicitly allow GPL dependencies to let the apache-airflow package
+# Explicitly use choose unicode dependency to let the apache-airflow package
 # installation continue. See:
 # https://github.com/apache/incubator-airflow/pull/3660
 env_vars: {
-    key: "AIRFLOW_GPL_UNIDECODE"
+    key: "SLUGIFY_USES_TEXT_UNIDECODE"
     value: "yes"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ cache:
   - "$HOME/.cache"
 env:
   global:
+    # Explicitly use choose unicode dependency to let the apache-airflow
+    # package installation continue. See:
+    # https://github.com/apache/incubator-airflow/pull/3660
+    - SLUGIFY_USES_TEXT_UNIDECODE=yes
     secure: fsBH64/WqTe7lRcn4awZU7q6+euS/LHgMq2Ee2ubaoxUei2GbK5jBgnGHxOKVL5sZ4KNfTc7d6NR5BB1ZouYr2v4q1ip7Il9kFG4g5qV4cIXzHusXkrjvIzQLupNpcD9JJZr1fmYh4AqXRs2kP/nZqb7xB6Jm/O+h+aeC1bhhBg=
 addons:
   apt:

--- a/composer/workflows/use_local_deps_test.py
+++ b/composer/workflows/use_local_deps_test.py
@@ -12,7 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 0), reason="requires Python 2")
 def test_dag_import():
     """Test that the DAG file can be successfully imported.
 

--- a/composer/workflows/use_local_deps_test.py
+++ b/composer/workflows/use_local_deps_test.py
@@ -12,13 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os.path
 import sys
 
 import pytest
 
 
-@pytest.mark.skipif(
-    sys.version_info >= (3, 0), reason="requires Python 2")
+@pytest.fixture(scope='module', autouse=True)
+def local_deps():
+    """Add local directory to the PYTHONPATH to allow absolute imports.
+
+    Relative imports do not work in Airflow workflow definitions.
+    """
+    workflows_dir = os.path.abspath(os.path.dirname(__file__))
+    sys.path.append(workflows_dir)
+    yield
+    sys.path.remove(workflows_dir)
+
+
 def test_dag_import():
     """Test that the DAG file can be successfully imported.
 

--- a/nox.py
+++ b/nox.py
@@ -157,9 +157,7 @@ ALL_SAMPLE_DIRECTORIES = sorted(list(_collect_dirs('.', suffix='.py', recurse_fu
 GAE_STANDARD_SAMPLES = [
     sample for sample in ALL_TESTED_SAMPLES
     if sample.startswith('./appengine/standard/')]
-PY2_ONLY_SAMPLES = GAE_STANDARD_SAMPLES + [
-    sample for sample in ALL_TESTED_SAMPLES
-    if sample.startswith('./composer/workflows')]
+PY2_ONLY_SAMPLES = GAE_STANDARD_SAMPLES
 PY3_ONLY_SAMPLES = [
     sample for sample in ALL_TESTED_SAMPLES
     if (sample.startswith('./appengine/standard_python37')

--- a/testing/test-env.tmpl.sh
+++ b/testing/test-env.tmpl.sh
@@ -1,5 +1,6 @@
 # Environment variables for system tests.
 export GCLOUD_PROJECT=your-project-id
+export GOOGLE_CLOUD_PROJECT=$GCLOUD_PROJECT
 export CLOUD_STORAGE_BUCKET=$GCLOUD_PROJECT
 export API_KEY=
 export BIGTABLE_CLUSTER=bigtable-test


### PR DESCRIPTION
Note: I had to skip the use_local_deps workflow sample because of a
change in relative versus absolute imports between Python 2 and Python
3. I have not yet checked the workflow within Airflow to see if it runs
under Python 3.

@TrevorEdwards please review