### PR TITLE
Update noxfile w/ py 3.5 and 3.7 sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -245,12 +245,11 @@ def py27(session, sample):
     _session_tests(session, sample)
 
 
-@nox.session(python="3.6")
+@nox.session(python=["3.5","3.6","3.7"])
 @nox.parametrize("sample", NON_GAE_STANDARD_SAMPLES_PY3)
-def py36(session, sample):
-    """Runs py.test for a sample using Python 3.6"""
+def py3(session, sample):
+    """Runs py.test for a sample using Python 3.5, 3.6, 3.7"""
     _session_tests(session, sample)
-
 
 @nox.session
 @nox.parametrize("sample", ALL_SAMPLE_DIRECTORIES)


### PR DESCRIPTION
This was an action item I had from our last meeting - all of the sessions show up when I run `nox -l` locally, but I'm not sure of the best way to test this to make sure I haven't broken stuff - would love insights from y'all