### PR TITLE
Add second action in a comment to ensure correct syntax

### DIFF
--- a/dlp/risk.py
+++ b/dlp/risk.py
@@ -94,7 +94,10 @@ def numerical_risk_analysis(
     }
 
     # Tell the API where to send a notification when the job is complete.
-    actions = [{"pub_sub": {"topic": "{}/topics/{}".format(parent, topic_id)}}]
+    actions = [
+        {'pub_sub': {'topic': '{}/topics/{}'.format(parent, topic_id)}},
+       #  {'save_findings': {'output_config': {'table': {'project_id': 'dlapi-test','dataset_id':'ste1','table_id': 'pytest1'}}}
+    }]
 
     # Configure risk analysis job
     # Give the name of the numeric column to compute risk metrics for

--- a/dlp/risk.py
+++ b/dlp/risk.py
@@ -96,7 +96,7 @@ def numerical_risk_analysis(
     # Tell the API where to send a notification when the job is complete.
     actions = [
         {'pub_sub': {'topic': '{}/topics/{}'.format(parent, topic_id)}},
-       #  {'save_findings': {'output_config': {'table': {'project_id': 'dlapi-test','dataset_id':'ste1','table_id': 'pytest1'}}}
+        {'save_findings': {'output_config': {'table': {'project_id': 'test-project','dataset_id':'test-dataset','table_id': 'test-table'}}}
     }]
 
     # Configure risk analysis job


### PR DESCRIPTION
The actions syntax was confusing for a customer, so adding a dummy entry to make sure the syntax for usage is clearer to avoid this in the future.