### PR TITLE
Correctly restore connection if MySQL server has gone away

### DIFF
--- a/functions/sql/mysql_sample.py
+++ b/functions/sql/mysql_sample.py
@@ -46,11 +46,9 @@ def __get_cursor():
       PyMySQL does NOT automatically reconnect,
       so we must reconnect explicitly using ping()
     """
-    try:
-        return mysql_conn.cursor()
-    except OperationalError:
+    if not mysql_conn.open:
         mysql_conn.ping(reconnect=True)
-        return mysql_conn.cursor()
+    return mysql_conn.cursor()
 
 
 def mysql_demo(request):


### PR DESCRIPTION
Based on this code example I have created and deployed a cloud function, which connects over a socket to the Cloud SQL Instance.

I however noticed that it wasn't behaving correctly: after a while I was getting back the Exception `pymysql.err.InterfaceError: (0, '')` on each request.

Scrolling back in the logs of my cloud function I noticed that the Exception started getting thrown after the connection the MySQL server got lost:

<img width="1078" alt="Screenshot 2019-09-26 at 09 41 45" src="https://user-images.githubusercontent.com/213073/65764078-15f61880-e125-11e9-91dc-b8869a6ed426.png">

Note this error in the logs, after which the `pymysql.err.InterfaceError: (0, '')` Exceptions pop up:

```
pymysql.err.OperationalError: (2006, "MySQL server has gone away (BrokenPipeError(32, 'Broken pipe'))")
```
When redeploying the function everything worked fine again, but a day later the same issue occurred again.

I narrowed down the problem to the reconnection logic as copied from the code example. It does not correctly restore the connection when the connection gets lost.

Running the code locally with `cloud_sql_proxy`, it behaves like so:

> Response: OK (e.g. the current time as reported by the MySQL Server)
> Response: OK
> Response: OK
> 
> **(manually break pipe by killing cloud_sql_proxy)**
> 
> Response: pymysql.err.OperationalError: (2006, "MySQL server has gone away (BrokenPipeError(32, 'Broken pipe'))")
> Response: pymysql.err.InterfaceError: (0, '')
> Response: pymysql.err.InterfaceError: (0, '')
> Response: pymysql.err.InterfaceError: (0, '')
> Response: pymysql.err.InterfaceError: (0, '')
> 
> **(restore cloud_sql_proxy connection)**
> 
> Response: pymysql.err.InterfaceError: (0, '')
> Response: pymysql.err.InterfaceError: (0, '')
> Response: pymysql.err.InterfaceError: (0, '')

This is a reproduction of the behavior as seen when the function runs on GCP.

With the altered code from this PR, this is the behavior:

> Response: OK (e.g. the current time as reported by the MySQL Server)
> Response: OK
> Response: OK
> 
> **(manually break pipe by killing cloud_sql_proxy)**
> 
> Response: pymysql.err.OperationalError: (2006, "MySQL server has gone away (BrokenPipeError(32, 'Broken pipe'))")
> Response: pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'localhost' ([Errno 61] Connection refused)")
> Response: pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'localhost' ([Errno 61] Connection refused)")
> Response: pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'localhost' ([Errno 61] Connection refused)")
> Response: pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'localhost' ([Errno 61] Connection refused)")
> 
> **(manually restore cloud_sql_proxy connection)**
> 
> Response: OK
> Response: OK
> Response: OK
> Response: OK

As you can see the connection correctly restores after the socket has become available again.