### PR TITLE
Pub/Sub: remove `_ah` in AppEngine Python3 sample

### DIFF
--- a/appengine/standard_python37/pubsub/README.md
+++ b/appengine/standard_python37/pubsub/README.md
@@ -25,7 +25,7 @@ Before you can run or deploy the sample, you will need to do the following:
         $ gcloud beta pubsub subscriptions create [your-subscription-name] \
             --topic=[your-topic-name] \
             --push-endpoint=\
-                https://[your-app-id].appspot.com/_ah/push-handlers/receive_messages?token=[your-token] \
+                https://[your-app-id].appspot.com/push-handlers/receive_messages?token=[your-token] \
             --ack-deadline=30 \
             --push-auth-service-account=[your-service-account] \
             --push-auth-token-audience=example.com
@@ -56,11 +56,11 @@ Then set environment variables before starting your application:
 The application can send messages locally, but it is not able to receive push messages locally. You can, however, simulate a push message by making an HTTP request to the local push notification endpoint. There is an included ``sample_message.json``. You can use
 ``curl`` or [httpie](https://github.com/jkbrzt/httpie) to POST this:
 
-    $ curl -i --data @sample_message.json "localhost:8080/_ah/push-handlers/receive_messages?token=[your-token]"
+    $ curl -i --data @sample_message.json "localhost:8080/push-handlers/receive_messages?token=[your-token]"
 
 Or
 
-    $ http POST ":8080/_ah/push-handlers/receive_messages?token=[your-token]" < sample_message.json
+    $ http POST ":8080/push-handlers/receive_messages?token=[your-token]" < sample_message.json
 
 Response:
 

--- a/appengine/standard_python37/pubsub/main.py
+++ b/appengine/standard_python37/pubsub/main.py
@@ -60,7 +60,7 @@ def index():
 
 
 # [START push]
-@app.route('/_ah/push-handlers/receive_messages', methods=['POST'])
+@app.route('/push-handlers/receive_messages', methods=['POST'])
 def receive_messages_handler():
     # Verify that the request originates from the application.
     if (request.args.get('token', '') !=

--- a/appengine/standard_python37/pubsub/main_test.py
+++ b/appengine/standard_python37/pubsub/main_test.py
@@ -89,7 +89,7 @@ def test_push_endpoint(monkeypatch, client, fake_token):
     monkeypatch.setattr(id_token, 'verify_oauth2_token',
                         _verify_mocked_oauth2_token)
 
-    url = '/_ah/push-handlers/receive_messages?token=' + \
+    url = '/push-handlers/receive_messages?token=' + \
         os.environ['PUBSUB_VERIFICATION_TOKEN']
 
     r = client.post(
@@ -115,9 +115,9 @@ def test_push_endpoint(monkeypatch, client, fake_token):
 
 def test_push_endpoint_errors(client):
     # no token
-    r = client.post('/_ah/push-handlers/receive_messages')
+    r = client.post('/push-handlers/receive_messages')
     assert r.status_code == 400
 
     # invalid token
-    r = client.post('/_ah/push-handlers/receive_messages?token=bad')
+    r = client.post('/push-handlers/receive_messages?token=bad')
     assert r.status_code == 400

--- a/codelabs/functions/python_powered/main.py
+++ b/codelabs/functions/python_powered/main.py
@@ -57,4 +57,6 @@ def python_powered(request):
     Returns:
         The response file, a JPG image that says "Python Powered"
     """
-    return flask.send_from_directory(os.getcwd(), "python_powered.jpg", mimetype="image/jpg")
+    return flask.send_from_directory(
+        os.getcwd(), "python_powered.jpg", mimetype="image/jpg"
+    )


### PR DESCRIPTION
`_ah` is not necessary when setting up Cloud Pub/Sub authenticated push subscriptions in App Engine Standard's Python3 runtime. 