### PR TITLE
Retry HttpErrors for test_patch_hl7v2_message

### DIFF
--- a/healthcare/api-client/v1/hl7v2/hl7v2_messages_test.py
+++ b/healthcare/api-client/v1/hl7v2/hl7v2_messages_test.py
@@ -193,7 +193,7 @@ def test_patch_hl7v2_message(test_dataset, test_hl7v2_store, capsys):
         project_id, cloud_region, dataset_id, hl7v2_store_id, hl7v2_message_file
     )
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=60)
+    @backoff.on_exception(backoff.expo, (AssertionError, HttpError), max_time=60)
     def run_eventually_consistent_test():
         hl7v2_messages_list = hl7v2_messages.list_hl7v2_messages(
             project_id, cloud_region, dataset_id, hl7v2_store_id


### PR DESCRIPTION
Closes #3714

Test failed on `googleapiclient.HttpError`

```
Traceback (most recent call last):
  File "/tmpfs/src/github/python-docs-samples/healthcare/api-client/v1/hl7v2/hl7v2_messages_test.py", line 209, in test_patch_hl7v2_message
    hl7v2_message_id = run_eventually_consistent_test()
  File "/tmpfs/src/github/python-docs-samples/healthcare/api-client/v1/hl7v2/.nox/py-3-7/lib/python3.7/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/tmpfs/src/github/python-docs-samples/healthcare/api-client/v1/hl7v2/hl7v2_messages_test.py", line 199, in run_eventually_consistent_test
    project_id, cloud_region, dataset_id, hl7v2_store_id
  File "/tmpfs/src/github/python-docs-samples/healthcare/api-client/v1/hl7v2/hl7v2_messages.py", line 184, in list_hl7v2_messages
    .list(parent=hl7v2_message_path)
  File "/tmpfs/src/github/python-docs-samples/healthcare/api-client/v1/hl7v2/.nox/py-3-7/lib/python3.7/site-packages/googleapiclient/_helpers.py", line 134, in positional_wrapper
    return wrapped(*args, **kwargs)
  File "/tmpfs/src/github/python-docs-samples/healthcare/api-client/v1/hl7v2/.nox/py-3-7/lib/python3.7/site-packages/googleapiclient/http.py", line 907, in execute
    raise HttpError(resp, content, uri=self.uri)
googleapiclient.errors.HttpError: 
```