### PR TITLE
Add Cloud Run to Python Samples

### DIFF
--- a/.kokoro/presubmit_tests_run.cfg
+++ b/.kokoro/presubmit_tests_run.cfg
@@ -1,0 +1,15 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
+
+# Tell the trampoline which build file to use.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/python-docs-samples/.kokoro/system_tests.sh"
+}
+
+env_vars: {
+    key: "NOX_SESSION"
+    value: "run"
+}

--- a/run/README.md
+++ b/run/README.md
@@ -1,0 +1,90 @@
+# Google Cloud Run Python Samples
+
+[![Open in Cloud Shell][shell_img]][shell_link]
+
+[shell_img]: http://gstatic.com/cloudssh/images/open-btn.png
+[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/python-docs-samples&page=editor&open_in_editor=blog/README.md
+
+This directory contains samples for [Google Cloud Run](https://cloud.run). [Cloud Run][run_docs] runs stateless [containers](https://cloud.google.com/containers/) on a fully managed environment or in your own GKE cluster.
+
+## Samples
+
+|           Sample                |        Description       |     Deploy    |
+| ------------------------------- | ------------------------ | ------------- |
+|[Hello World][helloworld]&nbsp;&#10149; | Quickstart | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_helloworld] |
+|[Cloud Pub/Sub][pubsub] | Handling Pub/Sub push messages | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_pubsub] |
+
+For more Cloud Run samples beyond Python, see the main list in the [Cloud Run Samples repository](https://github.com/GoogleCloudPlatform/cloud-run-samples).
+
+## Setup
+
+1. [Set up for Cloud Run development](https://cloud.google.com/run/docs/setup)
+
+2. Clone this repository:
+
+    ```
+    git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+    ```
+
+    Note: Some samples in the list above are hosted in other repositories. They are noted with the symbol "&#10149;".
+
+
+## How to run a sample locally
+
+1. [Install docker locally](https://docs.docker.com/install/)
+
+2. [Build the sample container](https://cloud.google.com/run/docs/building/containers#building_locally_and_pushing_using_docker):
+
+    ```
+    export SAMPLE=$sample
+    cd $SAMPLE
+    docker build --tag $sample .
+    ```
+
+3. [Run containers locally](https://cloud.google.com/run/docs/testing/local)
+
+    With the built container:
+
+    ```
+    PORT=8080 && docker run --rm -p 8080:${PORT} -e PORT=${PORT} $SAMPLE
+    ```
+
+    Overriding the built container with local code:
+
+    ```
+    PORT=8080 && docker run --rm \
+        -p 8080:${PORT} -e PORT=${PORT} \
+        -v $PWD:/app $SAMPLE
+    ```
+
+    Injecting your service account key:
+
+    ```
+    export SA_KEY_NAME=my-key-name-123
+    PORT=8080 && docker run --rm \
+        -p 8080:${PORT} -e PORT=${PORT} \
+        -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/${SA_KEY_NAME}.json \
+        -v $GOOGLE_APPLICATION_CREDENTIALS:/tmp/keys/${SA_KEY_NAME}.json:ro \
+        -v $PWD:/app $SAMPLE
+    ```
+
+## Deploying
+
+```
+gcloud builds submit --tag gcr.io/${GOOGLE_CLOUD_PROJECT}/${SAMPLE}
+gcloud beta run deploy $SAMPLE \
+  # Needed for Manual Logging sample.
+  --set-env-var GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}
+  --image gcr.io/${GOOGLE_CLOUD_PROJECT}/${SAMPLE}
+```
+
+See [Building containers][run_build] and [Deploying container images][run_deploy]
+for more information.
+
+[run_docs]: https://cloud.google.com/run/docs/
+[run_build]: https://cloud.google.com/run/docs/building/containers
+[run_deploy]: https://cloud.google.com/run/docs/deploying
+[helloworld]: https://github.com/knative/docs/tree/master/docs/serving/samples/hello-world/helloworld-python
+[pubsub]: pubsub/
+[run_button_helloworld]: https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/knative/docs&cloudshell_working_dir=docs/serving/samples/hello-world/helloworld-python
+[run_button_pubsub]: https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/python-docs-samples&cloudshell_working_dir=run/pubsub

--- a/run/pubsub/.dockerignore
+++ b/run/pubsub/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+__pycache__
+.pytest_cache

--- a/run/pubsub/.gcloudignore
+++ b/run/pubsub/.gcloudignore
@@ -1,0 +1,2 @@
+.pytest_cache
+__pycache__

--- a/run/pubsub/.gitignore
+++ b/run/pubsub/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.pytest_cache

--- a/run/pubsub/Dockerfile
+++ b/run/pubsub/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2019 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START run_pubsub_dockerfile]
+
+# Use the official Python image.
+# https://hub.docker.com/_/python
+FROM python:3.7
+
+# Copy application dependency manifests to the container image.
+# Copying this separately prevents re-running pip install on every code change.
+COPY requirements.txt ./
+
+# Install production dependencies.
+RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . .
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 main:app
+
+# [END run_pubsub_dockerfile]

--- a/run/pubsub/README.md
+++ b/run/pubsub/README.md
@@ -1,0 +1,32 @@
+# Cloud Run Pub/Sub Tutorial Sample
+
+This sample shows how to create a service that processes Pub/Sub messages.
+
+Use it with the [Cloud Pub/Sub with Cloud Run tutorial](http://cloud.google.com/run/docs/tutorials/pubsub).
+
+## Build
+
+```
+docker build --tag pubsub-tutorial:python .
+```
+
+## Run
+
+```
+docker run --rm -p 9090:8080 pubsub-tutorial:python
+```
+
+## Test
+
+```
+pytest
+```
+
+_Note: you may need to install `pytest` using `pip install pytest`._
+
+## Deploy
+
+```
+gcloud builds submit --tag gcr.io/${GOOGLE_CLOUD_PROJECT}/pubsub-tutorial
+gcloud alpha run deploy pubsub-tutorial --image gcr.io/${GOOGLE_CLOUD_PROJECT}/pubsub-tutorial
+```

--- a/run/pubsub/README.md
+++ b/run/pubsub/README.md
@@ -10,7 +10,7 @@ Use it with the [Cloud Pub/Sub with Cloud Run tutorial](http://cloud.google.com/
 docker build --tag pubsub-tutorial:python .
 ```
 
-## Run
+## Run Locally
 
 ```
 docker run --rm -p 9090:8080 pubsub-tutorial:python

--- a/run/pubsub/main.py
+++ b/run/pubsub/main.py
@@ -1,0 +1,54 @@
+# Copyright 2019 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START run_pubsub_server_setup]
+import base64
+from flask import Flask, request
+import os
+
+app = Flask(__name__)
+# [END run_pubsub_server_setup]
+
+
+# [START run_pubsub_handler]
+@app.route('/', methods=['POST'])
+def index():
+    envelope = request.get_json()
+    if not envelope:
+        msg = 'no Pub/Sub message received'
+        print(f'error: {msg}')
+        return f'Bad Request: {msg}', 400
+
+    if not isinstance(envelope, dict) or 'message' not in envelope:
+        msg = 'invalid Pub/Sub message format'
+        print(f'error: {msg}')
+        return f'Bad Request: {msg}', 400
+
+    pubsub_message = envelope['message']
+
+    name = 'World'
+    if isinstance(pubsub_message, dict) and 'data' in pubsub_message:
+        name = base64.b64decode(pubsub_message['data']).decode('utf-8').strip()
+
+    print(f'Hello {name}!')
+    return ('', 204)
+# [END run_pubsub_handler]
+
+
+if __name__ == '__main__':
+    PORT = int(os.getenv('PORT')) if os.getenv('PORT') else 8080
+
+    # This is used when running locally. Gunicorn is used to run the
+    # application on Cloud Run. See entrypoint in Dockerfile.
+    app.run(host='127.0.0.1', port=PORT, debug=True)

--- a/run/pubsub/main_test.py
+++ b/run/pubsub/main_test.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Google, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE:
+# These tests are unit tests that mock Pub/Sub.
+
+import base64
+from uuid import uuid4
+
+import pytest
+
+import main
+
+
+@pytest.fixture
+def client():
+    main.app.testing = True
+    return main.app.test_client()
+
+
+def test_empty_payload(client):
+    r = client.post('/', json='')
+    assert r.status_code == 400
+
+
+def test_invalid_payload(client):
+    r = client.post('/', json={'nomessage': 'invalid'})
+    assert r.status_code == 400
+
+
+def test_invalid_mimetype(client):
+    r = client.post('/', json="{ message: true }")
+    assert r.status_code == 400
+
+
+def test_minimally_valid_message(client, capsys):
+    r = client.post('/', json={'message': True})
+    assert r.status_code == 204
+
+    out, _ = capsys.readouterr()
+    assert 'Hello World!' in out
+
+
+def test_populated_message(client, capsys):
+    name = str(uuid4())
+    data = base64.b64encode(name.encode()).decode()
+
+    r = client.post('/', json={'message': {'data': data}})
+    assert r.status_code == 204
+
+    out, _ = capsys.readouterr()
+    assert f'Hello {name}!' in out

--- a/run/pubsub/requirements.txt
+++ b/run/pubsub/requirements.txt
@@ -1,0 +1,3 @@
+Flask==1.0.2
+pytest==4.3.1
+gunicorn==19.9.0


### PR DESCRIPTION
* Adds a Cloud Run section to the samples
* Introduces the Cloud Run + Cloud Pub/Sub sample app
* Adds Kokoro Presubmit checks for Cloud Run

Note: The Pub/Sub sample itself was written by @ace-n and I reviewed for product alignment.