### PR TITLE
Update datalabeling samples to use test endpoint.

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -39,6 +39,8 @@ SECRETS_PASSWORD=$(cat "${KOKORO_GFILE_DIR}/secrets-password.txt")
 source ./testing/test-env.sh
 export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/testing/service-account.json
 export GOOGLE_CLIENT_SECRETS=$(pwd)/testing/client-secrets.json
+# For Datalabeling samples to hit the testing endpoint
+export DATALABELING_ENDPOINT="test-datalabeling.sandbox.googleapis.com:443"
 
 # Run Cloud SQL proxy (background process exit when script does)
 wget --quiet https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy && chmod +x cloud_sql_proxy

--- a/datalabeling/create_annotation_spec_set.py
+++ b/datalabeling/create_annotation_spec_set.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 import argparse
+import os
+from google.api_core.client_options import ClientOptions
 
 
 # [START datalabeling_create_annotation_spec_set_beta]
@@ -24,6 +26,13 @@ def create_annotation_spec_set(project_id):
     """
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_create_annotation_spec_set_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+    # [START datalabeling_create_annotation_spec_set_beta]
 
     project_path = client.project_path(project_id)
 

--- a/datalabeling/create_annotation_spec_set_test.py
+++ b/datalabeling/create_annotation_spec_set_test.py
@@ -18,6 +18,7 @@ import os
 
 import create_annotation_spec_set
 from google.cloud import datalabeling_v1beta1 as datalabeling
+from google.api_core.client_options import ClientOptions
 import pytest
 
 PROJECT_ID = os.getenv('GCLOUD_PROJECT')
@@ -33,4 +34,11 @@ def test_create_annotation_spec_set(capsys):
     # Delete the created annotation spec set.
     annotation_spec_set_name = response.name
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_annotation_spec_set(annotation_spec_set_name)

--- a/datalabeling/create_instruction.py
+++ b/datalabeling/create_instruction.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 import argparse
+import os
+from google.api_core.client_options import ClientOptions
 
 
 # [START datalabeling_create_instruction_beta]
@@ -25,6 +27,13 @@ def create_instruction(project_id, data_type, instruction_gcs_uri):
     """
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_create_instruction_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+    # [START datalabeling_create_instruction_beta]
 
     project_path = client.project_path(project_id)
 

--- a/datalabeling/create_instruction_test.py
+++ b/datalabeling/create_instruction_test.py
@@ -17,6 +17,7 @@
 import os
 
 import create_instruction
+from google.api_core.client_options import ClientOptions
 from google.cloud import datalabeling_v1beta1 as datalabeling
 import pytest
 
@@ -38,4 +39,11 @@ def test_create_instruction(capsys):
     # Delete the created instruction.
     instruction_name = result.name
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_instruction(instruction_name)

--- a/datalabeling/export_data.py
+++ b/datalabeling/export_data.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 import argparse
+import os
+from google.api_core.client_options import ClientOptions
 
 
 # [START datalabeling_export_data_beta]
