### PR TITLE
.kokoro: use buildcop.sh script to publish logs

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -103,26 +103,8 @@ for file in **/requirements.txt; do
     # If this is a continuous build, send the test log to the Build Cop Bot.
     # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
     if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
-      XML=$(base64 -w 0 sponge_log.xml)
-
-      # See https://github.com/apps/build-cop-bot/installations/5943459.
-      MESSAGE=$(cat <<EOF
-      {
-          "Name": "buildcop",
-          "Type" : "function",
-          "Location": "us-central1",
-          "installation": {"id": "5943459"},
-          "repo": "GoogleCloudPlatform/python-docs-samples",
-          "buildID": "$KOKORO_GIT_COMMIT",
-          "buildURL": "https://source.cloud.google.com/results/invocations/$KOKORO_BUILD_ID",
-          "xunitXML": "$XML"
-      }
-EOF
-      )
-
-      # Use a service account with access to the repo-automation-bots project.
-      gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
-      gcloud pubsub topics publish passthrough --project=repo-automation-bots --message="$MESSAGE"
+      chmod +x $KOKORO_GFILE_DIR/buildcop.sh
+      $KOKORO_GFILE_DIR/buildcop.sh
     fi
 
     if [[ $EXIT -ne 0 ]]; then


### PR DESCRIPTION
The `buildcop.sh` is included in the Trampoline GCS directory.