### PR TITLE
.kokoro/testing: use buildcop binary to publish logs

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -103,8 +103,8 @@ for file in **/requirements.txt; do
     # If this is a continuous build, send the test log to the Build Cop Bot.
     # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
     if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
-      chmod +x $KOKORO_GFILE_DIR/buildcop.sh
-      $KOKORO_GFILE_DIR/buildcop.sh
+      chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
+      $KOKORO_GFILE_DIR/linux_amd64/buildcop
     fi
 
     if [[ $EXIT -ne 0 ]]; then


### PR DESCRIPTION
The script sometimes runs into shell limits passing arguments to gcloud.