@@ -23,6 +25,12 @@ def export_data(dataset_resource_name, annotated_dataset_resource_name,
     """Exports a dataset from the given Google Cloud project."""
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_export_data_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+    # [START datalabeling_export_data_beta]
 
     gcs_destination = datalabeling.types.GcsDestination(
         output_uri=export_gcs_uri, mime_type='text/csv')

--- a/datalabeling/import_data.py
+++ b/datalabeling/import_data.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 import argparse
+import os
+from google.api_core.client_options import ClientOptions
 
 
 # [START datalabeling_import_data_beta]
@@ -22,6 +24,12 @@ def import_data(dataset_resource_name, data_type, input_gcs_uri):
     """Imports data to the given Google Cloud project and dataset."""
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_import_data_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+    # [START datalabeling_import_data_beta]
 
     gcs_source = datalabeling.types.GcsSource(
         input_uri=input_gcs_uri, mime_type='text/csv')

--- a/datalabeling/label_image.py
+++ b/datalabeling/label_image.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 import argparse
+import os
+from google.api_core.client_options import ClientOptions
 
 
 # [START datalabeling_label_image_beta]
@@ -23,6 +25,12 @@ def label_image(dataset_resource_name, instruction_resource_name,
     """Labels an image dataset."""
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_label_image_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+    # [START datalabeling_label_image_beta]
 
     basic_config = datalabeling.types.HumanAnnotationConfig(
         instruction=instruction_resource_name,

--- a/datalabeling/label_image_test.py
+++ b/datalabeling/label_image_test.py
@@ -18,6 +18,7 @@ import os
 
 import create_annotation_spec_set
 import create_instruction
+from google.api_core.client_options import ClientOptions
 from google.cloud import datalabeling_v1beta1 as datalabeling
 import import_data
 import label_image
@@ -52,6 +53,13 @@ def annotation_spec_set():
 
     # tear down
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_annotation_spec_set(response.name)
 
 
@@ -66,6 +74,13 @@ def instruction():
 
     # tear down
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_instruction(instruction.name)
 
 
@@ -89,5 +104,12 @@ def test_label_image(capsys, annotation_spec_set, instruction, dataset):
     assert response.cancelled() is True
 
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.transport._operations_client.cancel_operation(
             operation_name)

--- a/datalabeling/label_text.py
+++ b/datalabeling/label_text.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 import argparse
-
+import os
+from google.api_core.client_options import ClientOptions
 
 # [START datalabeling_label_text_beta]
 def label_text(dataset_resource_name, instruction_resource_name,
@@ -23,6 +24,12 @@ def label_text(dataset_resource_name, instruction_resource_name,
     """Labels a text dataset."""
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_export_data_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+    # [START datalabeling_export_data_beta]
 
     basic_config = datalabeling.types.HumanAnnotationConfig(
         instruction=instruction_resource_name,

--- a/datalabeling/label_text_test.py
+++ b/datalabeling/label_text_test.py
@@ -19,6 +19,7 @@ import os
 import create_annotation_spec_set
 import create_instruction
 from google.cloud import datalabeling_v1beta1 as datalabeling
+from google.api_core.client_options import ClientOptions
 import import_data
 import label_text
 import manage_dataset
@@ -52,6 +53,13 @@ def annotation_spec_set():
 
     # tear down
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_annotation_spec_set(response.name)
 
 
@@ -66,6 +74,13 @@ def instruction():
 
     # tear down
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_instruction(instruction.name)
 
 
@@ -89,5 +104,12 @@ def test_label_text(capsys, annotation_spec_set, instruction, dataset):
     assert response.cancelled() is True
 
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.transport._operations_client.cancel_operation(
             operation_name)

--- a/datalabeling/label_video.py
+++ b/datalabeling/label_video.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 import argparse
-
+import os
+from google.api_core.client_options import ClientOptions
 
 # [START datalabeling_label_video_beta]
 def label_video(dataset_resource_name, instruction_resource_name,
@@ -23,6 +24,12 @@ def label_video(dataset_resource_name, instruction_resource_name,
     """Labels a video dataset."""
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_export_data_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+    # [START datalabeling_export_data_beta]
 
     basic_config = datalabeling.types.HumanAnnotationConfig(
         instruction=instruction_resource_name,

--- a/datalabeling/label_video_test.py
+++ b/datalabeling/label_video_test.py
@@ -18,6 +18,7 @@ import os
 
 import create_annotation_spec_set
 import create_instruction
+from google.api_core.client_options import ClientOptions
 from google.cloud import datalabeling_v1beta1 as datalabeling
 import import_data
 import label_video
@@ -52,6 +53,13 @@ def annotation_spec_set():
 
     # tear down
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_annotation_spec_set(response.name)
 
 
@@ -66,6 +74,13 @@ def instruction():
 
     # tear down
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.delete_instruction(instruction.name)
 
 
@@ -89,5 +104,12 @@ def test_label_video(capsys, annotation_spec_set, instruction, dataset):
     assert response.cancelled() is True
 
     client = datalabeling.DataLabelingServiceClient()
+
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+        client = datalabeling.DataLabelingServiceClient(client_options=opts)
+
     client.transport._operations_client.cancel_operation(
             operation_name)

--- a/datalabeling/manage_dataset.py
+++ b/datalabeling/manage_dataset.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 import argparse
+import os
+from google.api_core.client_options import ClientOptions
 
 
 # [START datalabeling_create_dataset_beta]
@@ -22,6 +24,12 @@ def create_dataset(project_id):
     """Creates a dataset for the given Google Cloud project."""
     from google.cloud import datalabeling_v1beta1 as datalabeling
     client = datalabeling.DataLabelingServiceClient()
+    # [END datalabeling_create_dataset_beta]
+    # If provided, use a provided test endpoint - this will prevent tests on
+    # this snippet from triggering any action by a real human
+    if 'DATALABELING_ENDPOINT' in os.environ:
+        opts = ClientOptions(api_endpoint=os.getenv('DATALABELING_ENDPOINT'))
+    # [START datalabeling_create_dataset_beta]
 
     formatted_project_name = client.project_path(project_id)
 


### PR DESCRIPTION
Update datalabeling samples to use test endpoint. These samples trigger real human action, so we want to use the test endpoint to avoid that from happening. 