### PR TITLE
cloud-sql: add Cloud Run support to sqlalchemy sample

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/.dockerignore
+++ b/cloud-sql/mysql/sqlalchemy/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.dockerignore
+__pycache__
+.pytest_cache

--- a/cloud-sql/mysql/sqlalchemy/.gitignore
+++ b/cloud-sql/mysql/sqlalchemy/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.pytest_cache

--- a/cloud-sql/mysql/sqlalchemy/Dockerfile
+++ b/cloud-sql/mysql/sqlalchemy/Dockerfile
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START run_pubsub_dockerfile]
-
 # Use the official Python image.
 # https://hub.docker.com/_/python
 FROM python:3.7
@@ -23,17 +21,17 @@ FROM python:3.7
 COPY requirements.txt ./
 
 # Install production dependencies.
-RUN pip install -r requirements.txt
+RUN set -ex; \
+    pip install -r requirements.txt; \
+    pip install gunicorn
 
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
 COPY . ./
 
-# Run the web service on container startup. 
-# Use gunicorn webserver with one worker process and 8 threads.
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
 CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 main:app
-
-# [END run_pubsub_dockerfile]

--- a/cloud-sql/mysql/sqlalchemy/README.md
+++ b/cloud-sql/mysql/sqlalchemy/README.md
@@ -75,3 +75,40 @@ Next, the following command will deploy the application to your Google Cloud pro
 ```bash
 gcloud app deploy
 ```
+
+## Deploy to Cloud Run
+
+See the [Cloud Run documentation](https://cloud.google.com/run/docs/configuring/connect-cloudsql)
+for more details on connecting a Cloud Run service to Cloud SQL.
+
+1. Build the container image:
+
+```sh
+gcloud builds submit --tag gcr.io/[YOUR_PROJECT_ID]/run-mysql
+```
+
+2. Deploy the service to Cloud Run:
+
+```sh
+gcloud beta run deploy run-mysql --image gcr.io/[YOUR_PROJECT_ID]/run-mysql
+```
+
+Take note of the URL output at the end of the deployment process.
+
+3. Configure the service for use with Cloud Run
+
+```sh
+gcloud beta run services update run-mysql \
+    --add-cloudsql-instances [INSTANCE_CONNECTION_NAME] \
+    --set-env-vars CLOUD_SQL_CONNECTION_NAME=[INSTANCE_CONNECTION_NAME],\
+      DB_USER=[MY_DB_USER],DB_PASS=[MY_DB_PASS],DB_NAME=[MY_DB]
+```
+Replace environment variables with the correct values for your Cloud SQL
+instance configuration.
+
+This step can be done as part of deployment but is separated for clarity.
+
+4. Navigate your browser to the URL noted in step 2.
+
+For more details about using Cloud Run see http://cloud.run.
+Review other [Python on Cloud Run samples](../../../run/).

--- a/run/README.md
+++ b/run/README.md
@@ -13,6 +13,7 @@ This directory contains samples for [Google Cloud Run](https://cloud.run). [Clou
 | ------------------------------- | ------------------------ | ------------- |
 |[Hello World][helloworld]&nbsp;&#10149; | Quickstart | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_helloworld] |
 |[Cloud Pub/Sub][pubsub] | Handling Pub/Sub push messages | [<img src="https://storage.googleapis.com/cloudrun/button.svg" alt="Run on Google Cloud" height="30">][run_button_pubsub] |
+|[Cloud SQL (MySQL)[mysql]        | Use MySQL with Cloud Run |      -        |
 
 For more Cloud Run samples beyond Python, see the main list in the [Cloud Run Samples repository](https://github.com/GoogleCloudPlatform/cloud-run-samples).
 
@@ -105,6 +106,7 @@ for more information.
 [run_deploy]: https://cloud.google.com/run/docs/deploying
 [helloworld]: https://github.com/knative/docs/tree/master/docs/serving/samples/hello-world/helloworld-python
 [pubsub]: pubsub/
+[mysql]: ../cloud-sql/mysql/sqlalchemy
 [run_button_helloworld]: https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/knative/docs&cloudshell_working_dir=docs/serving/samples/hello-world/helloworld-python
 [run_button_pubsub]: https://console.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_image=gcr.io/cloudrun/button&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/python-docs-samples&cloudshell_working_dir=run/pubsub
 [testing]: https://cloud.google.com/run/docs/testing/local#running_locally_using_docker_with_access_to_services


### PR DESCRIPTION
Add Cloud Run support to the Cloud SQL (MySQL) sample.
