### PR TITLE
Pub/Sub to GCS using Dataflow Tutorial

### DIFF
--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -5,30 +5,69 @@ import logging
 import apache_beam as beam
 import apache_beam.transforms.window as window
 from apache_beam.options.pipeline_options import PipelineOptions
-from apache_beam.options.pipeline_options import SetupOptions
-from apache_beam.options.pipeline_options import StandardOptions
 
 
 class ProcessDoFn(beam.DoFn):
+    """A distributed processing function that acts on individual elements in
+    the PCollection.
+    """
+
     def process(self, element, publish_time=beam.DoFn.TimestampParam):
+        """Enrich each Pub/Sub message with its publish timestamps.
+
+        Args:
+            element (bytestring): Pub/Sub message.
+            publish_time: Default to the publish timestamp from Pub/Sub.
+
+        Yields:
+            str: Message body and publish timestamp.
+        """
         publish_time = datetime.datetime.utcfromtimestamp(
             float(publish_time)).strftime("%Y-%m-%d %H:%M:%S.%f")
         yield element.decode('utf-8') + ' published at ' + publish_time
 
 
-class CustomDoFn(beam.DoFn):
+class OutputDoFn(beam.DoFn):
+
     def __init__(self, output_path):
         self.output_path = output_path
 
     def process(self, batch, window=beam.DoFn.WindowParam):
-        ts_format = '%Y-%m-%d %H:%M:%S'
+        """Write each batch in its own file to a Google Cloud Storage bucket.
+
+        Args:
+            batch (list of bytestring): list of enriched Pub/Sub messages.
+            window: Window info that has been bound to each batch.
+        """
+
+        ts_format = '%H:%M'
         window_start = window.start.to_utc_datetime().strftime(ts_format)
         window_end = window.end.to_utc_datetime().strftime(ts_format)
-        filename = self.output_path + ' ' + window_start + ' to ' + window_end
+        filename = '-'.join([self.output_path, window_start, window_end])
         contents = '\n'.join(str(element) for element in batch)
 
         with beam.io.gcp.gcsio.GcsIO().open(filename=filename, mode='w') as f:
             f.write(contents.encode('utf-8'))
+
+
+class ApplyWindowing(beam.PTransform):
+    """A composite transform that enriches Pub/Sub messages by their publish
+    timestamps and groups them by timed windows.
+    """
+
+    def __init__(self, window_size):
+        # Convert minutes into seconds.
+        self.window_size = int(window_size * 60)
+
+    def expand(self, pcoll):
+        return (pcoll
+                # Assigns each element in the PCollection to a time interval.
+                | beam.WindowInto(window.FixedWindows(self.window_size))
+                # Add publish timestamps to each element.
+                | 'Process Pub/Sub Message' >> beam.ParDo(ProcessDoFn())
+                | 'Add Empty Key' >> beam.Map(lambda elem: (None, elem))
+                | 'Groupby' >> beam.GroupByKey()
+                | 'Remove Key' >> beam.MapTuple(lambda key, val: val))
 
 
 def run(argv=None):
@@ -39,29 +78,27 @@ def run(argv=None):
               '"projects/<PROJECT_NAME>/topics/<TOPIC_NAME>".'))
     parser.add_argument(
         '--window_size',
-        type=int,
-        default=1,
+        type=float,
+        default=1.0,
         help=('Output file\'s window size in number of minutes.'))
     parser.add_argument(
         '--output_path',
         help=('GCS Path of the output file including filename prefix.'))
     known_args, pipeline_args = parser.parse_known_args(argv)
 
-    # One or more DoFn's rely on global context.
-    pipeline_options = PipelineOptions(pipeline_args)
-    pipeline_options.view_as(SetupOptions).save_main_session = True
-    pipeline_options.view_as(StandardOptions).streaming = True
+    # `save_main_session` is True because one or more DoFn's rely on
+    # globally imported modules.
+    pipeline_options = PipelineOptions(pipeline_args,
+                                       streaming=True,
+                                       save_main_session=True)
 
