### PR TITLE
GSP195-Updates for Python3 in appengine/standard/hello_world folder

### DIFF
--- a/appengine/standard/hello_world/app.yaml
+++ b/appengine/standard/hello_world/app.yaml
@@ -1,7 +1,5 @@
-runtime: python27
-api_version: 1
-threadsafe: true
+runtime: python37
 
 handlers:
 - url: /.*
-  script: main.app
+  script: auto


### PR DESCRIPTION
- Removed api_version parameter in the app.yaml as it is incompatible with python 3.
- Removed threadsafe parameter in the app.yaml as it is incompatible with python 3.
- Updated the script handlers to auto parameter in app.yaml file.