### PR TITLE
chore: remove unused oauth2client in healthcare

### DIFF
--- a/healthcare/api-client/v1/fhir/requirements.txt
+++ b/healthcare/api-client/v1/fhir/requirements.txt
@@ -3,4 +3,3 @@ google-auth-httplib2==0.0.3
 google-auth==1.14.1
 google-cloud==0.34.0
 google-cloud-storage==1.28.0
-oauth2client


### PR DESCRIPTION
Remove unused oauth2client in healthcare samples.

Part of #2648