### PR TITLE
Add note for high volume push requests

### DIFF
--- a/pubsub/cloud-client/publisher.py
+++ b/pubsub/cloud-client/publisher.py
@@ -207,9 +207,8 @@ def publish_messages_with_batch_settings(project_id, topic_name):
     # Configure the batch to publish as soon as there is one kilobyte
     # of data or one second has passed.
     batch_settings = pubsub_v1.types.BatchSettings(
-        # max_bytes=1024,  # One kilobyte
-        # max_latency=1,   # One second
-        max_messages = 5,
+        max_bytes=1024,  # One kilobyte
+        max_latency=1,   # One second
     )
     publisher = pubsub_v1.PublisherClient(batch_settings)
     topic_path = publisher.topic_path(project_id, topic_name)

--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -182,7 +182,6 @@ def receive_messages(project_id, subscription_name):
 
     def callback(message):
         print('Received message: {}'.format(message))
-        print(message.message_id)
         message.ack()
 
     subscriber.subscribe(subscription_path, callback=callback)


### PR DESCRIPTION
Using `id_token.verify_oauth2_token` isn't always ideal, especially when the volume of push requests is high. 

Adding a note to tell our users about best practices. 