### PR TITLE
chore: remove gcp-devrel-py-tools from iot and pubsub

### DIFF
--- a/iot/api-client/mqtt_example/requirements-test.txt
+++ b/iot/api-client/mqtt_example/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==5.3.2
 backoff==1.10.0
+flaky==3.6.1
+pytest==5.3.2

--- a/iot/api-client/mqtt_example/requirements.txt
+++ b/iot/api-client/mqtt_example/requirements.txt
@@ -1,6 +1,4 @@
 cryptography==2.9.1
-flaky==3.6.1
-gcp-devrel-py-tools==0.0.15
 google-api-python-client==1.8.0
 google-auth-httplib2==0.0.3
 google-auth==1.14.0

--- a/pubsub/cloud-client/requirements-test.txt
+++ b/pubsub/cloud-client/requirements-test.txt
@@ -1,4 +1,3 @@
+backoff==1.10.0
 pytest==5.3.2
-gcp-devrel-py-tools==0.0.15
 mock==3.0.5
-google-cloud-core==1.3.0


### PR DESCRIPTION
fixes #3372 
fixes #3373 