### PR TITLE
Update main.py

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/main.py
+++ b/cloud-sql/mysql/sqlalchemy/main.py
@@ -43,7 +43,7 @@ db = sqlalchemy.create_engine(
         password=db_pass,
         database=db_name,
         query={
-            'unix_socket': '/cloudsql/{}/'.format(cloud_sql_connection_name)
+            'unix_socket': '/cloudsql/{}'.format(cloud_sql_connection_name)
         }
     ),
     # ... Specify additional properties here.


### PR DESCRIPTION
Wrong format of 'unix_socket inside the query parameter in sqlalchemy.create_engine.
Doing:
  '/cloudsql/{}/'.format(cloud_sql_connection_name)
takes the path as a direcytory, the ending slash needs to be removed:
    '/cloudsql/{}'.format(cloud_sql_connection_name)