### PR TITLE
Remove name attribute from the input

### DIFF
--- a/storage/cloud-client/storage_generate_signed_post_policy_v4.py
+++ b/storage/cloud-client/storage_generate_signed_post_policy_v4.py
@@ -46,7 +46,7 @@ def generate_signed_post_policy_v4(bucket_name, blob_name):
         form += "  <input name='{}' value='{}' type='hidden'/>\n".format(key, value)
 
     form += "  <input type='file' name='file'/><br />\n"
-    form += "  <input type='submit' value='Upload File' name='submit'/><br />\n"
+    form += "  <input type='submit' value='Upload File' /><br />\n"
     form += "</form>"
 
     print(form)


### PR DESCRIPTION
If name='submit' is specified for the input type='submit' the endpoint returns the following error:

<Error>
<Code>InvalidPolicyDocument</Code>
<Message>
The content of the form does not meet the conditions specified in the policy document.
</Message>
<Details>Policy did not reference these fields: submit</Details>
</Error>