### PR TITLE
Revert "testing: bump the timeout for periodic builds"

### DIFF
--- a/.kokoro/python3.6/periodic.cfg
+++ b/.kokoro/python3.6/periodic.cfg
@@ -14,8 +14,6 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
-timeout_mins: 420 # 7 hours
-
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/python3.7/periodic.cfg
+++ b/.kokoro/python3.7/periodic.cfg
@@ -14,8 +14,6 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
-timeout_mins: 420 # 7 hours
-
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"

--- a/.kokoro/python3.8/periodic.cfg
+++ b/.kokoro/python3.8/periodic.cfg
@@ -14,8 +14,6 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
-timeout_mins: 420 # 7 hours
-
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"


### PR DESCRIPTION
Reverts GoogleCloudPlatform/python-docs-samples#3413

I don't think we need 7 hours any more.