-    with beam.Pipeline(options=pipeline_options) as p:
-        (p
-            | 'Read Pub/Sub Messages' >> beam.io.ReadFromPubSub(
-                topic=known_args.input_topic)
-            | beam.WindowInto(window.FixedWindows(known_args.window_size*60))
-            | beam.ParDo(ProcessDoFn())
-            | beam.Map(lambda e: (None, e))
-            | beam.GroupByKey()
-            | beam.MapTuple(lambda k, v: v)
-            | 'Write to GCS' >> beam.ParDo(CustomDoFn(known_args.output_path)))
+    with beam.Pipeline(options=pipeline_options) as pipeline:
+        (pipeline
+        | 'Read PubSub Messages' >> beam.io.ReadFromPubSub(
+            topic=known_args.input_topic)
+        | 'Window into' >> ApplyWindowing(known_args.window_size)
+        | 'Write to GCS' >> beam.ParDo(OutputDoFn(known_args.output_path)))
+
 
 if __name__ == '__main__': # noqa
     logging.getLogger().setLevel(logging.INFO)

--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -60,7 +60,7 @@ class AddTimestamps(beam.DoFn):
         """
 
         yield {
-            'message_body': json.loads(element),
+            'message_body': element.decode('utf-8'),
             'publish_time': datetime.datetime.utcfromtimestamp(
                 float(publish_time)).strftime("%Y-%m-%d %H:%M:%S.%f"),
         }
@@ -80,8 +80,7 @@ class WriteBatchesToGCS(beam.DoFn):
         filename = '-'.join([self.output_path, window_start, window_end])
 
         with beam.io.gcp.gcsio.GcsIO().open(filename=filename, mode='w') as f:
-            for element in batch:
-                f.write('{}\n'.format(json.dumps(element).encode('utf-8')))
+            f.write(json.dumps(batch).encode('utf-8'))
 
 
 def run(input_topic, output_path, window_size=1.0, pipeline_args=None):

--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import json
 import logging
 
 import apache_beam as beam
@@ -7,52 +8,9 @@ import apache_beam.transforms.window as window
 from apache_beam.options.pipeline_options import PipelineOptions
 
 
-class ProcessDoFn(beam.DoFn):
-    """A distributed processing function that acts on individual elements in
-    the PCollection.
-    """
-
-    def process(self, element, publish_time=beam.DoFn.TimestampParam):
-        """Enrich each Pub/Sub message with its publish timestamps.
-
-        Args:
-            element (bytestring): Pub/Sub message.
-            publish_time: Default to the publish timestamp from Pub/Sub.
-
-        Yields:
-            str: Message body and publish timestamp.
-        """
-        publish_time = datetime.datetime.utcfromtimestamp(
-            float(publish_time)).strftime("%Y-%m-%d %H:%M:%S.%f")
-        yield element.decode('utf-8') + ' published at ' + publish_time
-
-
-class OutputDoFn(beam.DoFn):
-
-    def __init__(self, output_path):
-        self.output_path = output_path
-
-    def process(self, batch, window=beam.DoFn.WindowParam):
-        """Write each batch in its own file to a Google Cloud Storage bucket.
-
-        Args:
-            batch (list of bytestring): list of enriched Pub/Sub messages.
-            window: Window info that has been bound to each batch.
-        """
-
-        ts_format = '%H:%M'
-        window_start = window.start.to_utc_datetime().strftime(ts_format)
-        window_end = window.end.to_utc_datetime().strftime(ts_format)
-        filename = '-'.join([self.output_path, window_start, window_end])
-        contents = '\n'.join(str(element) for element in batch)
-
-        with beam.io.gcp.gcsio.GcsIO().open(filename=filename, mode='w') as f:
-            f.write(contents.encode('utf-8'))
-
-
-class ApplyWindowing(beam.PTransform):
-    """A composite transform that enriches Pub/Sub messages by their publish
-    timestamps and groups them by timed windows.
+class GroupWindowsIntoBatches(beam.PTransform):
+    """A composite transform that enriches Pub/Sub messages by publish
+    timestamps and then groups them based on their window information.
     """
 
     def __init__(self, window_size):
