### PR TITLE
iam: remove extra spaces after region tag

### DIFF
--- a/iam/api-client/service_accounts.py
+++ b/iam/api-client/service_accounts.py
@@ -131,9 +131,8 @@ def disable_service_account(email):
     print("Disabled service account :" + email)
 # [END iam_disable_service_account]
 
+
 # [START iam_enable_service_account]
-
-
 def enable_service_account(email):
     """Enables a service account."""
 


### PR DESCRIPTION
There were a few extra spaces after the [START iam_enable_service_account] region tag.