### PR TITLE
Make 'command' required argument for detect.py

### DIFF
--- a/vision/cloud-client/detect/detect.py
+++ b/vision/cloud-client/detect/detect.py
@@ -855,7 +855,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    subparsers = parser.add_subparsers(dest='command')
+    subparsers = parser.add_subparsers(dest='command', required=True)
 
     detect_faces_parser = subparsers.add_parser(
         'faces', help=detect_faces.__doc__)


### PR DESCRIPTION
### Traceback if no command specified:
```
Traceback (most recent call last):
  File "/usr/local/bin/detect", line 968, in <module>
    if 'uri' in args.command:
TypeError: argument of type 'NoneType' is not iterable
```

### Error message after adding `required=True`:
```
usage: detect [-h]
              {faces,faces-uri,labels,labels-uri,landmarks,landmarks-uri,text,text-uri,logos,logos-uri,safe-search,safe-search-uri,properties,properties-uri,web,web-uri,web-geo,web-geo-uri,crophints,crophints-uri,document,document-uri,ocr-uri,object-localization,object-localization-uri}
              ...
detect: error: the following arguments are required: command
```