### PR TITLE
chore(bigquery): remove redundant dependency on pytest

### DIFF
--- a/bigquery/bqml/requirements.txt
+++ b/bigquery/bqml/requirements.txt
@@ -1,4 +1,3 @@
 google-cloud-bigquery[pandas]==1.9.0
 flaky==3.5.3
 mock==2.0.0
-pytest==4.2.0


### PR DESCRIPTION
The BQML dependency on pytest is redundant with the central testing
dependencies. Removing this dependency resolves a `TypeError: attrib()
got an unexpected keyword argument 'convert'` test failure caused by
incompatible versions.