### PR TITLE
Update Cloud SQL Proxy Docker Image.

### DIFF
--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -61,7 +61,7 @@ spec:
         - containerPort: 8080
 
       # [START proxy_container]
-      - image: gcr.io/cloudsql-docker/gce-proxy:1.05
+      - image: gcr.io/cloudsql-docker/gce-proxy:1.16
         name: cloudsql-proxy
         command: ["/cloud_sql_proxy", "--dir=/cloudsql",
                   "-instances=<your-cloudsql-connection-string>=tcp:5432",


### PR DESCRIPTION
Bumps the version to the latest Cloud SQL Proxy Docker Image to the latest version to be compatible with Postgres.

Resolves https://github.com/GoogleCloudPlatform/cloudsql-proxy/issues/328