### PR TITLE
Pub/Sub: synchronous pull with lease management

### DIFF
--- a/pubsub/cloud-client/requirements.txt
+++ b/pubsub/cloud-client/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-pubsub==0.37.2
+google-cloud-pubsub==0.38.0

--- a/pubsub/cloud-client/subscriber_test.py
+++ b/pubsub/cloud-client/subscriber_test.py
@@ -196,7 +196,7 @@ def test_receive_synchronously(
         publisher_client, topic, subscription_sync1, capsys):
     _publish_messages(publisher_client, topic)
 
-    subscriber.receive_messages_synchronously(PROJECT, SUBSCRIPTION_SYNC1)
+    subscriber.synchronous_pull(PROJECT, SUBSCRIPTION_SYNC1)
 
     out, _ = capsys.readouterr()
     assert 'Done.' in out

--- a/pubsub/cloud-client/subscriber_test.py
+++ b/pubsub/cloud-client/subscriber_test.py
@@ -160,6 +160,17 @@ def test_receive(publisher_client, topic, subscription, capsys):
     assert 'Message 1' in out
 
 
+def test_receive_synchronously(
+        publisher_client, topic, subscription, capsys):
+    _publish_messages(publisher_client, topic)
+
+    subscriber.receive_messages_synchronously(PROJECT, SUBSCRIPTION)
+    subscriber.synchronous_pull_with_lease_management(PROJECT, SUBSCRIPTION)
+
+    out, _ = capsys.readouterr()
+    assert 'Received and acknowledged all messages. Done.' in out
+
+
 def test_receive_with_custom_attributes(
         publisher_client, topic, subscription, capsys):
     _publish_messages_with_custom_attributes(publisher_client, topic)
@@ -188,18 +199,3 @@ def test_receive_with_flow_control(
     assert 'Listening' in out
     assert subscription in out
     assert 'Message 1' in out
-
-
-def test_receive_synchronously(
-        publisher_client, topic, subscription, capsys):
-    _publish_messages(publisher_client, topic)
-
-    with _make_sleep_patch():
-        with pytest.raises(RuntimeError, match='sigil'):
-            subscriber.receive_messages_with_flow_control(
-                PROJECT, SUBSCRIPTION)
-
-    out, _ = capsys.readouterr()
-    assert 'Message 1' in out
-    assert 'Message 2' in out
-    assert 'Message 3' in out


### PR DESCRIPTION
For very long-running tasks, we can reset the ack deadline every once in a while by calling `modify_ack_deadline` on the Subscriber API Client in separate processes. 