### PR TITLE
Update google-endpoints to version 4.8.0.

### DIFF
--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements.txt
@@ -1,2 +1,2 @@
-google-endpoints==4.7.0
+google-endpoints==4.8.0
 google-endpoints-api-management==1.11.0


### PR DESCRIPTION
Needed to update google-endpoints to 4.8.0 to avoid the 'audiences must be a dict when third-party issuers are in use'  that was introduced in 4.7.0. See https://github.com/cloudendpoints/endpoints-python/issues/184

Signed-off-by: Nancy Avinger <navinger@google.com>