### PR TITLE
add test modules to requirements.txt for iot examples

### DIFF
--- a/iot/api-client/http_example/requirements.txt
+++ b/iot/api-client/http_example/requirements.txt
@@ -5,3 +5,6 @@ google-auth==1.5.1
 google-cloud-pubsub==0.37.2
 pyjwt==1.6.4
 requests==2.19.1
+flaky
+mock
+pytest

--- a/iot/api-client/mqtt_example/requirements.txt
+++ b/iot/api-client/mqtt_example/requirements.txt
@@ -5,3 +5,6 @@ google-cloud-pubsub==0.37.2
 cryptography==2.3.1
 pyjwt==1.6.4
 paho-mqtt==1.3.1
+flaky
+mock
+pytest


### PR DESCRIPTION
Noticed requirements.txt for python virtualenv was missing the test modules (pytest/mock are explicitly required, and flaky is specified in pytest.ini in python-docs-samples root directory)