### PR TITLE
Changed env var to match between app.yaml and main.py in cloud_sql/mysql

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/app.yaml
+++ b/cloud-sql/mysql/sqlalchemy/app.yaml
@@ -17,7 +17,7 @@ runtime: python37
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
 # something like https://cloud.google.com/kms/ to help keep secrets secret.
 env_variables:
-  CLOUD_SQL_INSTANCE_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
+  CLOUD_SQL_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
   DB_USER: my-db-user
   DB_PASS: my-db-pass
   DB_NAME: my_db

--- a/cloud-sql/postgres/sqlalchemy/app.yaml
+++ b/cloud-sql/postgres/sqlalchemy/app.yaml
@@ -17,7 +17,7 @@ runtime: python37
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
 # something like https://cloud.google.com/kms/ to help keep secrets secret.
 env_variables:
-  CLOUD_SQL_INSTANCE_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
+  CLOUD_SQL_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
   DB_USER: my-db-user
   DB_PASS: my-db-pass
   DB_NAME: my_db


### PR DESCRIPTION
Previously, in the mysql example for cloud sql, there was a discrepancy between the naming of an environment variable in main.py and app.yaml. This PR changes the env var to "CLOUD_SQL_CONNECTION_NAME," matching the naming convention the [Java library uses](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/cloud-sql/mysql/servlet/src/main/java/com/example/cloudsql/ConnectionPoolContextListener.java).