### PR TITLE
run: Dockerfile COPY to ./

### DIFF
--- a/run/hello-broken/Dockerfile
+++ b/run/hello-broken/Dockerfile
@@ -20,7 +20,7 @@ FROM python:3.8
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.
-COPY requirements.txt .
+COPY requirements.txt ./
 
 # Install production dependencies.
 RUN pip install -r requirements.txt
@@ -28,7 +28,7 @@ RUN pip install -r requirements.txt
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
+COPY . ./
 
 # Run the web service on container startup. 
 # Use gunicorn webserver with one worker process and 8 threads.

--- a/run/logging-manual/Dockerfile
+++ b/run/logging-manual/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.8
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.
-COPY requirements.txt .
+COPY requirements.txt ./
 
 # Install production dependencies.
 RUN pip install -r requirements.txt
@@ -26,7 +26,7 @@ RUN pip install -r requirements.txt
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
+COPY . ./
 
 # Run the web service on container startup. 
 # Use gunicorn webserver with one worker process and 8 threads.

--- a/run/markdown-preview/editor/Dockerfile
+++ b/run/markdown-preview/editor/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.8-slim
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.
-COPY requirements.txt .
+COPY requirements.txt ./
 
 # Install production dependencies.
 RUN pip install -r requirements.txt
@@ -26,7 +26,7 @@ RUN pip install -r requirements.txt
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
+COPY . ./
 
 # Run the web service on container startup. 
 # Use gunicorn webserver with one worker process and 8 threads.

--- a/run/markdown-preview/renderer/Dockerfile
+++ b/run/markdown-preview/renderer/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.8-slim
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.
-COPY requirements.txt .
+COPY requirements.txt ./
 
 # Install production dependencies.
 RUN pip install -r requirements.txt
@@ -26,7 +26,7 @@ RUN pip install -r requirements.txt
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
+COPY . ./
 
 # Run the web service on container startup. 
 # Use gunicorn webserver with one worker process and 8 threads.

--- a/run/system-package/Dockerfile
+++ b/run/system-package/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -y && apt-get install -y \
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.
-COPY requirements.txt .
+COPY requirements.txt ./
 
 # Install production dependencies.
 RUN pip install -r requirements.txt
@@ -32,7 +32,7 @@ RUN pip install -r requirements.txt
 # Copy local code to the container image.
 ENV APP_HOME /app
 WORKDIR $APP_HOME
-COPY . .
+COPY . ./
 
 # Run the web service on container startup. 
 # Use gunicorn webserver with one worker process and 8 threads.


### PR DESCRIPTION
One of the Dockerfile sample practices we attempt on Cloud Run is to use `./` as the default destination of Dockerfile `COPY` statements.

It doesn't really change the behaviors we expect:

`COPY . .` = `COPY . ./`
`COPY README.md .` = `COPY README.md ./` = `COPY README.md README.md`

However, it matters when developers try to use the multi-source arguments option with COPY:

`COPY README.md main.py .` = ERROR!!
`COPY README.md main.py ./` = Happy Dance 👯 

By using `./` wherever just a `.` appears, it adds a little more noise to the Dockerfile but in exchange there's one less source of friction if developers iterate on top of the Dockerfiles we provide.

I'm working on standardizing this further, but for now sending a little PR to nudge Cloud Run Python alignment.