@@ -61,32 +19,81 @@ class ApplyWindowing(beam.PTransform):
 
     def expand(self, pcoll):
         return (pcoll
-                # Assigns each element in the PCollection to a time interval.
+                # Assigns window info to each element in the PCollection.
                 | beam.WindowInto(window.FixedWindows(self.window_size))
-                # Add publish timestamps to each element.
-                | 'Process Pub/Sub Message' >> beam.ParDo(ProcessDoFn())
-                | 'Add Empty Key' >> beam.Map(lambda elem: (None, elem))
+                # Transform each element by adding publish timestamp info.
+                | 'Process Pub/Sub Message' >> (beam.ParDo(AddTimestamps()))
+                # Use a dummy key to group all the elements in this window.
+                | 'Add Dummy Key' >> beam.Map(lambda elem: (None, elem))
                 | 'Groupby' >> beam.GroupByKey()
-                | 'Remove Key' >> beam.MapTuple(lambda key, val: val))
+                | 'Abandon Dummy Key' >> beam.MapTuple(lambda _, val: val))
+
+
+class AddTimestamps(beam.DoFn):
+    """A distributed processing function that acts on the elements in
+    the PCollection.
+    """
+
+    def process(self, element, publish_time=beam.DoFn.TimestampParam):
+        """Enrich each Pub/Sub message with its publish timestamp.
+
+        Args:
+            element (bytes): A Pub/Sub message.
+            publish_time: Default to the publish timestamp returned by the
+            Pub/Sub server that's been bound to the message by Apache Beam
+            at runtime.
+
+        Yields:
+            dict of str: Message body and publish timestamp.
+        """
+
+        yield {
+            'message_body': json.loads(element),
+            'publish_time': datetime.datetime.utcfromtimestamp(
+                float(publish_time)).strftime("%Y-%m-%d %H:%M:%S.%f"),
+        }
+
+
+class WriteBatchesToGCS(beam.DoFn):
+
+    def __init__(self, output_path):
+        self.output_path = output_path
+
+    def process(self, batch, window=beam.DoFn.WindowParam):
+        """Write one batch per file to a Google Cloud Storage bucket.
+
+        Args:
+            batch (list of dict): Each dictionary contains one message and its
+            publish timestamp.
+            window: Window inforamtion bound to the batch.
+        """
+
+        ts_format = '%H:%M'
+        window_start = window.start.to_utc_datetime().strftime(ts_format)
+        window_end = window.end.to_utc_datetime().strftime(ts_format)
+        filename = '-'.join([self.output_path, window_start, window_end])
+
+        with beam.io.gcp.gcsio.GcsIO().open(filename=filename, mode='w') as f:
+            f.write(json.dumps(batch).encode('utf-8'))
 
 
 def run(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--input_topic',
-        help=('The Cloud Pub/Sub topic to read from.'
-              '"projects/<PROJECT_NAME>/topics/<TOPIC_NAME>".'))
+        help='The Cloud Pub/Sub topic to read from.\n'
+             '"projects/<PROJECT_NAME>/topics/<TOPIC_NAME>".')
     parser.add_argument(
         '--window_size',
         type=float,
         default=1.0,
-        help=('Output file\'s window size in number of minutes.'))
+        help='Output file\'s window size in number of minutes.')
     parser.add_argument(
         '--output_path',
-        help=('GCS Path of the output file including filename prefix.'))
+        help='GCS Path of the output file including filename prefix.')
     known_args, pipeline_args = parser.parse_known_args(argv)
 
-    # `save_main_session` is True because one or more DoFn's rely on
+    # `save_main_session` is set to true because one or more DoFn's rely on
     # globally imported modules.
     pipeline_options = PipelineOptions(pipeline_args,
                                        streaming=True,
@@ -96,8 +103,9 @@ def run(argv=None):
         (pipeline
          | 'Read PubSub Messages' >> beam.io.ReadFromPubSub(
              topic=known_args.input_topic)
-         | 'Window into' >> ApplyWindowing(known_args.window_size)
-         | 'Write to GCS' >> beam.ParDo(OutputDoFn(known_args.output_path)))
+         | 'Window into' >> GroupWindowsIntoBatches(known_args.window_size)
+         | 'Write to GCS' >> beam.ParDo(
+             WriteBatchesToGCS(known_args.output_path)))
 
 
 if __name__ == '__main__': # noqa

--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import logging
 
 import apache_beam as beam
@@ -6,6 +7,28 @@ import apache_beam.transforms.window as window
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.options.pipeline_options import StandardOptions
+
+
+class ProcessDoFn(beam.DoFn):
+    def process(self, element, publish_time=beam.DoFn.TimestampParam):
+        publish_time = datetime.datetime.utcfromtimestamp(
+            float(publish_time)).strftime("%Y-%m-%d %H:%M:%S.%f")
+        yield element.decode('utf-8') + ' published at ' + publish_time
+
+
+class CustomDoFn(beam.DoFn):
+    def __init__(self, output_path):
+        self.output_path = output_path
+
+    def process(self, batch, window=beam.DoFn.WindowParam):
+        ts_format = '%Y-%m-%d %H:%M:%S'
+        window_start = window.start.to_utc_datetime().strftime(ts_format)
+        window_end = window.end.to_utc_datetime().strftime(ts_format)
+        filename = self.output_path + ' ' + window_start + ' to ' + window_end
+        contents = '\n'.join(str(element) for element in batch)
+
+        with beam.io.gcp.gcsio.GcsIO().open(filename=filename, mode='w') as f:
+            f.write(contents.encode('utf-8'))
 
 
 def run(argv=None):
