### PR TITLE
Database name missing for on production

### DIFF
--- a/appengine/standard_python37/django/mysite/settings.py
+++ b/appengine/standard_python37/django/mysite/settings.py
@@ -87,6 +87,7 @@ if os.getenv('GAE_APPLICATION', None):
         'default': {
             'ENGINE': 'django.db.backends.mysql',
             'HOST': '/cloudsql/[YOUR-CONNECTION-NAME]',
+            'NAME': '[YOUR-DATABASE]',
             'USER': '[YOUR-USERNAME]',
             'PASSWORD': '[YOUR-PASSWORD]',
         }


### PR DESCRIPTION
Name added as per the instructions in:
https://cloud.google.com/python/django/appengine#configure_the_database_settings

    5. Replace [YOUR-DATABASE] with the name you choose during the "Initialize your Cloud SQL instance" step.

Note the [python2 example](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/appengine/standard/django/mysite/settings.py#L113) the name was put in directly, so worth aligning them:

    'NAME': 'polls',