### PR TITLE
Adding legacy-endpoint-access sample

### DIFF
--- a/compute/metadata/detect_legacy_usage.py
+++ b/compute/metadata/detect_legacy_usage.py
@@ -56,8 +56,8 @@ def legacy_callback(diff):
 
 
 def main():
-  wait_for_legacy_usage(legacy_callback)
+    wait_for_legacy_usage(legacy_callback)
 
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/compute/metadata/detect_legacy_usage.py
+++ b/compute/metadata/detect_legacy_usage.py
@@ -1,0 +1,53 @@
+import json
+import requests
+import time
+
+METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1/'
+METADATA_HEADERS = {'Metadata-Flavor': 'Google'}
+
+
+def wait_for_legacy_usage(callback):
+    url = METADATA_URL + 'instance/legacy-endpoint-access/'
+    last_etag = '0'
+    counts = {'0.1': 0, 'v1beta1': 0}
+    while True:
+        r = requests.get(
+            url,
+            params={
+                'last_etag': last_etag,
+                'recursive': True,
+                'wait_for_change': True
+            },
+            headers=METADATA_HEADERS)
+        if r.status_code == 503:  # Metadata server unavailable
+            print('Metadata server unavailable. Sleeping for 1 second.')
+            time.sleep(1)
+            continue
+        if r.status_code == 404:  # Feature not yet supported
+            print('Legacy endpoint access not yet supported. Sleeping for 1 hour.')
+            time.sleep(3600)
+            continue
+        r.raise_for_status()
+
+        last_etag = r.headers['etag']
+        access_info = json.loads(r.text)
+        if access_info != counts:
+            diff = {
+                ver: access_info[ver] - counts[ver] for ver in counts
+            }
+            counts = access_info
+            callback(diff)
+
+
+def legacy_callback(diff):
+    print(
+        'Since last message, {} new requests to 0.1 endpoints and {} new '
+        'requests to v1beta1 endpoints.'.format(diff['0.1'], diff['v1beta1']))
+
+
+def main():
+  wait_for_legacy_usage(legacy_callback)
+
+
+if __name__ == '__main__':
+  main()

--- a/compute/metadata/detect_legacy_usage_test.py
+++ b/compute/metadata/detect_legacy_usage_test.py
@@ -14,6 +14,7 @@ def execute_test(requests_mock, *responses):
     except StopIteration:
         return callback_mock
 
+
 @mock.patch('detect_legacy_usage.requests')
 @mock.patch('detect_legacy_usage.time')
 def test_metadata_server_unavailable(time_mock, requests_mock):
@@ -27,10 +28,11 @@ def test_metadata_server_unavailable(time_mock, requests_mock):
     assert time_mock.sleep.call_count == 1
     assert time_mock.sleep.call_args_list[0][0] == (1,)
 
+
 @mock.patch('detect_legacy_usage.requests')
 @mock.patch('detect_legacy_usage.time')
 def test_endpoint_does_not_exist(time_mock, requests_mock):
-    # legacy-endpoint-access endpoint unavailable (removed or not yet supported)
+    # legacy-endpoint-access url unavailable (removed or not yet supported)
     response_mock = mock.Mock()
     response_mock.status_code = 404
 
@@ -40,17 +42,18 @@ def test_endpoint_does_not_exist(time_mock, requests_mock):
     assert time_mock.sleep.call_count == 1
     assert time_mock.sleep.call_args_list[0][0] == (3600,)
 
+
 @mock.patch('detect_legacy_usage.requests')
 @mock.patch('detect_legacy_usage.time')
 def test_callback_called_on_change(time_mock, requests_mock):
-    #Response 1 has starting counts (should not trigger callback)
+    # Response 1 has starting counts (should not trigger callback)
     response1_data = {'0.1': 5, 'v1beta1': 10}
     response1_mock = mock.Mock()
     response1_mock.status_code = 200
     response1_mock.text = json.dumps(response1_data)
     response1_mock.headers = {'etag': '1'}
 
-     #Response 2 has different data
+    # Response 2 has different data
     response2_data = {'0.1': 6, 'v1beta1': 10}
     response2_mock = mock.Mock()
     response2_mock.status_code = 200
@@ -68,14 +71,14 @@ def test_callback_called_on_change(time_mock, requests_mock):
 @mock.patch('detect_legacy_usage.requests')
 @mock.patch('detect_legacy_usage.time')
 def test_callback_not_called_without_change(time_mock, requests_mock):
-    #Response 1 has starting counts (should not trigger callback)
+    # Response 1 has starting counts (should not trigger callback)
     response1_data = {'0.1': 5, 'v1beta1': 10}
     response1_mock = mock.Mock()
     response1_mock.status_code = 200
     response1_mock.text = json.dumps(response1_data)
     response1_mock.headers = {'etag': '1'}
 
-    #Response 2 has the same data (no change)
+    # Response 2 has the same data (no change)
     response2_mock = mock.Mock()
     response2_mock.status_code = 200
     response2_mock.text = json.dumps(response1_data)

--- a/compute/metadata/detect_legacy_usage_test.py
+++ b/compute/metadata/detect_legacy_usage_test.py
@@ -1,0 +1,56 @@
+import mock
+import requests
+import json
+
+import detect_legacy_usage
+
+@mock.patch('detect_legacy_usage.requests')
+@mock.patch('detect_legacy_usage.time')
+def test_wait_for_legacy_usage(time_mock, requests_mock):
+    #Response 1 is a 404
+    response1_mock = mock.Mock()
+    response1_mock.status_code = 404
+    #Response 2 is a 503
+    response2_mock = mock.Mock()
+    response2_mock.status_code = 503
+    #Response 3 is a 200 with no change (all 0s)
+    response3_data = {'0.1': 0, 'v1beta1': 0}
+    response3_mock = mock.Mock()
+    response3_mock.status_code = 200
+    response3_mock.text = json.dumps(response3_data)
+    response3_mock.headers = {'etag': 1}
+    #Response 4 is a 200 with different data
+    response4_data = {'0.1': 0, 'v1beta1': 1}
+    response4_mock = mock.Mock()
+    response4_mock.status_code = 200
+    response4_mock.text = json.dumps(response4_data)
+    response4_mock.headers = {'etag': 2}
+
+    #Response 5 has another change
+    response5_data = {'0.1': 1, 'v1beta1': 1}
+    response5_mock = mock.Mock()
+    response5_mock.status_code = 200
+    response5_mock.text = json.dumps(response5_data)
+    response5_mock.headers = {'etag': 3}
+
+    requests_mock.codes.ok = requests.codes.ok
+    #Repeat last response to make sure callback isn't called (no change)
+    requests_mock.get.side_effect = [
+        response1_mock, response2_mock, response3_mock, response4_mock,
+        response5_mock, response5_mock, StopIteration()]
+
+
+
+    callback_mock = mock.Mock()
+
+    try:
+        detect_legacy_usage.wait_for_legacy_usage(callback_mock)
+    except StopIteration:
+        pass
+
+    assert callback_mock.call_count == 2
+    assert callback_mock.call_args_list[0][0] == (response4_data,)
+    assert callback_mock.call_args_list[1][0] == ({'0.1': 1, 'v1beta1': 0},)
+    assert time_mock.sleep.call_count == 2
+    assert time_mock.sleep.call_args_list[0][0] == (3600,)
+    assert time_mock.sleep.call_args_list[1][0] == (1,)


### PR DESCRIPTION
Adding a sample showing how to use the new legacy-endpoint-access endpoint to detect usage of the legacy metadata endpoints.