### PR TITLE
Deflake bigtable and spanner tests.

### DIFF
--- a/bigtable/metricscaler/metricscaler_test.py
+++ b/bigtable/metricscaler/metricscaler_test.py
@@ -46,17 +46,27 @@ def test_scale_bigtable():
 
     scale_bigtable(BIGTABLE_INSTANCE, BIGTABLE_INSTANCE, True)
 
-    time.sleep(10)
-    cluster.reload()
-
-    new_node_count = cluster.serve_nodes
-    assert (new_node_count == (original_node_count + SIZE_CHANGE_STEP))
+    for n in range(10):
+        time.sleep(10)
+        cluster.reload()
+        new_node_count = cluster.serve_nodes
+        try:
+            assert (new_node_count == (original_node_count + SIZE_CHANGE_STEP))
+        except AssertionError:
+            if n == 9:
+                raise
 
     scale_bigtable(BIGTABLE_INSTANCE, BIGTABLE_INSTANCE, False)
-    time.sleep(10)
-    cluster.reload()
-    final_node_count = cluster.serve_nodes
-    assert final_node_count == original_node_count
+
+    for n in range(10):
+        time.sleep(10)
+        cluster.reload()
+        final_node_count = cluster.serve_nodes
+        try:
+            assert final_node_count == original_node_count
+        except AssertionError:
+            if n == 9:
+                raise
 
 
 # Unit test for logic

--- a/spanner/cloud-client/snippets_test.py
+++ b/spanner/cloud-client/snippets_test.py
@@ -202,7 +202,9 @@ def test_query_with_struct(capsys):
 def test_query_with_array_of_struct(capsys):
     snippets.query_with_array_of_struct(INSTANCE_ID, DATABASE_ID)
     out, _ = capsys.readouterr()
-    assert 'SingerId: 8\nSingerId: 7\nSingerId: 6' in out
+    assert 'SingerId: 8' in out
+    assert 'SingerId: 7' in out
+    assert 'SingerId: 6' in out
 
 
 def test_query_struct_field(capsys):


### PR DESCRIPTION
* Spanner doesn't actually promise the order of the results, so make the assertion work regardless of ordering.
* Bigtable might need some more time to scale, so retry the assertion up to 10 times.