### PR TITLE
Revert "fixing translate-with-glossary bug (#2323)"

### DIFF
--- a/translate/cloud-client/beta_snippets.py
+++ b/translate/cloud-client/beta_snippets.py
@@ -269,7 +269,7 @@ def translate_text_with_glossary(project_id, glossary_id, text):
         target_language_code='es',
         glossary_config=glossary_config)
 
-    for translation in result.glossary_translations:
+    for translation in result.translations:
         print(translation)
     # [END translate_translate_text_with_glossary_beta]
 

--- a/translate/cloud-client/beta_snippets_test.py
+++ b/translate/cloud-client/beta_snippets_test.py
@@ -120,9 +120,9 @@ def test_list_glossary(capsys, glossary):
 
 def test_translate_text_with_glossary(capsys, glossary):
     beta_snippets.translate_text_with_glossary(
-            PROJECT_ID, glossary, 'account')
+            PROJECT_ID, glossary, 'directions')
     out, _ = capsys.readouterr()
-    assert 'cuenta' in out
+    assert 'direcciones' in out
 
 
 def test_delete_glossary(capsys, unique_glossary_id):


### PR DESCRIPTION
This reverts commit 1cf4d1f61047a56d253f98daa3481a930b0c3d53.

This reverts this merged PR:
https://github.com/GoogleCloudPlatform/python-docs-samples/pull/2323

I got a notification the tests failed after this was merged:
```
eta_snippets_test.py::test_translate_text FAILED                        [  6%]
beta_snippets_test.py::test_batch_translate_text PASSED                  [ 12%]
beta_snippets_test.py::test_detect_language PASSED                       [ 18%]
beta_snippets_test.py::test_list_languages PASSED                        [ 25%]
beta_snippets_test.py::test_list_languages_with_target PASSED            [ 31%]
beta_snippets_test.py::test_create_glossary PASSED                       [ 37%]
beta_snippets_test.py::test_get_glossary PASSED                          [ 43%]
beta_snippets_test.py::test_list_glossary PASSED                         [ 50%]
beta_snippets_test.py::test_translate_text_with_glossary PASSED          [ 56%]
beta_snippets_test.py::test_delete_glossary PASSED                       [ 62%]
quickstart_test.py::test_quickstart PASSED                               [ 68%]
snippets_test.py::test_detect_language PASSED                            [ 75%]
snippets_test.py::test_list_languages PASSED                             [ 81%]
snippets_test.py::test_list_languages_with_target PASSED                 [ 87%]
snippets_test.py::test_translate_text PASSED                             [ 93%]
snippets_test.py::test_translate_utf8 FAILED                             [100%]
=================================== FAILURES ===================================
_____________________________ test_translate_text ______________________________
Traceback (most recent call last):
  File "/home/travis/build/GoogleCloudPlatform/python-docs-samples/translate/cloud-client/beta_snippets_test.py", line 66, in test_translate_text
    assert 'Zdravo svet' in out
AssertionError: assert 'Zdravo svet' in 'Translated Text: translated_text: "Pozdrav svijetu"\n\n'
_____________________________ test_translate_utf8 ______________________________
Traceback (most recent call last):
  File "/home/travis/build/GoogleCloudPlatform/python-docs-samples/translate/cloud-client/snippets_test.py", line 49, in test_translate_utf8
    assert u'I like pineapples.' in out
AssertionError: assert 'I like pineapples.' in 'Text: 나는 파인애플을 좋아한다.\nTranslation: I like pineapple\nDetected source language: ko\n'
--------------------------- Captured stdout teardown ---------------------------
Deleted: projects/python-docs-samples-tests/locations/us-central1/glossaries/must-start-with-letters-21d8cbd4-ba2e-11e9-90a2-42010a140244
- generated xml file: /home/travis/build/GoogleCloudPlatform/python-docs-samples/translate/cloud-client/sponge_log.xml -
==================== 2 failed, 14 passed in 175.01 seconds =====================
```

The PR was green and therefore appeared safe to merge.

@nnegrey Any chance you could take a closer look w/ @ecrowdus?

In the meantime, this will revert the failing change, although it looks like a second translation test failed too 😕 ~ Use this PR if useful