### PR TITLE
DLP: Several python example scripts have badly behaved info_types parameter

### DIFF
--- a/dlp/deid.py
+++ b/dlp/deid.py
@@ -417,7 +417,7 @@ if __name__ == '__main__':
         help='Deidentify sensitive data in a string by masking it with a '
              'character.')
     mask_parser.add_argument(
-        '--info_types', action='append',
+        '--info_types', nargs='+',
         help='Strings representing info types to look for. A full list of '
              'info categories and types is available from the API. Examples '
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -786,7 +786,7 @@ if __name__ == '__main__':
         help='The Google Cloud project id to use as a parent resource.',
         default=default_project)
     parser_string.add_argument(
-        '--info_types', action='append',
+        '--info_types', nargs='+',
         help='Strings representing info types to look for. A full list of '
              'info categories and types is available from the API. Examples '
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
@@ -1041,7 +1041,7 @@ if __name__ == '__main__':
         help='The Google Cloud project id to use as a parent resource.',
         default=default_project)
     parser_bigquery.add_argument(
-        '--info_types', action='append',
+        '--info_types', nargs='+',
         help='Strings representing info types to look for. A full list of '
              'info categories and types is available from the API. Examples '
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '

--- a/dlp/redact.py
+++ b/dlp/redact.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
         help='The Google Cloud project id to use as a parent resource.',
         default=default_project)
     parser.add_argument(
-        '--info_types', action='append',
+        '--info_types', nargs='+',
         help='Strings representing info types to look for. A full list of '
              'info categories and types is available from the API. Examples '
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '

--- a/dlp/templates.py
+++ b/dlp/templates.py
@@ -178,7 +178,7 @@ if __name__ == '__main__':
         help='The Google Cloud project id to use as a parent resource.',
         default=default_project)
     parser_create.add_argument(
-        '--info_types', action='append',
+        '--info_types', nargs='+',
         help='Strings representing info types to look for. A full list of '
              'info categories and types is available from the API. Examples '
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '

--- a/dlp/triggers.py
+++ b/dlp/triggers.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
         help='The Google Cloud project id to use as a parent resource.',
         default=default_project)
     parser_create.add_argument(
-        '--info_types', action='append',
+        '--info_types', nargs='+',
         help='Strings representing info types to look for. A full list of '
              'info categories and types is available from the API. Examples '
              'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '


### PR DESCRIPTION
Fixing bug where "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS" are still present even when user 
specifies info_types. To fix I have converted action='append' to nargs='+' which will preserve defaults but allow user to override rather than append to the default list.