### PR TITLE
add TIMESTAMP column to pandas upload example

### DIFF
--- a/.kokoro/python2.7/common.cfg
+++ b/.kokoro/python2.7/common.cfg
@@ -39,5 +39,5 @@ action {
 # Specify which tests to run
 env_vars: {
     key: "RUN_TESTS_SESSION"
-    value: "py2-2.7"
+    value: "py2"
 }

--- a/bigquery/pandas-gbq-migration/samples_test.py
+++ b/bigquery/pandas-gbq-migration/samples_test.py
@@ -216,6 +216,11 @@ def test_client_library_upload_from_dataframe(temp_dataset):
             'my_string': ['a', 'b', 'c'],
             'my_int64': [1, 2, 3],
             'my_float64': [4.0, 5.0, 6.0],
+            'my_timestamp': [
+                pandas.Timestamp("1998-09-04T16:03:14"),
+                pandas.Timestamp("2010-09-13T12:03:45"),
+                pandas.Timestamp("2015-10-02T16:00:00")
+            ],
         }
     )
     client = bigquery.Client()
@@ -254,6 +259,11 @@ def test_pandas_gbq_upload_from_dataframe(temp_dataset):
             'my_string': ['a', 'b', 'c'],
             'my_int64': [1, 2, 3],
             'my_float64': [4.0, 5.0, 6.0],
+            'my_timestamp': [
+                pandas.Timestamp("1998-09-04T16:03:14"),
+                pandas.Timestamp("2010-09-13T12:03:45"),
+                pandas.Timestamp("2015-10-02T16:00:00")
+            ],
         }
     )
     table_id = 'my_dataset.new_table'


### PR DESCRIPTION
So long as NULLs are not present, the pandas dtype to
BigQuery data type auto conversion should work as
intended.

Closes internal issue 140645939.