### PR TITLE
Use latest 2.1.x Django to avoid PyMySql issue

### DIFF
--- a/appengine/standard_python37/django/requirements.txt
+++ b/appengine/standard_python37/django/requirements.txt
@@ -1,2 +1,2 @@
-Django==2.2.5
+Django==2.1.14
 PyMySQL==0.9.3


### PR DESCRIPTION
Django 2.2.5 checks the version number that PyMySql reports and does not accept it. The 2.1.14 version is up-to-date and does not have this problem.