### PR TITLE
Add Python virtual environment directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ credentials.dat
 .vscode/
 *sponge_log.xml
 .DS_store
+env/


### PR DESCRIPTION
Add the commonly used Python virtualenv directory `env/` to the gitignore.