### PR TITLE
Add Dataflow script to run templates

### DIFF
--- a/dataflow/run_template/README.md
+++ b/dataflow/run_template/README.md
@@ -1,0 +1,137 @@
+# Run template
+
+[`main.py`](main.py) - Script to run an [Apache Beam] template on [Google Cloud Dataflow].
+
+The following examples show how to run the [`Word_Count` template], but you can run any other template.
+
+For the `Word_Count` template, we require to pass an `output` Cloud Storage path prefix, and optionally we can pass an `inputFile` Cloud Storage file pattern for the inputs.
+If `inputFile` is not passed, it will take `gs://apache-beam-samples/shakespeare/kinglear.txt` as default.
+
+## Before you begin
+
+1. Install the [Cloud SDK].
+
+1. [Create a new project].
+
+1. [Enable billing].
+
+1. [Enable the APIs](https://console.cloud.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,bigquery,pubsub,datastore.googleapis.com,cloudfunctions.googleapis.com,cloudresourcemanager.googleapis.com): Dataflow, Compute Engine, Stackdriver Logging, Cloud Storage, Cloud Storage JSON, BigQuery, Pub/Sub, Datastore, Cloud Functions, and Cloud Resource Manager.
+
+1. Setup the Cloud SDK to your GCP project.
+
+   ```bash
+   gcloud init
+   ```
+
+1. Create a Cloud Storage bucket.
+
+   ```bash
+   gsutil mb gs://your-gcs-bucket
+   ```
+
+## Setup
+
+The following instructions will help you prepare your development environment.
+
+1. [Install Python and virtualenv].
+
+1. Clone the `python-docs-samples` repository.
+
+    ```bash
+    git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+    ```
+
+1. Navigate to the sample code directory.
+
+   ```bash
+   cd python-docs-samples/dataflow/run_template
+   ```
+
+1. Create a virtual environment and activate it.
+
+   ```bash
+   virtualenv env
+   source env/bin/activate
+   ```
+
+   > Once you are done, you can deactivate the virtualenv and go back to your global Python environment by running `deactivate`.
+
+1. Install the sample requirements.
+
+   ```bash
+   pip install -U -r requirements.txt
+   ```
+
+## Running locally
+
+To run a Dataflow template from the command line.
+
+> NOTE: To run locally, you'll need to [create a service account key] as a JSON file.
+> Then export an environment variable called `GOOGLE_APPLICATION_CREDENTIALS` pointing it to your service account file.
+
+```bash
+python main.py \
+  --project <your-gcp-project> \
+  --job wordcount-$(date +'%Y%m%d-%H%M%S') \
+  --template gs://dataflow-templates/latest/Word_Count \
+  --inputFile gs://apache-beam-samples/shakespeare/kinglear.txt \
+  --output gs://<your-gcs-bucket>/wordcount/outputs
+```
+
+## Running in Python
+
+To run a Dataflow template from Python.
+
+> NOTE: To run locally, you'll need to [create a service account key] as a JSON file.
+> Then export an environment variable called `GOOGLE_APPLICATION_CREDENTIALS` pointing it to your service account file.
+
+```py
+import main as run_template
+
+run_template.run(
+    project='your-gcp-project',
+    job='unique-job-name',
+    template='gs://dataflow-templates/latest/Word_Count',
+    parameters={
+        'inputFile': 'gs://apache-beam-samples/shakespeare/kinglear.txt',
+        'output': 'gs://<your-gcs-bucket>/wordcount/outputs',
+    }
+)
+```
+
+## Running in Cloud Functions
+
+To deploy this into a Cloud Function and run a Dataflow template via an HTTP request as a REST API.
+
+```bash
+PROJECT=$(gcloud config get-value project) \
+REGION=$(gcloud config get-value functions/region)
+
+# Deploy the Cloud Function.
+gcloud functions deploy run_template \
+  --runtime python37 \
+  --trigger-http \
+  --region $REGION
+
+# Call the Cloud Function via an HTTP request.
+curl -X POST "https://$REGION-$PROJECT.cloudfunctions.net/run_template" \
+  -d project=$PROJECT \
+  -d job=wordcount-$(date +'%Y%m%d-%H%M%S') \
+  -d template=gs://dataflow-templates/latest/Word_Count \
+  -d inputFile=gs://apache-beam-samples/shakespeare/kinglear.txt \
+  -d output=gs://<your-gcs-bucket>/wordcount/outputs
+```
+
+[Apache Beam]: https://beam.apache.org/
+[Google Cloud Dataflow]: https://cloud.google.com/dataflow/docs/
+[`Word_Count` template]: https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/master/src/main/java/com/google/cloud/teleport/templates/WordCount.java
+
+[Cloud SDK]: https://cloud.google.com/sdk/docs/
+[Create a new project]: https://console.cloud.google.com/projectcreate
+[Enable billing]: https://cloud.google.com/billing/docs/how-to/modify-project
+[Create a service account key]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
+[Creating and managing service accounts]: https://cloud.google.com/iam/docs/creating-managing-service-accounts
+[GCP Console IAM page]: https://console.cloud.google.com/iam-admin/iam
+[Granting roles to service accounts]: https://cloud.google.com/iam/docs/granting-roles-to-service-accounts
+
+[Install Python and virtualenv]: https://cloud.google.com/python/setup

--- a/dataflow/run_template/main.py
+++ b/dataflow/run_template/main.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+"""Script to run a Dataflow template."""
+
+
+def run(project, job, template, parameters=None):
+    """Runs a Dataflow template.
+
+    Args:
+        project (str): Google Cloud project ID to run on.
+        job (str): Unique Dataflow job name.
+        template (str): Google Cloud Storage path to Dataflow template.
+        parameters (dict): Dictionary of parameters for the specified template.
+    Returns:
+        The response from the Dataflow service after running the template.
+    """
+    parameters = parameters or {}
+
+    # [START dataflow_run_template]
+    from googleapiclient.discovery import build
+
+    # project = 'your-gcp-project'
+    # job = 'unique-job-name'
+    # template = 'gs://dataflow-templates/latest/Word_Count'
+    # parameters = {
+    #     'inputFile': 'gs://dataflow-samples/shakespeare/kinglear.txt',
+    #     'output': 'gs://<your-gcs-bucket>/wordcount/outputs',
+    # }
+
+    service = build('dataflow', 'v1b3')
+    request = service.projects().templates().launch(
+        projectId=project,
+        gcsPath=template,
+        body={
+            'jobName': job,
+            'parameters': parameters,
+        }
+    )
+
+    response = request.execute()
+    # [END dataflow_run_template]
+    return response
+
+
+def run_template(request):
+    """HTTP Cloud Function.
+    Args:
+        request (flask.Request): The request object.
+        <http://flask.pocoo.org/docs/1.0/api/#flask.Request>
+    Returns:
+        The response text, or any set of values that can be turned into a
+        Response object using `make_response`
+        <http://flask.pocoo.org/docs/1.0/api/#flask.Flask.make_response>.
+    """
+    parameters = request.get_json(silent=True) or {}  # application/json
+    parameters.update(request.form.to_dict())         # Form request data
+    parameters.update(request.args.to_dict())         # URL parameters
+
+    project = parameters.pop('project')
+    job = parameters.pop('job')
+    template = parameters.pop('template')
+    response = run(
+        project=project,
+        job=job,
+        template=template,
+        parameters=parameters,
+    )
+    return json.dumps(response, separators=(',', ':'))
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--project', required=True,
+                        help='Google Cloud project ID to run on.')
+    parser.add_argument('--job', required=True,
+                        help='Unique Dataflow job name.')
+    parser.add_argument('--template', required=True,
+                        help='Google Cloud Storage path to Dataflow template.')
+    args, unknown_args = parser.parse_known_args()
+
+    # Parse the template parameters.
+    template_argparser = argparse.ArgumentParser()
+    for arg in unknown_args:
+        if arg.startswith('-'):
+            template_argparser.add_argument(arg)
+    parameters = template_argparser.parse_args(unknown_args)
+
+    response = run(
+        project=args.project,
+        job=args.job,
+        template=args.template,
+        parameters=parameters.__dict__,
+    )
+    print(json.dumps(response, indent=2))

