### PR TITLE
Use explicit URIs for Video Intelligence sample tests

### DIFF
--- a/video/cloud-client/analyze/analyze_test.py
+++ b/video/cloud-client/analyze/analyze_test.py
@@ -14,38 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 
 import analyze
 
 
-BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
-LABELS_FILE_PATH = '/video/cat.mp4'
-EXPLICIT_CONTENT_FILE_PATH = '/video/cat.mp4'
-SHOTS_FILE_PATH = '/video/gbikes_dinosaur.mp4'
-
-
 @pytest.mark.slow
 def test_analyze_shots(capsys):
-    analyze.analyze_shots(
-        'gs://{}{}'.format(BUCKET, SHOTS_FILE_PATH))
+    analyze.analyze_shots('gs://demomaker/gbikes_dinosaur.mp4')
     out, _ = capsys.readouterr()
     assert 'Shot 1:' in out
 
 
 @pytest.mark.slow
 def test_analyze_labels(capsys):
-    analyze.analyze_labels(
-        'gs://{}{}'.format(BUCKET, LABELS_FILE_PATH))
+    analyze.analyze_labels('gs://demomaker/cat.mp4')
     out, _ = capsys.readouterr()
     assert 'label description: cat' in out
 
 
 @pytest.mark.slow
 def test_analyze_explicit_content(capsys):
-    analyze.analyze_explicit_content(
-        'gs://{}{}'.format(BUCKET, EXPLICIT_CONTENT_FILE_PATH))
+    analyze.analyze_explicit_content('gs://demomaker/cat.mp4')
     out, _ = capsys.readouterr()
     assert 'pornography' in out

--- a/video/cloud-client/analyze/beta_snippets_test.py
+++ b/video/cloud-client/analyze/beta_snippets_test.py
@@ -14,19 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 
 import beta_snippets
-
-BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
-FILE_PATH = 'video/googlework_short.mp4'
 
 
 @pytest.mark.slow
 def test_speech_transcription(capsys):
     beta_snippets.speech_transcription(
-        'gs://{}/{}'.format(BUCKET, FILE_PATH))
+        'gs://python-docs-samples-tests/video/googlework_short.mp4')
     out, _ = capsys.readouterr()
     assert 'cultural' in out

--- a/video/cloud-client/labels/labels_test.py
+++ b/video/cloud-client/labels/labels_test.py
@@ -14,20 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 
 import labels
 
 
-BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
-LABELS_FILE_PATH = '/video/cat.mp4'
-
-
 @pytest.mark.slow
 def test_feline_video_labels(capsys):
-    labels.analyze_labels(
-        'gs://{}{}'.format(BUCKET, LABELS_FILE_PATH))
+    labels.analyze_labels('gs://demomaker/cat.mp4')
     out, _ = capsys.readouterr()
     assert 'Video label description: cat' in out

--- a/video/cloud-client/shotchange/shotchange_test.py
+++ b/video/cloud-client/shotchange/shotchange_test.py
@@ -14,19 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import pytest
 
 import shotchange
 
-BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
-SHOTS_FILE_PATH = '/video/gbikes_dinosaur.mp4'
-
 
 @pytest.mark.slow
 def test_shots_dino(capsys):
-    shotchange.analyze_shots(
-        'gs://{}{}'.format(BUCKET, SHOTS_FILE_PATH))
+    shotchange.analyze_shots('gs://demomaker/gbikes_dinosaur.mp4')
     out, _ = capsys.readouterr()
     assert 'Shot 1:' in out


### PR DESCRIPTION
Resolves contributor friction that Rebecca identified when writing https://github.com/GoogleCloudPlatform/python-docs-samples/pull/1738

Currently, in order to run the tests, a contributor needs to find and download certain files, upload them to their bucket, and set an environment variable to point to their bucket. This PR updates the tests use public GCS URIs, so future contributors will not need to figure out and follow these confusing set-up steps.