### PR TITLE
Pub/Sub: update publish with batch settings sample

### DIFF
--- a/pubsub/cloud-client/publisher.py
+++ b/pubsub/cloud-client/publisher.py
@@ -183,8 +183,8 @@ def publish_messages_with_batch_settings(project_id, topic_name):
     # Configure the batch to publish as soon as there is one kilobyte
     # of data or one second has passed.
     batch_settings = pubsub_v1.types.BatchSettings(
-        max_bytes=1024, # One kilobyte
-        max_latency=1,  # One second
+        max_bytes=1024,
+        max_latency=1
     )
     publisher = pubsub_v1.PublisherClient(batch_settings)
     topic_path = publisher.topic_path(project_id, topic_name)

--- a/pubsub/cloud-client/publisher.py
+++ b/pubsub/cloud-client/publisher.py
@@ -180,11 +180,12 @@ def publish_messages_with_batch_settings(project_id, topic_name):
     # TODO project_id = "Your Google Cloud Project ID"
     # TODO topic_name = "Your Pub/Sub topic name"
 
-    # Configure the batch to publish as soon as there is one kilobyte
-    # of data or one second has passed.
+    # Configure the batch to publish as soon as there is ten messages,
+    # one kilobyte of data, or one second has passed.
     batch_settings = pubsub_v1.types.BatchSettings(
-        max_bytes=1024,
-        max_latency=1
+        max_messages=10,  # default 100
+        max_bytes=1024,  # default 1 MB
+        max_latency=1,  # default 10 ms
     )
     publisher = pubsub_v1.PublisherClient(batch_settings)
     topic_path = publisher.topic_path(project_id, topic_name)

--- a/pubsub/cloud-client/publisher.py
+++ b/pubsub/cloud-client/publisher.py
@@ -175,8 +175,6 @@ def publish_messages_with_error_handler(project_id, topic_name):
 def publish_messages_with_batch_settings(project_id, topic_name):
     """Publishes multiple messages to a Pub/Sub topic with batch settings."""
     # [START pubsub_publisher_batch_settings]
-    import threading
-
     from google.cloud import pubsub_v1
 
     # TODO project_id = "Your Google Cloud Project ID"


### PR DESCRIPTION
The previous sample resolves each publish future as each message is published, effectively skipping batching. 

The new sample uses the non-blocking function `add_done_callback()` on publish futures instead of `result()` in the main thread. 