### PR TITLE
Fix compatibility issues of google_jwt_client.py with python 3.

### DIFF
--- a/endpoints/getting-started/clients/google-jwt-client.py
+++ b/endpoints/getting-started/clients/google-jwt-client.py
@@ -64,7 +64,7 @@ def generate_jwt(sa_keyfile,
 def make_jwt_request(signed_jwt, url='https://your-endpoint.com'):
     """Makes an authorized request to the endpoint"""
     headers = {
-        'Authorization': 'Bearer {}'.format(signed_jwt),
+        'Authorization': 'Bearer {}'.format(signed_jwt.decode('utf-8')),
         'content-type': 'application/json'
     }
     response = requests.get(url, headers=headers)


### PR DESCRIPTION
Original issue: https://groups.google.com/forum/#!topic/google-cloud-endpoints/ORvn8zJ_QQE
When google_jwt_client.py was executed with python 3, the Authorization
header was formatted as, "Authorization: Bearer b'JWT_TOKEN'". The b'
prefix made the token invalid.

This fix is compatible with both python 2 and python 3.