### PR TITLE
Changes from CHAR to VARCHAR on Cloud SQL example

### DIFF
--- a/cloud-sql/postgres/sqlalchemy/main.py
+++ b/cloud-sql/postgres/sqlalchemy/main.py
@@ -89,7 +89,7 @@ def create_tables():
         conn.execute(
             "CREATE TABLE IF NOT EXISTS votes "
             "( vote_id SERIAL NOT NULL, time_cast timestamp NOT NULL, "
-            "candidate CHAR(6) NOT NULL, PRIMARY KEY (vote_id) );"
+            "candidate VARCHAR(6) NOT NULL, PRIMARY KEY (vote_id) );"
         )
 
 


### PR DESCRIPTION
Using CHAR was bringing extra spaces on the frontend for comparison and leading to display wrong information.