### PR TITLE
fixing translate-with-glossary bug

### DIFF
--- a/translate/cloud-client/beta_snippets.py
+++ b/translate/cloud-client/beta_snippets.py
@@ -269,7 +269,7 @@ def translate_text_with_glossary(project_id, glossary_id, text):
         target_language_code='es',
         glossary_config=glossary_config)
 
-    for translation in result.translations:
+    for translation in result.glossary_translations:
         print(translation)
     # [END translate_translate_text_with_glossary_beta]
 

--- a/translate/cloud-client/beta_snippets_test.py
+++ b/translate/cloud-client/beta_snippets_test.py
@@ -120,9 +120,9 @@ def test_list_glossary(capsys, glossary):
 
 def test_translate_text_with_glossary(capsys, glossary):
     beta_snippets.translate_text_with_glossary(
-            PROJECT_ID, glossary, 'directions')
+            PROJECT_ID, glossary, 'account')
     out, _ = capsys.readouterr()
-    assert 'direcciones' in out
+    assert 'cuenta' in out
 
 
 def test_delete_glossary(capsys, unique_glossary_id):


### PR DESCRIPTION
@beccasaurus 

now: translate-with-glossary prints the translations that use a glossary
previously: translate-with-glossary printed translations that didn't use a glossary