### PR TITLE
Fix for error when missing MySQLdb

### DIFF
--- a/appengine/standard_python37/django/mysite/settings.py
+++ b/appengine/standard_python37/django/mysite/settings.py
@@ -95,7 +95,7 @@ if os.getenv('GAE_APPLICATION', None):
             'HOST': '/cloudsql/[YOUR-CONNECTION-NAME]',
             'USER': '[YOUR-USERNAME]',
             'PASSWORD': '[YOUR-PASSWORD]',
-            'NAME': 'polls',
+            'NAME': '[YOUR-DATABASE]',
         }
     }
 else:

--- a/appengine/standard_python37/django/mysite/settings.py
+++ b/appengine/standard_python37/django/mysite/settings.py
@@ -95,6 +95,7 @@ if os.getenv('GAE_APPLICATION', None):
             'HOST': '/cloudsql/[YOUR-CONNECTION-NAME]',
             'USER': '[YOUR-USERNAME]',
             'PASSWORD': '[YOUR-PASSWORD]',
+            'NAME': 'polls',
         }
     }
 else:

--- a/appengine/standard_python37/django/mysite/settings.py
+++ b/appengine/standard_python37/django/mysite/settings.py
@@ -79,15 +79,11 @@ WSGI_APPLICATION = 'mysite.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
-# Check to see if MySQLdb is available; if not, have pymysql masquerade as
-# MySQLdb. This is a convenience feature for developers who cannot install
-# MySQLdb locally; when running in production on Google App Engine Standard
-# Environment, MySQLdb will be used.
-try:
-    import MySQLdb  # noqa: F401
-except ImportError:
-    import pymysql
-    pymysql.install_as_MySQLdb()
+# Install PyMySQL as mysqlclient/MySQLdb to use Django's mysqlclient adapter
+# See https://docs.djangoproject.com/en/2.1/ref/databases/#mysql-db-api-drivers for
+# more information
+import pymysql
+pymysql.install_as_MySQLdb()
 
 # [START db_setup]
 if os.getenv('GAE_APPLICATION', None):

--- a/appengine/standard_python37/django/mysite/settings.py
+++ b/appengine/standard_python37/django/mysite/settings.py
@@ -79,6 +79,16 @@ WSGI_APPLICATION = 'mysite.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
+# Check to see if MySQLdb is available; if not, have pymysql masquerade as
+# MySQLdb. This is a convenience feature for developers who cannot install
+# MySQLdb locally; when running in production on Google App Engine Standard
+# Environment, MySQLdb will be used.
+try:
+    import MySQLdb  # noqa: F401
+except ImportError:
+    import pymysql
+    pymysql.install_as_MySQLdb()
+
 # [START db_setup]
 if os.getenv('GAE_APPLICATION', None):
     # Running on production App Engine, so connect to Google Cloud SQL using


### PR DESCRIPTION
While looking into the cause of an exception:

    ModuleNotFoundError: No module named 'MySQLdb'

I noticed the pymysql initialisation was missing, yet it was [done for the python2 tutorial settings.py counterpart](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/appengine/standard/django/mysite/settings.py#L95-L103)..


Note that this was noticed even when running the app in ["production" on GAE](https://console.cloud.google.com/errors/CIv9orry98OZRw?time=PT1H&project=expanded-talon-217815) (link for my own error in case it's accessible by Google employees). 
So worth looking into if this is the case here:

    ...This is a convenience feature for developers who cannot install
    # MySQLdb locally; when running in production on Google App Engine Standard
    # Environment, MySQLdb will be used.
