### PR TITLE
Fix encoding of object names.

### DIFF
--- a/storage/signed_urls/generate_signed_urls.py
+++ b/storage/signed_urls/generate_signed_urls.py
@@ -30,6 +30,7 @@ import hashlib
 import sys
 
 # pip install six
+import six
 from six.moves.urllib.parse import quote
 
 # [START storage_signed_url_signer]
@@ -49,7 +50,7 @@ def generate_signed_url(service_account_file, bucket_name, object_name,
         sys.exit(1)
 
     # [START storage_signed_url_canonical_uri]
-    escaped_object_name = quote(object_name, safe='')
+    escaped_object_name = quote(six.ensure_binary(object_name), safe=b'/~')
     canonical_uri = '/{}/{}'.format(bucket_name, escaped_object_name)
     # [END storage_signed_url_canonical_uri]
 


### PR DESCRIPTION
Per the docs, the "/" character should not be escaped in the object name
portion of the signed URL.  Also, Python 2 and 3 differ on whether the
tilde character should be escaped by the url library's `quote` method,
so in order for our sample to work on both Python2 and Python3, we
should always specify the tilde as a "safe" character. For reference, we
already fixed this same bug in gsutil a few months ago:
https://github.com/GoogleCloudPlatform/gsutil/blob/4531874e3a3d45ca642fc9c9fa438ba58c8f1494/gslib/commands/signurl.py#L543