### PR TITLE
Fix: Reuse same Spanner database in Cloud Function

### DIFF
--- a/functions/spanner/main.py
+++ b/functions/spanner/main.py
@@ -19,12 +19,11 @@ instance_id = 'test-instance'
 database_id = 'example-db'
 
 client = spanner.Client()
+instance = client.instance(instance_id)
+database = instance.database(database_id)
 
 
 def spanner_read_data(request):
-    instance = client.instance(instance_id)
-    database = instance.database(database_id)
-
     query = 'SELECT * FROM Albums'
 
     outputs = []


### PR DESCRIPTION
The Cloud Functions Python example creates a database object each time the function is run. This means that a new session pool is created and destroyed at each run of the function.

The example has been modified to reuse the same database object.

Closes #2762 