### PR TITLE
Adjust Cloud Firestore update_doc_array snippet to not require an extra import

### DIFF
--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -15,7 +15,6 @@ import datetime
 from time import sleep
 
 from google.cloud import firestore
-from google.cloud.firestore_v1 import ArrayRemove, ArrayUnion
 import google.cloud.exceptions
 
 
@@ -319,10 +318,10 @@ def update_doc_array():
     city_ref = db.collection(u'cities').document(u'DC')
 
     # Atomically add a new region to the 'regions' array field.
-    city_ref.update({u'regions': ArrayUnion([u'greater_virginia'])})
+    city_ref.update({u'regions': firestore.ArrayUnion([u'greater_virginia'])})
 
     # // Atomically remove a region from the 'regions' array field.
-    city_ref.update({u'regions': ArrayRemove([u'east_coast'])})
+    city_ref.update({u'regions': firestore.ArrayRemove([u'east_coast'])})
     # [END fs_update_doc_array]
     city = city_ref.get()
     print(u'Updated the regions field of the DC. {}'.format(city.to_dict()))


### PR DESCRIPTION
Some readers were tripping over how to resolve the import of ArrayUnion and ArrayRemove, see:

https://github.com/googleapis/google-cloud-python/issues/8792
https://stackoverflow.com/questions/57219705/unable-to-import-fieldvalue-arrayunion/57226431#57226431