@@ -28,26 +51,17 @@ def run(argv=None):
     pipeline_options = PipelineOptions(pipeline_args)
     pipeline_options.view_as(SetupOptions).save_main_session = True
     pipeline_options.view_as(StandardOptions).streaming = True
-    p = beam.Pipeline(options=pipeline_options)
 
-    # Read from Cloud Pub/Sub into a PCollection.
-    if known_args.input_topic:
-        messages = (p
-                    | 'Read Pub/Sub Messages' >> beam.io.ReadFromPubSub(
-                        topic=known_args.input_topic)
-                    .with_output_types(bytes))
-
-    # Group messages by fixed-sized minute intervals.
-    transformed = (messages
-                   | beam.WindowInto(
-                       window.FixedWindows(known_args.window_size))
-                   .with_output_types(bytes))
-
-    # Output to GCS
-    transformed | beam.io.WriteToText(file_path_prefix=known_args.output_path)
-
-    result = p.run()
-    result.wait_until_finish()
+    with beam.Pipeline(options=pipeline_options) as p:
+        (p
+            | 'Read Pub/Sub Messages' >> beam.io.ReadFromPubSub(
+                topic=known_args.input_topic)
+            | beam.WindowInto(window.FixedWindows(known_args.window_size*60))
+            | beam.ParDo(ProcessDoFn())
+            | beam.Map(lambda e: (None, e))
+            | beam.GroupByKey()
+            | beam.MapTuple(lambda k, v: v)
+            | 'Write to GCS' >> beam.ParDo(CustomDoFn(known_args.output_path)))
 
 if __name__ == '__main__': # noqa
     logging.getLogger().setLevel(logging.INFO)

--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -94,10 +94,10 @@ def run(argv=None):
 
     with beam.Pipeline(options=pipeline_options) as pipeline:
         (pipeline
-        | 'Read PubSub Messages' >> beam.io.ReadFromPubSub(
-            topic=known_args.input_topic)
-        | 'Window into' >> ApplyWindowing(known_args.window_size)
-        | 'Write to GCS' >> beam.ParDo(OutputDoFn(known_args.output_path)))
+         | 'Read PubSub Messages' >> beam.io.ReadFromPubSub(
+             topic=known_args.input_topic)
+         | 'Window into' >> ApplyWindowing(known_args.window_size)
+         | 'Write to GCS' >> beam.ParDo(OutputDoFn(known_args.output_path)))
 
 
 if __name__ == '__main__': # noqa

--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google Inc.
+# Copyright 2019 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -1,0 +1,54 @@
+import argparse
+import logging
+
+import apache_beam as beam
+import apache_beam.transforms.window as window
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.options.pipeline_options import StandardOptions
+
+
+def run(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--input_topic',
+        help=('The Cloud Pub/Sub topic to read from.'
+              '"projects/<PROJECT_NAME>/topics/<TOPIC_NAME>".'))
+    parser.add_argument(
+        '--window_size',
+        type=int,
+        default=1,
+        help=('Output file\'s window size in number of minutes.'))
+    parser.add_argument(
+        '--output_path',
+        help=('GCS Path of the output file including filename prefix.'))
+    known_args, pipeline_args = parser.parse_known_args(argv)
+
+    # One or more DoFn's rely on global context.
+    pipeline_options = PipelineOptions(pipeline_args)
+    pipeline_options.view_as(SetupOptions).save_main_session = True
+    pipeline_options.view_as(StandardOptions).streaming = True
+    p = beam.Pipeline(options=pipeline_options)
+
+    # Read from Cloud Pub/Sub into a PCollection.
+    if known_args.input_topic:
+        messages = (p
+                    | 'Read Pub/Sub Messages' >> beam.io.ReadFromPubSub(
+                        topic=known_args.input_topic)
+                    .with_output_types(bytes))
+
+    # Group messages by fixed-sized minute intervals.
+    transformed = (messages
+                   | beam.WindowInto(
+                       window.FixedWindows(known_args.window_size))
+                   .with_output_types(bytes))
+
+    # Output to GCS
+    transformed | beam.io.WriteToText(file_path_prefix=known_args.output_path)
+
+    result = p.run()
+    result.wait_until_finish()
+
+if __name__ == '__main__': # noqa
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/pubsub/streaming-analytics/PubSubToGCS.py
+++ b/pubsub/streaming-analytics/PubSubToGCS.py
@@ -80,7 +80,8 @@ class WriteBatchesToGCS(beam.DoFn):
         filename = '-'.join([self.output_path, window_start, window_end])
 
         with beam.io.gcp.gcsio.GcsIO().open(filename=filename, mode='w') as f:
