### PR TITLE
Fix incorrect data submission

### DIFF
--- a/functions/composer/composer_storage_trigger.py
+++ b/functions/composer/composer_storage_trigger.py
@@ -58,7 +58,7 @@ def trigger_dag(data, context=None):
         + '/dag_runs'
     )
     # Make a POST request to IAP which then Triggers the DAG
-    make_iap_request(webserver_url, client_id, method='POST', json=data)
+    make_iap_request(webserver_url, client_id, method='POST', json={"conf":data})
 
 
 # This code is copied from


### PR DESCRIPTION
The configuration to send composer needs to be inside the data block rather than the JSON body itself