### PR TITLE
Add exporter registration step in OpenCensus Stats quick start

### DIFF
--- a/opencensus/metrics_quickstart.py
+++ b/opencensus/metrics_quickstart.py
@@ -56,6 +56,9 @@ def main():
     print('Exporting stats to project "{}"'
           .format(exporter.options.project_id))
 
+    # Register exporter to the view manager.
+    stats.stats.view_manager.register_exporter(exporter)
+
     # Record 100 fake latency values between 0 and 5 seconds.
     for num in range(100):
         ms = random() * 5 * 1000


### PR DESCRIPTION
In current sample, no steps is written to register Stackdriver exporter to view manager. This is misleading sample in real world, and like [OpenCensus' document](http://localhost:1313/quickstart/python/metrics/#exporting-to-prometheus) it should show the step to register the exporter to reduce confusion.