### PR TITLE
Change Django sample so that mysqlclient is not installed by default

### DIFF
--- a/appengine/flexible/django_cloudsql/mysite/settings.py
+++ b/appengine/flexible/django_cloudsql/mysite/settings.py
@@ -78,19 +78,34 @@ WSGI_APPLICATION = 'mysite.wsgi.application'
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
 # [START dbconfig]
+
+# The following DATABASES configuration is for PostgreSQL. If you are using
+# MySQL, use the commented-out block that follows this one instead. In this
+# case, please also follow the commented instructions in requirements.txt.
+
 DATABASES = {
     'default': {
-        # If you are using Cloud SQL for MySQL rather than PostgreSQL, set
-        # 'ENGINE': 'django.db.backends.mysql' instead of the following.
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'polls',
         'USER': '<your-database-user>',
         'PASSWORD': '<your-database-password>',
-        # For MySQL, set 'PORT': '3306' instead of the following. Any Cloud
-        # SQL Proxy instances running locally must also be set to tcp:3306.
         'PORT': '5432',
     }
 }
+
+# Uncomment this DATABASES block and use it instead of the above if you are
+# using MySQL. Also follow the commented instructions in requirements.txt.
+
+# DATABASES = {
+#     'default': {
+#         'ENGINE': 'django.db.backends.mysql',
+#         'NAME': 'polls',
+#         'USER': '<your-database-user>',
+#         'PASSWORD': '<your-database-password>',
+#         'PORT': '3306',
+#     }
+# }
+
 # In the flexible environment, you connect to CloudSQL using a unix socket.
 # Locally, you can use the CloudSQL proxy to proxy a localhost connection
 # to the instance

--- a/appengine/flexible/django_cloudsql/requirements.txt
+++ b/appengine/flexible/django_cloudsql/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.1.9
-mysqlclient==1.4.1
+# mysqlclient==1.4.1  # Uncomment this line if using MySQL
 wheel==0.32.3
 gunicorn==19.9.0
-psycopg2==2.7.7
+psycopg2==2.7.7  # Comment this line out if using MySQL


### PR DESCRIPTION
This addresses customer feedback that mysql vs postgres is confusing and that when using postgres, mysqlclient is required (and installation fails locally because mysql libs are not installed) by default.