### PR TITLE
Make texttospeech quickstart compatible with microgenerator library (DO NOT MERGE)

### DIFF
--- a/texttospeech/cloud-client/quickstart.py
+++ b/texttospeech/cloud-client/quickstart.py
@@ -48,7 +48,7 @@ def run_quickstart():
 
     # Perform the text-to-speech request on the text input with the selected
     # voice parameters and audio file type
-    response = client.synthesize_speech(synthesis_input, voice, audio_config)
+    response = client.synthesize_speech(request = {'input': synthesis_input, 'voice': voice, 'audio_config': audio_config})
 
     # The response's audio_content is binary.
     with open('output.mp3', 'wb') as out:

--- a/texttospeech/cloud-client/quickstart.py
+++ b/texttospeech/cloud-client/quickstart.py
@@ -28,23 +28,23 @@ def run_quickstart():
     Note: ssml must be well-formed according to:
         https://www.w3.org/TR/speech-synthesis/
     """
-    from google.cloud import texttospeech
+    from google.cloud import texttospeech_v1 as texttospeech
 
     # Instantiates a client
     client = texttospeech.TextToSpeechClient()
 
     # Set the text input to be synthesized
-    synthesis_input = texttospeech.types.SynthesisInput(text="Hello, World!")
+    synthesis_input = texttospeech.SynthesisInput(text="Hello, World!")
 
     # Build the voice request, select the language code ("en-US") and the ssml
     # voice gender ("neutral")
-    voice = texttospeech.types.VoiceSelectionParams(
+    voice = texttospeech.VoiceSelectionParams(
         language_code='en-US',
-        ssml_gender=texttospeech.enums.SsmlVoiceGender.NEUTRAL)
+        ssml_gender=texttospeech.SsmlVoiceGender.NEUTRAL)
 
     # Select the type of audio file you want returned
-    audio_config = texttospeech.types.AudioConfig(
-        audio_encoding=texttospeech.enums.AudioEncoding.MP3)
+    audio_config = texttospeech.AudioConfig(
+        audio_encoding=texttospeech.AudioEncoding.MP3)
 
     # Perform the text-to-speech request on the text input with the selected
     # voice parameters and audio file type


### PR DESCRIPTION
(1) Request dictionaries are passed to functions. This was converted automatically using a script provided by the microgenerator.
(2) Types and enums are all available at `google.cloud.texttospeech`, so `google.cloud.texttospeech.enums` and `google.cloud.types` are unneeded. 