--- a/dataflow/run_template/main_test.py
+++ b/dataflow/run_template/main_test.py
@@ -1,0 +1,91 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flask
+import json
+import os
+import pytest
+import subprocess as sp
+import time
+
+from datetime import datetime
+from werkzeug.urls import url_encode
+
+import main
+
+PROJECT = os.environ['GCLOUD_PROJECT']
+BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
+
+# Wait time until a job can be cancelled, as a best effort.
+# If it fails to be cancelled, the job will run for ~8 minutes.
+WAIT_TIME = 5  # seconds
+
+# Create a fake "app" for generating test request contexts.
+@pytest.fixture(scope="module")
+def app():
+    return flask.Flask(__name__)
+
+
+def test_run_template_empty_args(app):
+    with app.test_request_context():
+        with pytest.raises(KeyError):
+            main.run_template(flask.request)
+
+
+def test_run_template_url(app):
+    args = {
+        'project': PROJECT,
+        'job': datetime.now().strftime('test_run_template_url-%Y%m%d-%H%M%S'),
+        'template': 'gs://dataflow-templates/latest/Word_Count',
+        'inputFile': 'gs://apache-beam-samples/shakespeare/kinglear.txt',
+        'output': 'gs://{}/dataflow/wordcount/outputs'.format(BUCKET),
+    }
+    with app.test_request_context('/?' + url_encode(args)):
+        res = main.run_template(flask.request)
+        data = json.loads(res)
+        job_id = data['job']['id']
+        time.sleep(WAIT_TIME)
+        assert sp.call(['gcloud', 'dataflow', 'jobs', 'cancel', job_id]) == 0
+
+
+def test_run_template_data(app):
+    args = {
+        'project': PROJECT,
+        'job': datetime.now().strftime('test_run_template_data-%Y%m%d-%H%M%S'),
+        'template': 'gs://dataflow-templates/latest/Word_Count',
+        'inputFile': 'gs://apache-beam-samples/shakespeare/kinglear.txt',
+        'output': 'gs://{}/dataflow/wordcount/outputs'.format(BUCKET),
+    }
+    with app.test_request_context(data=args):
+        res = main.run_template(flask.request)
+        data = json.loads(res)
+        job_id = data['job']['id']
+        time.sleep(WAIT_TIME)
+        assert sp.call(['gcloud', 'dataflow', 'jobs', 'cancel', job_id]) == 0
+
+
+def test_run_template_json(app):
+    args = {
+        'project': PROJECT,
+        'job': datetime.now().strftime('test_run_template_json-%Y%m%d-%H%M%S'),
+        'template': 'gs://dataflow-templates/latest/Word_Count',
+        'inputFile': 'gs://apache-beam-samples/shakespeare/kinglear.txt',
+        'output': 'gs://{}/dataflow/wordcount/outputs'.format(BUCKET),
+    }
+    with app.test_request_context(json=args):
+        res = main.run_template(flask.request)
+        data = json.loads(res)
+        job_id = data['job']['id']
+        time.sleep(WAIT_TIME)
+        assert sp.call(['gcloud', 'dataflow', 'jobs', 'cancel', job_id]) == 0

--- a/dataflow/run_template/requirements.txt
+++ b/dataflow/run_template/requirements.txt
@@ -1,0 +1,1 @@
+google-api-python-client==1.7.9


### PR DESCRIPTION
This adds a helper script to run a Dataflow template from the command line, from Python, or from a Cloud Function HTTP endpoint.