### PR TITLE
Fix Firestore order_by descending syntax

### DIFF
--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -529,7 +529,7 @@ def order_simple_limit_desc():
     # [START order_simple_limit_desc]
     cities_ref = db.collection(u'cities')
     query = cities_ref.order_by(
-        u'name', direction=firestore.Query.DESCENDING).limit(3)
+        u'name', direction=db.Query.DESCENDING).limit(3)
     results = query.get()
     # [END order_simple_limit_desc]
     print(results)
@@ -540,7 +540,7 @@ def order_multiple():
     # [START order_multiple]
     cities_ref = db.collection(u'cities')
     cities_ref.order_by(u'state').order_by(
-        u'population', direction=firestore.Query.DESCENDING)
+        u'population', direction=db.Query.DESCENDING)
     # [END order_multiple]
 
 


### PR DESCRIPTION
The docs currently suggest that the proper way to get documents in descending order is with `firestore.Query.DESCENDING`.

However, this throws an error for me: `Module 'firebase_admin.firestore' has no 'Query' member`.

I've resolved this by instead using `db.Query.DESCENDING`, where `db = firestore.Client()`.

I don't know if this is actually a problem, but this is what I needed to do.