-            f.write(json.dumps(batch).encode('utf-8'))
+            for element in batch:
+                f.write('{}\n'.format(json.dumps(element)).encode('utf-8'))
 
 
 def run(input_topic, output_path, window_size=1.0, pipeline_args=None):

--- a/pubsub/streaming-analytics/PubSubToGCS_test.py
+++ b/pubsub/streaming-analytics/PubSubToGCS_test.py
@@ -88,7 +88,6 @@ def test_run(publisher_client, topic_path):
     # Check for output files on GCS.
     assert sp.call(['gsutil', 'ls', 'gs://{}/pubsub/'.format(BUCKET)]) == 0
 
-    # Clean up. Delete topic. Delete files.
-    assert sp.call(['gcloud', 'pubsub', 'topics', 'delete', TOPIC]) == 0
+    # Clean up. Delete files.
     assert sp.call(['gsutil', '-m', 'rm', '-rf',
                     'gs://{}/pubsub/'.format(BUCKET)]) == 0

--- a/pubsub/streaming-analytics/PubSubToGCS_test.py
+++ b/pubsub/streaming-analytics/PubSubToGCS_test.py
@@ -1,0 +1,94 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing as mp
+import os
+import pytest
+import subprocess as sp
+import time
+
+from google.cloud import pubsub_v1
+
+
+PROJECT = os.environ['GCLOUD_PROJECT']
+BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
+TOPIC = 'test-topic'
+
+
+@pytest.fixture
+def publisher_client():
+    yield pubsub_v1.PublisherClient()
+
+
+@pytest.fixture
+def topic_path(publisher_client):
+    topic_path = publisher_client.topic_path(PROJECT, TOPIC)
+
+    try:
+        publisher_client.delete_topic(topic_path)
+    except Exception:
+        pass
+
+    response = publisher_client.create_topic(topic_path)
+    yield response.name
+
+
+def _infinite_publish_job(publisher_client, topic_path):
+    while True:
+        future = publisher_client.publish(
+            topic_path, data='Hello World!'.encode('utf-8'))
+        future.result()
+        time.sleep(10)
+
+
+def test_run(publisher_client, topic_path):
+    """This is antegration test that runs `PubSubToGCS.py` in its entirety.
+    It checks for output files on GCS.
+    """
+
+    # Use one process to publish messages to a topic.
+    publish_process = mp.Process(
+        target=lambda: _infinite_publish_job(publisher_client, topic_path))
+
+    # Use another process to run the streaming pipeline that should write one
+    # file to GCS every minute (according to the default window size).
+    pipeline_process = mp.Process(
+        target=lambda: sp.call([
+            'python', 'PubSubToGCS.py',
+            '--project', PROJECT,
+            '--runner', 'DirectRunner',
+            '--temp_location', 'gs://{}/pubsub/temp'.format(BUCKET),
+            '--input_topic', topic_path,
+            '--output_path', 'gs://{}/pubsub/output'.format(BUCKET),
+        ])
+    )
+
+    publish_process.start()
+    pipeline_process.start()
+
+    # Times out the streaming pipeline after 90 seconds.
+    pipeline_process.join(timeout=90)
+    # Immediately kills the publish process after the pipeline shuts down.
+    publish_process.join(timeout=0)
+
+    pipeline_process.terminate()
+    publish_process.terminate()
+
+    # Check for output files on GCS.
+    assert sp.call(['gsutil', 'ls', 'gs://{}/pubsub/'.format(BUCKET)]) == 0
+
+    # Clean up. Delete topic. Delete files.
+    assert sp.call(['gcloud', 'pubsub', 'topics', 'delete', TOPIC]) == 0
+    assert sp.call(['gsutil', '-m', 'rm', '-rf',
+                    'gs://{}/pubsub/'.format(BUCKET)]) == 0

