### PR TITLE
Add max-line-length to nox lint.

### DIFF
--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -125,6 +125,7 @@ FLAKE8_COMMON_ARGS = [
     "--exclude",
     ".nox,.cache,env,lib,generated_pb2,*_pb2.py,*_pb2_grpc.py",
     "--ignore=E121,E123,E126,E203, E226,E24,E266,E501,E704,W503,W504,I100,I201,I202",
+    "--max-line-length=88",
 ]
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -153,6 +153,7 @@ FLAKE8_COMMON_ARGS = [
     "--exclude",
     ".nox,.cache,env,lib,generated_pb2,*_pb2.py,*_pb2_grpc.py",
     "--ignore=E121,E123,E126,E226,E24,E704,W503,W504,I100,I201,I202",
+    "--max-line-length=88",
 ]
 
 


### PR DESCRIPTION
Makes `nox -s lint` compatible with `nox -s blacken`'s defaults.