### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/appengine/standard/i18n/i18n_utils.py
+++ b/appengine/standard/i18n/i18n_utils.py
@@ -19,6 +19,7 @@
 The idea of this example, especially for how to translate strings in
 Javascript is originally from an implementation of Django i18n.
 """
+from __future__ import print_function
 
 
 import gettext
@@ -49,7 +50,7 @@ def _get_plural_forms(js_translations):
         for l in js_translations._catalog[''].split('\n'):
             if l.startswith('Plural-Forms:'):
                 plural = l.split(':', 1)[1].strip()
-                print "plural is %s" % plural
+                print("plural is %s" % plural)
     if plural is not None:
         for raw_element in plural.split(';'):
             element = raw_element.strip()
@@ -57,7 +58,7 @@ def _get_plural_forms(js_translations):
                 n_plural = int(element.split('=', 1)[1])
             elif element.startswith('plural='):
                 plural = element.split('=', 1)[1]
-                print "plural is now %s" % plural
+                print("plural is now %s" % plural)
     else:
         n_plural = 2
         plural = '(n == 1) ? 0 : 1'

--- a/appengine/standard/i18n/i18n_utils.py
+++ b/appengine/standard/i18n/i18n_utils.py
@@ -34,7 +34,7 @@ from webob import Request
 try:
     basestring
 except NameError:
-    basestring = basestring
+    basestring = str
 
 
 def _get_plural_forms(js_translations):

--- a/appengine/standard/i18n/i18n_utils.py
+++ b/appengine/standard/i18n/i18n_utils.py
@@ -21,7 +21,6 @@ Javascript is originally from an implementation of Django i18n.
 """
 from __future__ import print_function
 
-
 import gettext
 import json
 import os
@@ -31,6 +30,11 @@ import jinja2
 import webapp2
 
 from webob import Request
+
+try:
+    basestring
+except NameError:
+    basestring = basestring
 
 
 def _get_plural_forms(js_translations):
@@ -84,9 +88,9 @@ def convert_translations_to_dict(js_translations):
     for key, value in js_translations._catalog.items():
         if key == '':
             continue
-        if type(key) in (str, unicode):
+        if isinstance(key, basestring):
             translations_dict['catalog'][key] = value
-        elif type(key) == tuple:
+        elif isinstance(key, tuple):
             if key[0] not in translations_dict['catalog']:
                 translations_dict['catalog'][key[0]] = [''] * n_plural
             translations_dict['catalog'][key[0]][int(key[1])] = value

--- a/appengine/standard/i18n/i18n_utils.py
+++ b/appengine/standard/i18n/i18n_utils.py
@@ -54,7 +54,7 @@ def _get_plural_forms(js_translations):
         for l in js_translations._catalog[''].split('\n'):
             if l.startswith('Plural-Forms:'):
                 plural = l.split(':', 1)[1].strip()
-                print('plural is {}}'.format(plural))
+                print('plural is {}'.format(plural))
     if plural is not None:
         for raw_element in plural.split(';'):
             element = raw_element.strip()

--- a/appengine/standard/i18n/i18n_utils.py
+++ b/appengine/standard/i18n/i18n_utils.py
@@ -54,7 +54,7 @@ def _get_plural_forms(js_translations):
         for l in js_translations._catalog[''].split('\n'):
             if l.startswith('Plural-Forms:'):
                 plural = l.split(':', 1)[1].strip()
-                print("plural is %s" % plural)
+                print('plural is {}}'.format(plural))
     if plural is not None:
         for raw_element in plural.split(';'):
             element = raw_element.strip()
@@ -62,7 +62,7 @@ def _get_plural_forms(js_translations):
                 n_plural = int(element.split('=', 1)[1])
             elif element.startswith('plural='):
                 plural = element.split('=', 1)[1]
-                print("plural is now %s" % plural)
+                print('plural is now {}'.format(plural))
     else:
         n_plural = 2
         plural = '(n == 1) ? 0 : 1'

--- a/appengine/standard/mail/header.py
+++ b/appengine/standard/mail/header.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +41,7 @@ class SendMailHandler(webapp2.RequestHandler):
         </form></body></html>""")
 
     def post(self):
-        print repr(self.request.POST)
+        print(repr(self.request.POST))
         id = self.request.POST['thread_id']
         send_example_mail('{}@appspot.gserviceaccount.com'.format(
             app_identity.get_application_id()), id)

--- a/appengine/standard/ndb/properties/snippets.py
+++ b/appengine/standard/ndb/properties/snippets.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,4 +148,4 @@ class Part(ndb.Model):
 
 def print_part():
     p1 = Part(name='foo', color=Color.RED)
-    print p1.color  # prints "RED"
+    print(p1.color)  # prints "RED"

--- a/appengine/standard/ndb/queries/snippets_test.py
+++ b/appengine/standard/ndb/queries/snippets_test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -343,7 +344,7 @@ def test_fetch_message_accounts_inefficient(testbed):
 
     assert len(message_account_pairs) == 5
 
-    print repr(message_account_pairs)
+    print(repr(message_account_pairs))
     for i in range(1, 6):
         message, account = message_account_pairs[i - 1]
         assert message.content == 'Message %s' % i


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.