### PR TITLE
Fix "delete_full_collection" snippet

### DIFF
--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -802,7 +802,7 @@ def delete_full_collection():
 
     # [START delete_full_collection]
     def delete_collection(coll_ref, batch_size):
-        docs = coll_ref.limit(10).stream()
+        docs = coll_ref.limit(batch_size).stream()
         deleted = 0
 
         for doc in docs:


### PR DESCRIPTION
Query limit is incorrectly set to 10 instead of `batch_size`. 

[Java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/b9f7749ba2755c9bf3e8ea1ec1fd581a67b6d1b0/firestore/src/main/java/com/example/firestore/snippets/ManageDataSnippets.java#L309-L330) or [Go](https://github.com/GoogleCloudPlatform/golang-samples/blob/862f0c0569fb13c2f2fee5ec20579ce3887736ba/firestore/firestore_snippets/save.go#L261-L298) implementations use the correct batchSize value.