### PR TITLE
[IAM] Add client initialization to each access.py sample  

### DIFF
--- a/iam/api-client/access.py
+++ b/iam/api-client/access.py
@@ -29,6 +29,7 @@ import googleapiclient.discovery
 # [START iam_get_policy]
 def get_policy(project_id):
     """Gets IAM policy for a project."""
+
     # pylint: disable=no-member
     credentials = service_account.Credentials.from_service_account_file(
     filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
@@ -45,6 +46,7 @@ def get_policy(project_id):
 # [START iam_modify_policy_add_member]
 def modify_policy_add_member(policy, role, member):
     """Adds a new member to a role binding."""
+
     credentials = service_account.Credentials.from_service_account_file(
     filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
     scopes=['https://www.googleapis.com/auth/cloud-platform'])
@@ -62,6 +64,7 @@ def modify_policy_add_member(policy, role, member):
 # [START iam_modify_policy_add_role]
 def modify_policy_add_role(policy, role, member):
     """Adds a new role binding to a policy."""
+
     credentials = service_account.Credentials.from_service_account_file(
     filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
     scopes=['https://www.googleapis.com/auth/cloud-platform'])
@@ -81,6 +84,7 @@ def modify_policy_add_role(policy, role, member):
 # [START iam_set_policy]
 def set_policy(project_id, policy):
     """Sets IAM policy for a project."""
+
     # pylint: disable=no-member
     credentials = service_account.Credentials.from_service_account_file(
     filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],

--- a/iam/api-client/access.py
+++ b/iam/api-client/access.py
@@ -26,19 +26,15 @@ import os
 from google.oauth2 import service_account
 import googleapiclient.discovery
 
-
-credentials = service_account.Credentials.from_service_account_file(
-    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
-    scopes=['https://www.googleapis.com/auth/cloud-platform'])
-service = googleapiclient.discovery.build(
-    'cloudresourcemanager', 'v1', credentials=credentials)
-
-
 # [START iam_get_policy]
 def get_policy(project_id):
     """Gets IAM policy for a project."""
-
     # pylint: disable=no-member
+    credentials = service_account.Credentials.from_service_account_file(
+    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
+    scopes=['https://www.googleapis.com/auth/cloud-platform'])
+    service = googleapiclient.discovery.build(
+        'cloudresourcemanager', 'v1', credentials=credentials)
     policy = service.projects().getIamPolicy(
         resource=project_id, body={}).execute()
     print(policy)
@@ -49,6 +45,13 @@ def get_policy(project_id):
 # [START iam_modify_policy_add_member]
 def modify_policy_add_member(policy, role, member):
     """Adds a new member to a role binding."""
+    credentials = service_account.Credentials.from_service_account_file(
+    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
+    scopes=['https://www.googleapis.com/auth/cloud-platform'])
+    service = googleapiclient.discovery.build(
+        'cloudresourcemanager', 'v1', credentials=credentials)
+
+
     binding = next(b for b in policy['bindings'] if b['role'] == role)
     binding['members'].append(member)
     print(binding)
@@ -59,6 +62,12 @@ def modify_policy_add_member(policy, role, member):
 # [START iam_modify_policy_add_role]
 def modify_policy_add_role(policy, role, member):
     """Adds a new role binding to a policy."""
+    credentials = service_account.Credentials.from_service_account_file(
+    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
+    scopes=['https://www.googleapis.com/auth/cloud-platform'])
+    service = googleapiclient.discovery.build(
+        'cloudresourcemanager', 'v1', credentials=credentials)
+
     binding = {
         'role': role,
         'members': [member]
@@ -72,8 +81,13 @@ def modify_policy_add_role(policy, role, member):
 # [START iam_set_policy]
 def set_policy(project_id, policy):
     """Sets IAM policy for a project."""
-
     # pylint: disable=no-member
+    credentials = service_account.Credentials.from_service_account_file(
+    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
+    scopes=['https://www.googleapis.com/auth/cloud-platform'])
+    service = googleapiclient.discovery.build(
+        'cloudresourcemanager', 'v1', credentials=credentials)
+
     policy = service.projects().setIamPolicy(
         resource=project_id, body={
             'policy': policy

--- a/iam/api-client/access.py
+++ b/iam/api-client/access.py
@@ -26,14 +26,15 @@ import os
 from google.oauth2 import service_account
 import googleapiclient.discovery
 
+
 # [START iam_get_policy]
 def get_policy(project_id):
     """Gets IAM policy for a project."""
 
     # pylint: disable=no-member
     credentials = service_account.Credentials.from_service_account_file(
-    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
-    scopes=['https://www.googleapis.com/auth/cloud-platform'])
+        filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
+        scopes=['https://www.googleapis.com/auth/cloud-platform'])
     service = googleapiclient.discovery.build(
         'cloudresourcemanager', 'v1', credentials=credentials)
     policy = service.projects().getIamPolicy(
@@ -47,13 +48,6 @@ def get_policy(project_id):
 def modify_policy_add_member(policy, role, member):
     """Adds a new member to a role binding."""
 
-    credentials = service_account.Credentials.from_service_account_file(
-    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
-    scopes=['https://www.googleapis.com/auth/cloud-platform'])
-    service = googleapiclient.discovery.build(
-        'cloudresourcemanager', 'v1', credentials=credentials)
-
-
     binding = next(b for b in policy['bindings'] if b['role'] == role)
     binding['members'].append(member)
     print(binding)
@@ -64,12 +58,6 @@ def modify_policy_add_member(policy, role, member):
 # [START iam_modify_policy_add_role]
 def modify_policy_add_role(policy, role, member):
     """Adds a new role binding to a policy."""
-
-    credentials = service_account.Credentials.from_service_account_file(
-    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
-    scopes=['https://www.googleapis.com/auth/cloud-platform'])
-    service = googleapiclient.discovery.build(
-        'cloudresourcemanager', 'v1', credentials=credentials)
 
     binding = {
         'role': role,
@@ -87,8 +75,8 @@ def set_policy(project_id, policy):
 
     # pylint: disable=no-member
     credentials = service_account.Credentials.from_service_account_file(
-    filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
-    scopes=['https://www.googleapis.com/auth/cloud-platform'])
+        filename=os.environ['GOOGLE_APPLICATION_CREDENTIALS'],
+        scopes=['https://www.googleapis.com/auth/cloud-platform'])
     service = googleapiclient.discovery.build(
         'cloudresourcemanager', 'v1', credentials=credentials)
 


### PR DESCRIPTION
Initializes a `cloudresourcemanager` client in each snippet.

Reason: received a bug report where a user tried to call these functions on an IAM API client, not a ResourceManager client. This sample code lives in the IAM docs, so not being clear about which API is used here could be confusing. 