### PR TITLE
Address broken test by updating CREATE MODEL options.

### DIFF
--- a/bigquery/bqml/ncaa_tutorial_test.py
+++ b/bigquery/bqml/ncaa_tutorial_test.py
@@ -61,7 +61,6 @@ def test_ncaa_tutorial(delete_dataset):
         CREATE OR REPLACE MODEL `bqml_tutorial.ncaa_model`
         OPTIONS (
             model_type='linear_reg',
-            data_split_eval_fraction=0.1,
             max_iteration=50 ) AS
         SELECT
             * EXCEPT (


### PR DESCRIPTION
Tracked internally as 118618672.

This is one possible remedy for the test failure.  The other is to specify all the necessary data split options.