### PR TITLE
Pub/Sub: remove publish concurrency control sample

### DIFF
--- a/pubsub/cloud-client/README.rst
+++ b/pubsub/cloud-client/README.rst
@@ -93,8 +93,8 @@ To run this sample:
     $ python publisher.py
 
     usage: publisher.py [-h]
-                        project
-                        {list,create,delete,publish,publish-with-custom-attributes,publish-with-futures,publish-with-batch-settings}
+                        project_id
+                        {list,create,delete,publish,publish-with-custom-attributes,publish-with-error-handler,publish-with-batch-settings,publish-with-retry-settings}
                         ...
 
     This application demonstrates how to perform basic operations on topics
@@ -104,8 +104,8 @@ To run this sample:
     at https://cloud.google.com/pubsub/docs.
 
     positional arguments:
-      project               Your Google Cloud project ID
-      {list,create,delete,publish,publish-with-custom-attributes,publish-with-futures,publish-with-batch-settings}
+      project_id            Your Google Cloud project ID
+      {list,create,delete,publish,publish-with-custom-attributes,publish-with-error-handler,publish-with-batch-settings,publish-with-retry-settings}
         list                Lists all Pub/Sub topics in the given project.
         create              Create a new Pub/Sub topic.
         delete              Deletes an existing Pub/Sub topic.
@@ -113,12 +113,14 @@ To run this sample:
         publish-with-custom-attributes
                             Publishes multiple messages with custom attributes to
                             a Pub/Sub topic.
-        publish-with-futures
-                            Publishes multiple messages to a Pub/Sub topic and
-                            prints their message IDs.
+        publish-with-error-handler
+                            Publishes multiple messages to a Pub/Sub topic with an
+                            error handler.
         publish-with-batch-settings
                             Publishes multiple messages to a Pub/Sub topic with
                             batch settings.
+        publish-with-retry-settings
+                            Publishes messages with custom retry settings.
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -141,8 +143,8 @@ To run this sample:
     $ python subscriber.py
 
     usage: subscriber.py [-h]
-                         project
-                         {list_in_topic,list_in_project,create,create-push,delete,update,receive,receive-custom-attributes,receive-flow-control,listen_for_errors}
+                         project_id
+                         {list_in_topic,list_in_project,create,create-push,delete,update,receive,receive-custom-attributes,receive-flow-control,receive-synchronously,receive-synchronously-with-lease,listen_for_errors}
                          ...
 
     This application demonstrates how to perform basic operations on
@@ -152,26 +154,26 @@ To run this sample:
     at https://cloud.google.com/pubsub/docs.
 
     positional arguments:
-      project               Your Google Cloud project ID
-      {list_in_topic,list_in_project,create,create-push,delete,update,receive,receive-custom-attributes,receive-flow-control,listen_for_errors}
+      project_id            Your Google Cloud project ID
+      {list_in_topic,list_in_project,create,create-push,delete,update,receive,receive-custom-attributes,receive-flow-control,receive-synchronously,receive-synchronously-with-lease,listen_for_errors}
         list_in_topic       Lists all subscriptions for a given topic.
         list_in_project     Lists all subscriptions in the current project.
         create              Create a new pull subscription on the given topic.
-        create-push         Create a new push subscription on the given topic. For
-                            example, endpoint is "https://my-test-
-                            project.appspot.com/push".
+        create-push         Create a new push subscription on the given topic.
         delete              Deletes an existing Pub/Sub topic.
         update              Updates an existing Pub/Sub subscription's push
                             endpoint URL. Note that certain properties of a
                             subscription, such as its topic, are not modifiable.
-                            For example, endpoint is "https://my-test-
-                            project.appspot.com/push".
         receive             Receives messages from a pull subscription.
         receive-custom-attributes
                             Receives messages from a pull subscription.
         receive-flow-control
                             Receives messages from a pull subscription with flow
                             control.
+        receive-synchronously
+                            Pulling messages synchronously.
+        receive-synchronously-with-lease
+                            Pulling messages synchronously with lease management
         listen_for_errors   Receives messages and catches errors from a pull
                             subscription.
 

--- a/pubsub/cloud-client/publisher.py
+++ b/pubsub/cloud-client/publisher.py
@@ -128,30 +128,6 @@ def publish_messages_with_custom_attributes(project_id, topic_name):
     # [END pubsub_publish_custom_attributes]
 
 
-def publish_messages_with_futures(project_id, topic_name):
-    """Publishes multiple messages to a Pub/Sub topic and prints their
-    message IDs."""
-    # [START pubsub_publisher_concurrency_control]
-    from google.cloud import pubsub_v1
-
-    # TODO project_id = "Your Google Cloud Project ID"
-    # TODO topic_name = "Your Pub/Sub topic name"
-
-    publisher = pubsub_v1.PublisherClient()
-    topic_path = publisher.topic_path(project_id, topic_name)
-
-    for n in range(1, 10):
-        data = u"Message number {}".format(n)
-        # Data must be a bytestring
-        data = data.encode("utf-8")
-        # When you publish a message, the client returns a future.
-        future = publisher.publish(topic_path, data=data)
-        print(future.result())
-
-    print("Published messages with futures.")
-    # [END pubsub_publisher_concurrency_control]
-
-
 def publish_messages_with_error_handler(project_id, topic_name):
     # [START pubsub_publish_messages_error_handler]
     """Publishes multiple messages to a Pub/Sub topic with an error handler."""
@@ -308,11 +284,6 @@ if __name__ == "__main__":
     )
     publish_with_custom_attributes_parser.add_argument("topic_name")
 
-    publish_with_futures_parser = subparsers.add_parser(
-        "publish-with-futures", help=publish_messages_with_futures.__doc__
-    )
-    publish_with_futures_parser.add_argument("topic_name")
-
     publish_with_error_handler_parser = subparsers.add_parser(
         "publish-with-error-handler",
         help=publish_messages_with_error_handler.__doc__,
@@ -345,8 +316,6 @@ if __name__ == "__main__":
         publish_messages_with_custom_attributes(
             args.project_id, args.topic_name
         )
-    elif args.command == "publish-with-futures":
-        publish_messages_with_futures(args.project_id, args.topic_name)
     elif args.command == "publish-with-error-handler":
         publish_messages_with_error_handler(args.project_id, args.topic_name)
     elif args.command == "publish-with-batch-settings":

--- a/pubsub/cloud-client/publisher_test.py
+++ b/pubsub/cloud-client/publisher_test.py
@@ -138,10 +138,3 @@ def test_publish_with_error_handler(topic_publish, capsys):
 
     out, _ = capsys.readouterr()
     assert "Published" in out
-
-
-def test_publish_with_futures(topic_publish, capsys):
-    publisher.publish_messages_with_futures(PROJECT, TOPIC_PUBLISH)
-
-    out, _ = capsys.readouterr()
-    assert "Published" in out


### PR DESCRIPTION
Publish concurrency control isn't supported by the Pub/Sub publisher client. After I dereference this sample on [Cloud Pub/Sub docs](https://cloud.google.com/pubsub/docs/publisher#concurrency), I will remove this sample from the repo. 