### PR TITLE
Switch continuous tests to only test changed files.

### DIFF
--- a/.kokoro/lint/presubmit.cfg
+++ b/.kokoro/lint/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_only_diff.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python2.7/continuous.cfg
+++ b/.kokoro/python2.7/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python2.7/presubmit.cfg
+++ b/.kokoro/python2.7/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_only_diff.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python3.6/continuous.cfg
+++ b/.kokoro/python3.6/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python3.6/presubmit.cfg
+++ b/.kokoro/python3.6/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_only_diff.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python3.7/continuous.cfg
+++ b/.kokoro/python3.7/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python3.7/presubmit.cfg
+++ b/.kokoro/python3.7/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_only_diff.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python3.8/continuous.cfg
+++ b/.kokoro/python3.8/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python3.8/presubmit.cfg
+++ b/.kokoro/python3.8/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_only_diff.sh"
+    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -20,11 +20,16 @@ set -eo pipefail
 # Enables `**` to include files nested inside sub-folders
 shopt -s globstar
 
-# `--only-changed` will only run tests on projects container changes from the master branch.
-if [[ $* == *--only-diff* ]]; then
-    ONLY_DIFF="true"
-else
-    ONLY_DIFF="false"
+DIFF_FROM=""
+
+# `--only-diff-master will only run tests on project changes from the master branch.
+if [[ $* == *--only-diff-master* ]]; then
+    DIFF_FROM="origin/master.."
+fi
+
+# `--only-diff-master will only run tests on project changes from the previous commit.
+if [[ $* == *--only-diff-head* ]]; then
+    DIFF_FROM="HEAD~.."
 fi
 
 cd github/python-docs-samples
@@ -67,8 +72,8 @@ for file in **/requirements.txt; do
     cd "$file"
 
     # If $DIFF_ONLY is true, skip projects without changes.
-    if [[ "$ONLY_DIFF" = "true" ]]; then
-        git diff --quiet origin/master.. .
+    if [[ "DIFF_FROM" != "" ]]; then
+        git diff --quiet "$DIFF_FROM" .
         CHANGED=$?
         if [[ "$CHANGED" -eq 0 ]]; then
           # echo -e "\n Skipping $file: no changes in folder.\n"
@@ -105,9 +110,9 @@ for file in **/requirements.txt; do
     nox -s "$RUN_TESTS_SESSION"
     EXIT=$?
 
-    # If this is a continuous build, send the test log to the Build Cop Bot.
+    # If this is a periodic build, send the test log to the Build Cop Bot.
     # See https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
-    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"continuous"* ]]; then
+    if [[ $KOKORO_BUILD_ARTIFACTS_SUBDIR = *"periodic"* ]]; then
       chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
       $KOKORO_GFILE_DIR/linux_amd64/buildcop
     fi

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -72,7 +72,7 @@ for file in **/requirements.txt; do
     cd "$file"
 
     # If $DIFF_FROM is set, use it to check for changes in this directory.
-    if [[ "DIFF_FROM" != "" ]]; then
+    if [[ "$DIFF_FROM" != "" ]]; then
         git diff --quiet "$DIFF_FROM" .
         CHANGED=$?
         if [[ "$CHANGED" -eq 0 ]]; then

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -71,7 +71,7 @@ for file in **/requirements.txt; do
     file=$(dirname "$file")
     cd "$file"
 
-    # If $DIFF_ONLY is true, skip projects without changes.
+    # If $DIFF_FROM is set, use it to check for changes in this directory.
     if [[ "DIFF_FROM" != "" ]]; then
         git diff --quiet "$DIFF_FROM" .
         CHANGED=$?

--- a/.kokoro/tests/run_tests_diff_head.sh
+++ b/.kokoro/tests/run_tests_diff_head.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 mydir="${0%/*}"
-"$mydir"/run_tests.sh --only-diff
+"$mydir"/run_tests.sh --only-diff-master

--- a/.kokoro/tests/run_tests_diff_head.sh
+++ b/.kokoro/tests/run_tests_diff_head.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 mydir="${0%/*}"
-"$mydir"/run_tests.sh --only-diff-master
+"$mydir"/run_tests.sh --only-diff-head

--- a/.kokoro/tests/run_tests_diff_master.sh
+++ b/.kokoro/tests/run_tests_diff_master.sh
@@ -1,4 +1,5 @@
-# Copyright 2020 Google LLC
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,11 +12,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Tell the trampoline which build file to use.
-env_vars: {
-    key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
-}
+mydir="${0%/*}"
+"$mydir"/run_tests.sh --only-diff-head

--- a/.kokoro/tests/run_tests_diff_master.sh
+++ b/.kokoro/tests/run_tests_diff_master.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 mydir="${0%/*}"
-"$mydir"/run_tests.sh --only-diff-head
+"$mydir"/run_tests.sh --only-diff-master


### PR DESCRIPTION
- Switches continuous tests to only test files changed from the last commit 
- Switches buildcop to only report fails from the periodic build

Fixes #3314