### PR TITLE
Fix Spanner `BOOL` example after upstream typo fix

### DIFF
--- a/spanner/cloud-client/snippets.py
+++ b/spanner/cloud-client/snippets.py
@@ -1207,7 +1207,7 @@ def query_data_with_bool(instance_id, database_id):
         'outdoor_venue': exampleBool
     }
     param_type = {
-        'outdoor_venue': param_types.BOOE
+        'outdoor_venue': param_types.BOOL
     }
 
     with database.snapshot() as snapshot:


### PR DESCRIPTION
Summary:
This code used to be correct, when the Spanner Python API had a typo in
the parameter name, but that typo was fixed in an upstream pull request:
<https://github.com/googleapis/google-cloud-python/pull/7295>

Test Plan:
Running `git grep BOOE` now returns no results.

wchargin-branch: bool-not-booe