### PR TITLE
BigQuery Storage: Update to use faster Arrow data format.

### DIFF
--- a/bigquery_storage/to_dataframe/requirements.txt
+++ b/bigquery_storage/to_dataframe/requirements.txt
@@ -1,6 +1,6 @@
 google-auth==1.6.2
-google-cloud-bigquery-storage==0.3.0
-google-cloud-bigquery==1.11.1
-fastavro==0.21.17
+google-cloud-bigquery-storage==0.6.0
+google-cloud-bigquery==1.17.0
+pyarrow==0.13.0
 ipython==7.2.0
-pandas==0.24.0
+pandas==0.24.2


### PR DESCRIPTION
Requires `google-cloud-bigquery` 1.17.0.