### PR TITLE
Rename Cloud ML Engine to AI Platform

### DIFF
--- a/ml_engine/online_prediction/predict.py
+++ b/ml_engine/online_prediction/predict.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Examples of using the Cloud ML Engine's online prediction service."""
+"""Examples of using AI Platform's online prediction service."""
 import argparse
 import base64
 import json
@@ -29,7 +29,7 @@ def predict_json(project, model, instances, version=None):
     """Send json data to a deployed model for prediction.
 
     Args:
-        project (str): project where the Cloud ML Engine Model is deployed.
+        project (str): project where the AI Platform Model is deployed.
         model (str): model name.
         instances ([Mapping[str: Any]]): Keys should be the names of Tensors
             your deployed model expects as inputs. Values should be datatypes
@@ -40,7 +40,7 @@ def predict_json(project, model, instances, version=None):
         Mapping[str: any]: dictionary of prediction results defined by the
             model.
     """
-    # Create the ML Engine service object.
+    # Create the AI Platform service object.
     # To authenticate set the environment variable
     # GOOGLE_APPLICATION_CREDENTIALS=<path_to_service_account_file>
     service = googleapiclient.discovery.build('ml', 'v1')
@@ -69,7 +69,7 @@ def predict_examples(project,
     """Send protocol buffer data to a deployed model for prediction.
 
     Args:
-        project (str): project where the Cloud ML Engine Model is deployed.
+        project (str): project where the AI Platform Model is deployed.
         model (str): model name.
         example_bytes_list ([str]): A list of bytestrings representing
             serialized tf.train.Example protocol buffers. The contents of this

--- a/ml_engine/online_prediction/scikit-xg-predict.py
+++ b/ml_engine/online_prediction/scikit-xg-predict.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Examples of using the Cloud ML Engine's online prediction service,
+"""Examples of using AI Platform's online prediction service,
    modified for scikit-learn and XGBoost."""
 
 import googleapiclient.discovery
@@ -23,7 +23,7 @@ import googleapiclient.discovery
 def predict_json(project, model, instances, version=None):
     """Send json data to a deployed model for prediction.
     Args:
-        project (str): project where the Cloud ML Engine Model is deployed.
+        project (str): project where the AI Platform Model is deployed.
         model (str): model name.
         instances ([[float]]): List of input instances, where each input
                    instance is a list of floats.
@@ -32,7 +32,7 @@ def predict_json(project, model, instances, version=None):
         Mapping[str: any]: dictionary of prediction results defined by the
             model.
     """
-    # Create the ML Engine service object.
+    # Create the AI Platform service object.
     # To authenticate set the environment variable
     # GOOGLE_APPLICATION_CREDENTIALS=<path_to_service_account_file>
     service = googleapiclient.discovery.build('ml', 'v1')

--- a/notebooks/tutorials/cloud-ml-engine/Training and prediction with scikit-learn.ipynb
+++ b/notebooks/tutorials/cloud-ml-engine/Training and prediction with scikit-learn.ipynb
@@ -6,13 +6,13 @@
    "source": [
     "# Training and prediction with scikit-learn\n",
     "\n",
-    "This notebook demonstrates how to use Cloud Machine Learning Engine to train a simple classification model using `scikit-learn`, and then deploy the model to get predictions.\n",
+    "This notebook demonstrates how to use AI Platform to train a simple classification model using `scikit-learn`, and then deploy the model to get predictions.\n",
     "\n",
     "You train the model to predict a person's income level based on the [Census Income data set](https://archive.ics.uci.edu/ml/datasets/Census+Income).\n",
     "\n",
     "Before you jump in, let’s cover some of the different tools you’ll be using:\n",
     "\n",
-    "+ [Cloud Machine Learning Engine](https://cloud.google.com/ml-engine/) (Cloud ML Engine) is a managed service that enables you to easily build machine learning models that work on any type of data, of any size.\n",
+    "+ [AI Platform](https://cloud.google.com/ml-engine/) (AI Platform) is a managed service that enables you to easily build machine learning models that work on any type of data, of any size.\n",
     "\n",
     "+ [Cloud Storage](https://cloud.google.com/storage/) is a unified object storage for developers and enterprises, from live data serving to data analytics/ML to data archiving.\n",
     "\n",
@@ -27,7 +27,7 @@
     "\n",
     "### Enable the required APIs\n",
     "\n",
-    "In order to use Cloud ML Engine, confirm that the required APIs are enabled:"
+    "In order to use AI Platform, confirm that the required APIs are enabled:"
    ]
   },
   {
@@ -152,7 +152,7 @@
     "+ Fits the model is against the training data\n",
     "+ Exports the model with the [Python `pickle` library](https://docs.python.org/3/library/pickle.html)\n",
     "\n",
-    "The following model training code is not executed within this notebook. Instead, it is saved to a Python file and packaged as a Python module that runs on Cloud ML Engine after you submit the training job."
+    "The following model training code is not executed within this notebook. Instead, it is saved to a Python file and packaged as a Python module that runs on AI Platform after you submit the training job."
    ]
   },
   {
@@ -391,7 +391,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once the model is successfully created and trained, you can serve it. A model can have different versions. In order to serve the model, create a model and version in Cloud ML Engine.\n",
+    "Once the model is successfully created and trained, you can serve it. A model can have different versions. In order to serve the model, create a model and version in AI Platform.\n",
     "\n",
     "Define the model and version names:"
    ]
@@ -410,7 +410,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create the model in Cloud ML Engine:"
+    "Create the model in AI Platform:"
    ]
   },
   {
@@ -451,7 +451,7 @@
     "\n",
     "### Format data for prediction\n",
     "\n",
-    "Before you send an online prediction request, you must format your test data to prepare it for use by the Cloud ML Engine prediction service. Make sure that the format of your input instances matches what your model expects.\n",
+    "Before you send an online prediction request, you must format your test data to prepare it for use by AI Platform prediction service. Make sure that the format of your input instances matches what your model expects.\n",
     "\n",
     "Create an `input.json` file with each input instance on a separate line. The following example uses ten data instances. Note that the format of input instances needs to match what your model expects. In this example, the Census model requires 14 features, so your input must be a matrix of shape (`num_instances, 14`)."
    ]

--- a/notebooks/tutorials/cloud-ml-engine/Training and prediction with scikit-learn.ipynb
+++ b/notebooks/tutorials/cloud-ml-engine/Training and prediction with scikit-learn.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "Before you jump in, let’s cover some of the different tools you’ll be using:\n",
     "\n",
-    "+ [AI Platform](https://cloud.google.com/ml-engine/) (AI Platform) is a managed service that enables you to easily build machine learning models that work on any type of data, of any size.\n",
+    "+ [AI Platform](https://cloud.google.com/ml-engine/) is a managed service that enables you to easily build machine learning models that work on any type of data, of any size.\n",
     "\n",
     "+ [Cloud Storage](https://cloud.google.com/storage/) is a unified object storage for developers and enterprises, from live data serving to data analytics/ML to data archiving.\n",
     "\n",
@@ -451,7 +451,7 @@
     "\n",
     "### Format data for prediction\n",
     "\n",
-    "Before you send an online prediction request, you must format your test data to prepare it for use by AI Platform prediction service. Make sure that the format of your input instances matches what your model expects.\n",
+    "Before you send an online prediction request, you must format your test data to prepare it for use by the AI Platform prediction service. Make sure that the format of your input instances matches what your model expects.\n",
     "\n",
     "Create an `input.json` file with each input instance on a separate line. The following example uses ten data instances. Note that the format of input instances needs to match what your model expects. In this example, the Census model requires 14 features, so your input must be a matrix of shape (`num_instances, 14`)."
    ]


### PR DESCRIPTION
Renames all instances of the following terms in strings and other text:

* Cloud Machine Learning Engine
* Cloud ML Engine
* ML Engine

To be cautious about broken links, this change doesn't rename any files
or change any URLs. (The ml_engine directory may be renamed later, after
a sweep to find all the places where this code is included or linked
to.)