### PR TITLE
chore: update pytest version

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ addopts =
     --no-success-flaky-report
     --tb=native
 norecursedirs = .git env lib .tox .nox
+junit_family = xunit2

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -5,8 +5,8 @@ funcsigs==1.0.2
 mock==3.0.5
 PyCrypto==2.6.1
 pytest-cov==2.8.1
-pytest==5.3.0; python_version > "3.0"
-pytest==4.6.6; python_version < "3.0"
+pytest==5.3.2; python_version > "3.0"
+pytest==4.6.9; python_version < "3.0"
 pyyaml==5.1.2
 responses==0.10.6
 WebTest==2.0.33


### PR DESCRIPTION
Bumps pytest to the latest versions of 4 and 5, and sets the [`junit_family`](https://docs.pytest.org/en/latest/reference.html#confval-junit_family).