### PR TITLE
Fix pubsub topic name format

### DIFF
--- a/healthcare/api-client/dicom/dicom_stores.py
+++ b/healthcare/api-client/dicom/dicom_stores.py
@@ -169,9 +169,8 @@ def patch_dicom_store(
 
     patch = {
         'notificationConfig': {
-            'pubsubTopic': 'projects/{}/locations/{}/topics/{}'.format(
+            'pubsubTopic': 'projects/{}/topics/{}'.format(
                 project_id,
-                cloud_region,
                 pubsub_topic)}}
 
     request = client.projects().locations().datasets().dicomStores().patch(


### PR DESCRIPTION
Apparently the patch API tolerated a bad format name until a few weeks ago, so this error was uncaught until now.