--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -106,7 +106,7 @@ The following example will run a streaming pipeline. It will read messages from 
 + `--output`: sets the output GCS path prefix to write files to
 + `--runner [optional]`: specifies the runner to run the pipeline, defaults to `DirectRunner`
 + `--windowSize [optional]`: specifies the window size in minutes, defaults to 1
-+ `--temp_location`: needed for execution of the pipeline
++ `--temp_location`: needed for executing the pipeline
 
 ```bash
 python -m PubSubToGCS -W ignore \
@@ -165,11 +165,6 @@ gsutil ls gs://$BUCKET_NAME/samples/
 [Creating and managing service accounts]: https://cloud.google.com/iam/docs/creating-managing-service-accounts
 [GCP Console IAM page]: https://console.cloud.google.com/iam-admin/iam
 [Granting roles to service accounts]: https://cloud.google.com/iam/docs/granting-roles-to-service-accounts
-
-[Java Development Kit (JDK)]: https://www.oracle.com/technetwork/java/javase/downloads/index.html
-[JAVA_HOME]: https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars001.html
-[Apache Maven]: http://maven.apache.org/download.cgi
-[Maven installation guide]: http://maven.apache.org/install.html
 
 [GCP Console create Dataflow job page]: https://console.cloud.google.com/dataflow/createjob
 [GCP Console Dataflow page]: https://console.cloud.google.com/dataflow

--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -1,0 +1,174 @@
+# Stream Cloud Pub/Sub with Cloud Dataflow
+
+Sample(s) showing how to use [Google Cloud Pub/Sub] with [Google Cloud Dataflow].
+
+## Before you begin
+
+1. Install the [Cloud SDK].
+
+1. [Create a new project].
+
+1. [Enable billing].
+
+1. [Enable the APIs](https://console.cloud.google.com/flows/enableapi?apiid=dataflow,compute_component,logging,storage_component,storage_api,pubsub,cloudresourcemanager.googleapis.com,cloudscheduler.googleapis.com,appengine.googleapis.com): Dataflow, Compute Engine, Stackdriver Logging, Cloud Storage, Cloud Storage JSON, Pub/Sub, Cloud Scheduler, Cloud Resource Manager, and App Engine.
+
+1. Setup the Cloud SDK to your GCP project.
+
+   ```bash
+   gcloud init
+   ```
+
+1. [Create a service account key] as a JSON file.
+   For more information, see [Creating and managing service accounts].
+
+   * From the **Service account** list, select **New service account**.
+   * In the **Service account name** field, enter a name.
+   * From the **Role** list, select **Project > Owner**.
+
+     > **Note**: The **Role** field authorizes your service account to access resources.
+     > You can view and change this field later by using the [GCP Console IAM page].
+     > If you are developing a production app, specify more granular permissions than **Project > Owner**.
+     > For more information, see [Granting roles to service accounts].
+
+   * Click **Create**. A JSON file that contains your key downloads to your computer.
+
+1. Set your `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to your service account key file.
+
+   ```bash
+   export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credentials.json
+   ```
+
+1. Create a Cloud Storage bucket.
+
+   ```bash
+   BUCKET_NAME=your-gcs-bucket
+   PROJECT_NAME=$(gcloud config get-value project)
+
+   gsutil mb gs://$BUCKET_NAME
+   ```
+
+ 1. Start a [Google Cloud Scheduler] job that publishes one message to a [Google Cloud Pub/Sub] topic every minute. This will create an [App Engine] app if one has never been created on the project.
+
+    ```bash
+    # Create a Pub/Sub topic.
+    gcloud pubsub topics create cron-topic
+
+    # Create a Cloud Scheduler job
+    gcloud scheduler jobs create pubsub publisher-job --schedule="* * * * *" \
+      --topic=cron-topic --message-body="Hello!"
+
+    # Run the job.
+    gcloud scheduler jobs run publisher-job
+    ```
+
+## Setup
+
+The following instructions will help you prepare your development environment.
+
+1. [Install Python and virtualenv.](https://cloud.google.com/python/setup)
+
+1. Clone the `python-docs-samples` repository.
+
+    ```bash
+    git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+    ```
+
+1. Navigate to the sample code directory.
+
+   ```bash
+   cd python-docs-samples/pubsub/streaming-analytics
+   ```
+
+1. Create a virtual environment and activate it.
+
+  ```bash
+  virtualenv env
+  source env/bin/activate
+  ```
+  > Once you are finished with the tutorial, you can deactivate the virtualenv and go back to your global Python environment by running `deactivate`.
+
+1. Install the sample requirements.
+
+  ```bash
+  pip install -U -r requirements.txt
+  ```
+
+## Streaming Analytics
+
+### Google Cloud Pub/Sub to Google Cloud Storage
+
+* [PubSubToGCS.py](PubSubToGCS.py)
+
+The following example will run a streaming pipeline. It will read messages from a Pub/Sub topic, then window them into fixed-sized intervals, and write one file per window into a GCS location.
+
++ `--project`: sets the Google Cloud project ID to run the pipeline on
++ `--inputTopic`: sets the input Pub/Sub topic to read messages from
++ `--output`: sets the output GCS path prefix to write files to
++ `--runner [optional]`: specifies the runner to run the pipeline, defaults to `DirectRunner`
++ `--windowSize [optional]`: specifies the window size in minutes, defaults to 1
+
+```bash
+python PubSubToGCS.py \
+  --project=$PROJECT_NAME \
+  --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \
+  --output=gs://$BUCKET_NAME/samples/output \
+  --runner=DataflowRunner \
+  --windowSize=2
+```
+
+After the job has been submitted, you can check its status in the [GCP Console Dataflow page].
+
+You can also check the output to your GCS bucket using the command line below or in the [GCP Console Storage page]. You may need to wait a few minutes for the files to appear.
+
+```bash
+gsutil ls gs://$BUCKET_NAME/samples/
+```
+
+## Cleanup
+
+1. Delete the [Google Cloud Scheduler] job.
+    ```bash
+    gcloud scheduler jobs delete publisher-job
+    ```
+
+1. `Ctrl+C` to stop the program in your terminal. Note that this does not actually stop the job if you use `DataflowRunner`. Skip 3 if you use the `DirectRunner`.
+
+1. Stop the Dataflow job in [GCP Console Dataflow page]. Cancel the job instead of draining it. This may take some minutes.
+
+1. Delete the topic. [Google Cloud Dataflow] will automatically delete the subscription associated with the streaming pipeline when the job is canceled.
+   ```bash
+   gcloud pubsub topics delete cron-topic
+   ```
+
+1. Lastly, to avoid incurring charges to your GCP account for the resources created in this tutorial:
+
+    ```bash
+    # Delete only the files created by this sample.
+    gsutil -m rm -rf "gs://$BUCKET_NAME/samples/output*"
+
+    # [optional] Remove the Cloud Storage bucket.
+    gsutil rb gs://$BUCKET_NAME
+    ```
+
+[Apache Beam]: https://beam.apache.org/
+[Google Cloud Pub/Sub]: https://cloud.google.com/pubsub/docs/
+[Google Cloud Dataflow]: https://cloud.google.com/dataflow/docs/
+[Google Cloud Scheduler]: https://cloud.google.com/scheduler/docs/
+[App Engine]: https://cloud.google.com/appengine/docs/
+
+[Cloud SDK]: https://cloud.google.com/sdk/docs/
+[Create a new project]: https://console.cloud.google.com/projectcreate
+[Enable billing]: https://cloud.google.com/billing/docs/how-to/modify-project
+[Create a service account key]: https://console.cloud.google.com/apis/credentials/serviceaccountkey
+[Creating and managing service accounts]: https://cloud.google.com/iam/docs/creating-managing-service-accounts
+[GCP Console IAM page]: https://console.cloud.google.com/iam-admin/iam
+[Granting roles to service accounts]: https://cloud.google.com/iam/docs/granting-roles-to-service-accounts
+
+[Java Development Kit (JDK)]: https://www.oracle.com/technetwork/java/javase/downloads/index.html
+[JAVA_HOME]: https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars001.html
+[Apache Maven]: http://maven.apache.org/download.cgi
+[Maven installation guide]: http://maven.apache.org/install.html
+
+[GCP Console create Dataflow job page]: https://console.cloud.google.com/dataflow/createjob
+[GCP Console Dataflow page]: https://console.cloud.google.com/dataflow
+[GCP Console Storage page]: https://console.cloud.google.com/storage

--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -109,10 +109,10 @@ The following example will run a streaming pipeline. It will read messages from 
 + `--temp_location`: needed for execution of the pipeline
 
 ```bash
-python -m PubSubToGCS \
+python -m PubSubToGCS -W ignore \
   --project=$PROJECT_NAME \
-  --input_topic=projects/$PROJECT_NAME/topics/june \
-  --output_path=gs://$BUCKET_NAME/labor \
+  --input_topic=projects/$PROJECT_NAME/topics/$TOPIC_NAME \
+  --output_path=gs://$BUCKET_NAME/june \
   --runner=DataflowRunner \
   --window_size=2 \
   --temp_location=gs://$BUCKET_NAME/temp \

--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -144,7 +144,7 @@ The following example will run a streaming pipeline. It will read messages from 
 + `--temp_location`: needed for executing the pipeline
 
 ```bash
-python -m PubSubToGCS -W ignore \
+python PubSubToGCS.py \
   --project=$PROJECT_NAME \
   --input_topic=projects/$PROJECT_NAME/topics/$TOPIC_NAME \
   --output_path=gs://$BUCKET_NAME/samples/output \

--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -112,11 +112,10 @@ The following example will run a streaming pipeline. It will read messages from 
 python -m PubSubToGCS -W ignore \
   --project=$PROJECT_NAME \
   --input_topic=projects/$PROJECT_NAME/topics/$TOPIC_NAME \
-  --output_path=gs://$BUCKET_NAME/june \
+  --output_path=gs://$BUCKET_NAME/samples/output \
   --runner=DataflowRunner \
   --window_size=2 \
-  --temp_location=gs://$BUCKET_NAME/temp \
-  --experiments=allow_non_updateable_job
+  --temp_location=gs://$BUCKET_NAME/temp
 ```
 
 After the job has been submitted, you can check its status in the [GCP Console Dataflow page].

--- a/pubsub/streaming-analytics/README.md
+++ b/pubsub/streaming-analytics/README.md
@@ -106,14 +106,17 @@ The following example will run a streaming pipeline. It will read messages from 
 + `--output`: sets the output GCS path prefix to write files to
 + `--runner [optional]`: specifies the runner to run the pipeline, defaults to `DirectRunner`
 + `--windowSize [optional]`: specifies the window size in minutes, defaults to 1
++ `--temp_location`: needed for execution of the pipeline
 
 ```bash
-python PubSubToGCS.py \
+python -m PubSubToGCS \
   --project=$PROJECT_NAME \
-  --inputTopic=projects/$PROJECT_NAME/topics/cron-topic \
-  --output=gs://$BUCKET_NAME/samples/output \
+  --input_topic=projects/$PROJECT_NAME/topics/june \
+  --output_path=gs://$BUCKET_NAME/labor \
   --runner=DataflowRunner \
-  --windowSize=2
+  --window_size=2 \
+  --temp_location=gs://$BUCKET_NAME/temp \
+  --experiments=allow_non_updateable_job
 ```
 
 After the job has been submitted, you can check its status in the [GCP Console Dataflow page].

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,0 +1,1 @@
+google-api-python-client==1.7.9

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,1 +1,1 @@
-apache-beam==2.15.0
+apache-beam[gcp]==2.15.0

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,2 +1,2 @@
 apache-beam[gcp]==2.15.0
-google-cloud-pubsub==1.0.0
+google-cloud-storage==1.19.0

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,1 +1,2 @@
 apache-beam[gcp]==2.15.0
+google-cloud-pubsub==1.0.0

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,2 +1,1 @@
-google-api-python-client==1.7.9
 apache-beam==2.15.0

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,1 +1,2 @@
 google-api-python-client==1.7.9
+apache-beam==2.15.0

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,2 +1,1 @@
 apache-beam[gcp]==2.15.0
-google-cloud-storage==1.19.0


### PR DESCRIPTION
~~Unable to merge until Apache Beam supports TextIO for Python/Streaming. Currently, only Pub/Sub to BigQuery is supported in Python. Check out their Build-in I/O Transforms table [here](https://beam.apache.org/documentation/io/built-in/).~~
_(Sorry @kir-titievsky I was wrong about this!)_

Streaming Pub/Sub to GCS using Dataflow Python Tutorial. 

~~@davidcavazos I have got lots of string encoding and decoding operations in the code. If you see a way to reduce redundancy, please let me know.~~

I will work on a separate PR to add Stream Pub/Sub to BigQuery using Dataflow. 