### PR TITLE
BigQuery: Add sample for explicitly creating client from service acco…

### DIFF
--- a/bigquery/cloud-client/authenticate_service_account.py
+++ b/bigquery/cloud-client/authenticate_service_account.py
@@ -1,0 +1,52 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START bigquery_client_json_credentials]
+from google.cloud import bigquery
+from google.oauth2 import service_account
+# [END bigquery_client_json_credentials]
+
+
+def authenticate(key_path):
+    # [START bigquery_client_json_credentials]
+    # TODO(developer): Set key_path to the path to the service account key
+    #                  file.
+    # key_path = "path/to/service_account.json"
+
+    credentials = service_account.Credentials.from_service_account_file(
+        key_path,
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+    # [END bigquery_client_json_credentials]
+    return credentials
+
+
+def create_client(credentials):
+    # [START bigquery_client_json_credentials]
+    client = bigquery.Client(
+        credentials=credentials,
+        project=credentials.project_id,
+    )
+    # [END bigquery_client_json_credentials]
+    return client
+
+
+def main():
+    import os
+    credentials = authenticate(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
+    create_client(credentials)
+
+
+if __name__ == "__main__":
+    main()

--- a/bigquery/cloud-client/authenticate_service_account.py
+++ b/bigquery/cloud-client/authenticate_service_account.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 
-def authenticate(key_path):
+
+def main():
+    key_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
     # [START bigquery_client_json_credentials]
+    from google.cloud import bigquery
     from google.oauth2 import service_account
 
     # TODO(developer): Set key_path to the path to the service account key
@@ -25,13 +30,6 @@ def authenticate(key_path):
         key_path,
         scopes=["https://www.googleapis.com/auth/cloud-platform"],
     )
-    # [END bigquery_client_json_credentials]
-    return credentials
-
-
-def create_client(credentials):
-    # [START bigquery_client_json_credentials]
-    from google.cloud import bigquery
 
     client = bigquery.Client(
         credentials=credentials,
@@ -39,12 +37,6 @@ def create_client(credentials):
     )
     # [END bigquery_client_json_credentials]
     return client
-
-
-def main():
-    import os
-    credentials = authenticate(os.environ["GOOGLE_APPLICATION_CREDENTIALS"])
-    create_client(credentials)
 
 
 if __name__ == "__main__":

--- a/bigquery/cloud-client/authenticate_service_account.py
+++ b/bigquery/cloud-client/authenticate_service_account.py
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START bigquery_client_json_credentials]
-from google.cloud import bigquery
-from google.oauth2 import service_account
-# [END bigquery_client_json_credentials]
-
 
 def authenticate(key_path):
     # [START bigquery_client_json_credentials]
+    from google.oauth2 import service_account
+
     # TODO(developer): Set key_path to the path to the service account key
     #                  file.
     # key_path = "path/to/service_account.json"
@@ -34,6 +31,8 @@ def authenticate(key_path):
 
 def create_client(credentials):
     # [START bigquery_client_json_credentials]
+    from google.cloud import bigquery
+
     client = bigquery.Client(
         credentials=credentials,
         project=credentials.project_id,

--- a/bigquery/cloud-client/authenticate_service_account_test.py
+++ b/bigquery/cloud-client/authenticate_service_account_test.py
@@ -25,6 +25,9 @@ def mock_credentials(*args, **kwargs):
 
 
 def test_main(monkeypatch):
-    monkeypatch.setattr('google.oauth2.service_account.Credentials.from_service_account_file', mock_credentials)
+    monkeypatch.setattr(
+        'google.oauth2.service_account.Credentials.from_service_account_file',
+        mock_credentials,
+    )
     client = authenticate_service_account.main()
     assert client is not None

--- a/bigquery/cloud-client/authenticate_service_account_test.py
+++ b/bigquery/cloud-client/authenticate_service_account_test.py
@@ -17,9 +17,14 @@ import google.auth
 import authenticate_service_account
 
 
-def test_create_client():
+def mock_credentials(*args, **kwargs):
     credentials, _ = google.auth.default(
         ["https://www.googleapis.com/auth/cloud-platform"]
     )
-    client = authenticate_service_account.create_client(credentials)
+    return credentials
+
+
+def test_main(monkeypatch):
+    monkeypatch.setattr('google.oauth2.service_account.Credentials.from_service_account_file', mock_credentials)
+    client = authenticate_service_account.main()
     assert client is not None

--- a/bigquery/cloud-client/authenticate_service_account_test.py
+++ b/bigquery/cloud-client/authenticate_service_account_test.py
@@ -1,0 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import google.auth
+
+import authenticate_service_account
+
+
+def test_create_client():
+    credentials, _ = google.auth.default(["https://www.googleapis.com/auth/cloud-platform"])
+    client = authenticate_service_account.create_client(credentials)
+    assert client is not None

--- a/bigquery/cloud-client/authenticate_service_account_test.py
+++ b/bigquery/cloud-client/authenticate_service_account_test.py
@@ -18,6 +18,8 @@ import authenticate_service_account
 
 
 def test_create_client():
-    credentials, _ = google.auth.default(["https://www.googleapis.com/auth/cloud-platform"])
+    credentials, _ = google.auth.default(
+        ["https://www.googleapis.com/auth/cloud-platform"]
+    )
     client = authenticate_service_account.create_client(credentials)
     assert client is not None


### PR DESCRIPTION
…unt credentials.

We got some feedback that we don't show how to use an explicit credentials argument in our BigQuery authentication samples. We prefer using the credentials argument over using the `Client.from_service_account_json`, as an explicit `credentials` argument gives a better indication for how to construct a client with other credentials types as well.