### PR TITLE
Improve and fix Cloud Spanner samples that transfer marketing budget

### DIFF
--- a/spanner/cloud-client/snippets_test.py
+++ b/spanner/cloud-client/snippets_test.py
@@ -270,7 +270,7 @@ def test_query_data_with_parameter(capsys):
 def test_write_with_dml_transaction(capsys):
     snippets.write_with_dml_transaction(INSTANCE_ID, DATABASE_ID)
     out, _ = capsys.readouterr()
-    assert "Transferred 300000 from Album1's budget to Album2's" in out
+    assert "Transferred 200000 from Album2's budget to Album1's" in out
 
 
 def update_data_with_partitioned_dml(capsys):


### PR DESCRIPTION
The samples that transfer part of an album's marketing budget had some issues:

+ `read_write_transaction`: Compared `second_album_budget` with an arbitrary integer, rather than explicitly checking against `transfer_amount`.
+ `write_with_dml_transaction`: Moved money from album 1 to album 2, even though `read_write_transaction` was the other way around. Also retrieved album 1's budget where it should have retrieved album 2's budget.

This change fixes those issues and updates the tests accordingly.

@jsimonweb PTAL