### PR TITLE
Drop xfail for passing test_remove_bucket_label

### DIFF
--- a/storage/cloud-client/snippets_test.py
+++ b/storage/cloud-client/snippets_test.py
@@ -48,10 +48,6 @@ def test_add_bucket_label(capsys):
     assert 'example' in out
 
 
-@pytest.mark.xfail(
-    reason=(
-        'https://github.com/GoogleCloudPlatform'
-        '/google-cloud-python/issues/3711'))
 def test_remove_bucket_label(capsys):
     snippets.add_bucket_label(BUCKET)
     snippets.remove_bucket_label(BUCKET)


### PR DESCRIPTION
The Python client was fixed in https://github.com/googleapis/google-cloud-python/issues/3711 so the test now passes.