### PR TITLE
Add GCS configuration info to Authoring Guide

### DIFF
--- a/AUTHORING_GUIDE.md
+++ b/AUTHORING_GUIDE.md
@@ -478,11 +478,19 @@ need to set environment variables for the tests to be able to use your project
 and its resources. See `testing/test-env.tmpl.sh` for a list of all environment
 variables used by all tests. Not every test needs all of these variables.
 
+#### Google Cloud Storage resources
 
+Certain samples require integration with Google Cloud Storage (GCS),
+most commonly for APIs that read files from GCS. To run the tests for
+these samples, configure your GCS bucket name via the `CLOUD_STORAGE_BUCKET`
+environment variable.
 
+The resources required by tests can usually be found in the `./resources`
+folder inside the sample directory. You can upload these resources to your
+own bucket to run the tests, e.g. using `gsutil`:  
+`gsutil cp ./resources/* gs://$CLOUD_STORAGE_BUCKET/`
 
-
-
-
-
-
+Many of these resources are already uploaded to a public read-only bucket.
+If your tests are failing because files are not found in your GCS bucket,
+you can try setting `CLOUD_STORAGE_BUCKET=cloud-samples-data` to use the
+public bucket.


### PR DESCRIPTION
Add information about the `CLOUD_STORAGE_BUCKET` environment variable used by tests, as well as the availability of `cloud-samples-data` which contains files required for a number of the test suites

/cc @theacodes 