### PR TITLE
Use latest esp docker image with tag 1

### DIFF
--- a/endpoints/kubernetes/grpc-bookstore.yaml
+++ b/endpoints/kubernetes/grpc-bookstore.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
       - name: esp
-        image: gcr.io/endpoints-release/endpoints-runtime:1.16.0
+        image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
           "--http2_port=9000",
           "--service=SERVICE_NAME",


### PR DESCRIPTION
Otherwise, many users still using very old ESP image 1.16.0

Tag "1" is always points to the latest ESP image