### PR TITLE
Fix serving static files on production

### DIFF
--- a/appengine/standard_python37/django/app.yaml
+++ b/appengine/standard_python37/django/app.yaml
@@ -5,7 +5,7 @@ handlers:
 # This configures Google App Engine to serve the files in the app's static
 # directory.
 - url: /static
-  static_dir: static_files/
+  static_dir: static/
 
 # This handler routes all requests not caught above to your main app. It is
 # required when static routes are defined, but can be omitted (along with


### PR DESCRIPTION
Django collectstatic adds files to ``static/`` folder rather than ``static_files/``.