### PR TITLE
Order rows client-side when BQ Storage API is used.

### DIFF
--- a/bigquery_storage/to_dataframe/main_test.py
+++ b/bigquery_storage/to_dataframe/main_test.py
@@ -84,7 +84,6 @@ def test_query_to_dataframe(capsys, clients):
     view_count
     FROM `bigquery-public-data.stackoverflow.posts_questions`
     WHERE tags like '%google-bigquery%'
-    ORDER BY view_count DESC
     """
 
     dataframe = (
@@ -97,6 +96,11 @@ def test_query_to_dataframe(capsys, clients):
         # BigQuery Storage API fails to read the query results.
         .to_dataframe(bqstorage_client=bqstorageclient)
     )
+
+    # When the BigQuery Storage API is used, large results may be downloaded in
+    # parallel, so the order of rows in the DataFrame is not deterministic.
+    # Sort the rows client-side if a specific order is needed.
+    dataframe = dataframe.sort_values(by=["view_count"])
     print(dataframe.head())
     # [END bigquerystorage_pandas_tutorial_read_query_results]
     # [END bigquerystorage_pandas_tutorial_all]


### PR DESCRIPTION
Parallelism in downloads means the order of rows might not be preserved. (Though it should be when there is only one stream.)

Thought: Do we check for ORDER BY and intentionally only use one stream to download? Does the BQ Storage API respect row order in that case?