### PR TITLE
fix: changes fields printed in list glossary sample; some minor fixes

### DIFF
--- a/translate/cloud-client/translate_v3_create_glossary.py
+++ b/translate/cloud-client/translate_v3_create_glossary.py
@@ -34,7 +34,7 @@ def sample_create_glossary(project_id, input_uri, glossary_id):
     # TODO(developer): Uncomment and set the following variables
     # project_id = 'YOUR_PROJECT_ID'
     # glossary_id = 'your-glossary-display-name'
-    # input_uri = 'gs://cloud-samples-data/translation/glossary.csv'
+    # input_uri = 'gs://cloud-samples-data/translation/glossary_ja.csv'
     location = 'us-central1'  # The location of the glossary
 
     name = client.glossary_path(
@@ -50,6 +50,10 @@ def sample_create_glossary(project_id, input_uri, glossary_id):
     input_config = translate.types.GlossaryInputConfig(
         gcs_source=gcs_source)
 
+    # Note: You can create a glossary using one of two modes:
+    # language_code_set or language_pair. When listing the information for
+    # a glossary, you can only get information for the mode you used
+    # when creating the glossary.
     glossary = translate.types.Glossary(
         name=name,
         language_codes_set=language_codes_set,

--- a/translate/cloud-client/translate_v3_list_glossary.py
+++ b/translate/cloud-client/translate_v3_list_glossary.py
@@ -34,7 +34,8 @@ def sample_list_glossaries(project_id):
 
     # TODO(developer): Uncomment and set the following variables
     # project_id = '[Google Cloud Project ID]'
-    parent = client.location_path(project_id, "us-central1")
+    location = 'us-central1'
+    parent = client.location_path(project_id, location)
 
     # Iterate over all results
     for glossary in client.list_glossaries(parent):
@@ -42,11 +43,14 @@ def sample_list_glossaries(project_id):
         print('Entry count: {}'.format(glossary.entry_count))
         print('Input uri: {}'.format(
             glossary.input_config.gcs_source.input_uri))
+
+        # Note: You can create a glossary using one of two modes:
+        # language_code_set or language_pair. When listing the information for
+        # a glossary, you can only get information for the mode you used
+        # when creating the glossary.
         for language_code in glossary.language_codes_set.language_codes:
             print('Language code: {}'.format(language_code))
-        if glossary.language_pair:
-            print(glossary.language_pair.source_language_code)
-            print(glossary.language_pair.target_language_code)
+
 
 # [END translate_v3_list_glossary]
 


### PR DESCRIPTION
Adds a comment; removes extraneous field access in Translation glossary samples.

Affected region tags / code snippets:

- translate_v3_create_glossary
- translate_v3_list_glossary