### PR TITLE
fix wrong get_check_exists sample. No exception now

### DIFF
--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -218,10 +218,10 @@ def get_check_exists():
     # [START get_check_exists]
     doc_ref = db.collection(u'cities').document(u'SF')
 
-    try:
-        doc = doc_ref.get()
+    doc = doc_ref.get()
+    if doc.exists:
         print(u'Document data: {}'.format(doc.to_dict()))
-    except google.cloud.exceptions.NotFound:
+    else:
         print(u'No such document!')
     # [END get_check_exists]
 


### PR DESCRIPTION
PR as requested in https://github.com/GoogleCloudPlatform/python-docs-samples/issues/2261#issuecomment-537086484

There are no more exceptions when no document found in DocumentReference.get() call.

If the document does not exist at the time of the snapshot is taken, the snapshot’s reference, data, update_time, and create_time attributes will all be None and its exists attribute will be False.

https://googleapis.github.io/google-cloud-python/latest/firestore/document.html#google.cloud.firestore_v1.document.DocumentReference.get

Now issues https://github.com/googleapis/google-cloud-python/issues/4530 and https://github.com/googleapis/google-cloud-python/pull/4531 are resolved