### PR TITLE
Enable Renovate bot.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "extends": [
+    "config:base"
+  ],
+  "labels": [
+    "kokoro:run"
+  ],
+  "prConcurrentLimit": 5,
+  "prCreation": "not-pending",
+  "rebaseStalePrs": true
+}


### PR DESCRIPTION
Merging this PR will enable Renovate once enabled. Uses the default setup, plus a few other things

* Adds "kokoro:run" to new renovate PRs (even if it's not useful yet)
* Limits 5 open PRs at once
* Opens PRs even if tests fail
* Rebases stale PRs automagically