### PR TITLE
BigQuery: Update pandas/bqstorage samples to latest library changes.

### DIFF
--- a/bigquery/pandas-gbq-migration/requirements.txt
+++ b/bigquery/pandas-gbq-migration/requirements.txt
@@ -1,2 +1,5 @@
-google-cloud-bigquery[pandas,pyarrow]==1.9.0
-pandas-gbq==0.9.0
+google-cloud-bigquery==1.20.0
+google-cloud-bigquery-storage==0.7.0
+pandas==0.25.1
+pandas-gbq==0.11.0
+pyarrow==0.14.1

--- a/bigquery_storage/to_dataframe/jupyter_test.py
+++ b/bigquery_storage/to_dataframe/jupyter_test.py
@@ -75,9 +75,6 @@ def test_jupyter_small_query(ipython):
     assert "stackoverflow" in ip.user_ns  # verify that variable exists
 
 
-@pytest.mark.skipif(
-    "TRAVIS" in os.environ, reason="Not running long-running queries on Travis"
-)
 def test_jupyter_tutorial(ipython):
     ip = IPython.get_ipython()
     ip.extension_manager.load_extension("google.cloud.bigquery")
@@ -86,33 +83,18 @@ def test_jupyter_tutorial(ipython):
     # speed-up of using the BigQuery Storage API to download the results.
     sample = """
     # [START bigquerystorage_jupyter_tutorial_query]
-    %%bigquery nodejs_deps --use_bqstorage_api
-    SELECT
-        dependency_name,
-        dependency_platform,
-        project_name,
-        project_id,
-        version_number,
-        version_id,
-        dependency_kind,
-        optional_dependency,
-        dependency_requirements,
-        dependency_project_id
-    FROM
-        `bigquery-public-data.libraries_io.dependencies`
-    WHERE
-        LOWER(dependency_platform) = 'npm'
-    LIMIT 2500000
+    %%bigquery tax_forms --use_bqstorage_api
+    SELECT * FROM `bigquery-public-data.irs_990.irs_990_2012`
     # [END bigquerystorage_jupyter_tutorial_query]
     """
     result = ip.run_cell(_strip_region_tags(sample))
     result.raise_error()  # Throws an exception if the cell failed.
 
-    assert "nodejs_deps" in ip.user_ns  # verify that variable exists
-    nodejs_deps = ip.user_ns["nodejs_deps"]
+    assert "tax_forms" in ip.user_ns  # verify that variable exists
+    tax_forms = ip.user_ns["tax_forms"]
 
     # [START bigquerystorage_jupyter_tutorial_results]
-    nodejs_deps.head()
+    tax_forms.head()
     # [END bigquerystorage_jupyter_tutorial_results]
 
     # [START bigquerystorage_jupyter_tutorial_context]
@@ -123,26 +105,11 @@ def test_jupyter_tutorial(ipython):
 
     sample = """
     # [START bigquerystorage_jupyter_tutorial_query_default]
-    %%bigquery java_deps
-    SELECT
-        dependency_name,
-        dependency_platform,
-        project_name,
-        project_id,
-        version_number,
-        version_id,
-        dependency_kind,
-        optional_dependency,
-        dependency_requirements,
-        dependency_project_id
-    FROM
-        `bigquery-public-data.libraries_io.dependencies`
-    WHERE
-        LOWER(dependency_platform) = 'maven'
-    LIMIT 2500000
+    %%bigquery tax_forms
+    SELECT * FROM `bigquery-public-data.irs_990.irs_990_2012`
     # [END bigquerystorage_jupyter_tutorial_query_default]
     """
     result = ip.run_cell(_strip_region_tags(sample))
     result.raise_error()  # Throws an exception if the cell failed.
 
-    assert "java_deps" in ip.user_ns  # verify that variable exists
+    assert "tax_forms" in ip.user_ns  # verify that variable exists

--- a/bigquery_storage/to_dataframe/requirements.txt
+++ b/bigquery_storage/to_dataframe/requirements.txt
@@ -1,6 +1,6 @@
 google-auth==1.6.2
-google-cloud-bigquery-storage==0.6.0
-google-cloud-bigquery==1.17.0
-pyarrow==0.13.0
+google-cloud-bigquery-storage==0.7.0
+google-cloud-bigquery==1.20.0
+pyarrow==0.14.1
 ipython==7.2.0
-pandas==0.24.2
+pandas==0.25.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -167,7 +167,8 @@ PY2_ONLY_SAMPLES = GAE_STANDARD_SAMPLES
 PY3_ONLY_SAMPLES = [
     sample for sample in ALL_TESTED_SAMPLES
     if (sample.startswith('./appengine/standard_python37')
-        or sample.startswith('./functions/'))]
+        or sample.startswith('./functions/')
+        or sample.startswith('./bigquery/pandas-gbq-migration'))]
 NON_GAE_STANDARD_SAMPLES_PY2 = sorted(list((
     set(ALL_TESTED_SAMPLES) -
     set(GAE_STANDARD_SAMPLES)) -


### PR DESCRIPTION
* Show how to use BQ Storage API with pandas-gbq and magics.
* Update tests to actually run BQ Storage API on smaller IRS 990 table.