### PR TITLE
Fix typo in comment

### DIFF
--- a/cloud-sql/postgres/sqlalchemy/main.py
+++ b/cloud-sql/postgres/sqlalchemy/main.py
@@ -36,7 +36,7 @@ logger = logging.getLogger()
 # managing a pool of connections to your database
 db = sqlalchemy.create_engine(
     # Equivalent URL:
-    # postgres+pg8000://<db_user>:<db_pass>@/<db_name>?unix_socket=/cloudsql/<cloud_sql_instance_name>
+    # postgres+pg8000://<db_user>:<db_pass>@/<db_name>?unix_sock=/cloudsql/<cloud_sql_instance_name>
     sqlalchemy.engine.url.URL(
         drivername='postgres+pg8000',
         username=db_user,


### PR DESCRIPTION
This is a minor typo in the comment but looks a little confusing since the correct `unix_sock` reference is in the code just a few lines lower.