### PR TITLE
[monitoring] testing: start using build specific projects

### DIFF
--- a/.kokoro/python3.6/common.cfg
+++ b/.kokoro/python3.6/common.cfg
@@ -48,5 +48,5 @@ env_vars: {
 # but we'll update the value once we have more Cloud projects.
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
-    value: "python-docs-samples-tests"
+    value: "python-docs-samples-tests-py36"
 }

--- a/.kokoro/python3.7/common.cfg
+++ b/.kokoro/python3.7/common.cfg
@@ -48,5 +48,5 @@ env_vars: {
 # Temporary setting my own project for testing the behavior on the PR.
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
-    value: "python-docs-samples-tests"
+    value: "python-docs-samples-tests-py37"
 }

--- a/.kokoro/python3.8/common.cfg
+++ b/.kokoro/python3.8/common.cfg
@@ -48,5 +48,5 @@ env_vars: {
 # but we'll update the value once we have more Cloud projects.
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
-    value: "python-docs-samples-tests"
+    value: "python-docs-samples-tests-py38"
 }

--- a/monitoring/api/v3/alerts-client/README.rst
+++ b/monitoring/api/v3/alerts-client/README.rst
@@ -14,6 +14,11 @@ This directory contains samples for Google Stackdriver Alerting API. Stackdriver
 
 .. _Google Stackdriver Alerting API: https://cloud.google.com/monitoring/alerts/
 
+To run the sample, you need to enable the API at: https://console.cloud.google.com/apis/library/monitoring.googleapis.com
+
+To run the sample, you need to have `Monitoring Admin` role.
+
+
 Setup
 -------------------------------------------------------------------------------
 
@@ -87,7 +92,21 @@ To run this sample:
         list-alert-policies
         list-notification-channels
         enable-alert-policies
+                            Enable or disable alert policies in a project.
+                            Arguments: project_name (str) enable (bool): Enable or
+                            disable the policies. filter_ (str, optional): Only
+                            enable/disable alert policies that match this filter_.
+                            See
+                            https://cloud.google.com/monitoring/api/v3/sorting-
+                            and-filtering
         disable-alert-policies
+                            Enable or disable alert policies in a project.
+                            Arguments: project_name (str) enable (bool): Enable or
+                            disable the policies. filter_ (str, optional): Only
+                            enable/disable alert policies that match this filter_.
+                            See
+                            https://cloud.google.com/monitoring/api/v3/sorting-
+                            and-filtering
         replace-notification-channels
         backup
         restore

--- a/monitoring/api/v3/alerts-client/README.rst
+++ b/monitoring/api/v3/alerts-client/README.rst
@@ -18,7 +18,7 @@ To run the sample, you need to enable the API at: https://console.cloud.google.c
 
 To run the sample, you need to have `Monitoring Admin` role.
 
-Please visit [the Cloud Console UI of this API](https://console.cloud.google.com/monitoring) and create a new Workspace with the same name of your Cloud project.
+Please visit [the Cloud Console UI of this API](https://console.cloud.google.com/monitoring) and [create a new Workspace with the same name of your Cloud project](https://cloud.google.com/monitoring/workspaces/create).
 
 
 Setup

--- a/monitoring/api/v3/alerts-client/README.rst
+++ b/monitoring/api/v3/alerts-client/README.rst
@@ -18,6 +18,8 @@ To run the sample, you need to enable the API at: https://console.cloud.google.c
 
 To run the sample, you need to have `Monitoring Admin` role.
 
+Please visit [the Cloud Console UI of this API](https://console.cloud.google.com/monitoring) and create a new Workspace with the same name of your Cloud project.
+
 
 Setup
 -------------------------------------------------------------------------------

--- a/monitoring/api/v3/alerts-client/README.rst.in
+++ b/monitoring/api/v3/alerts-client/README.rst.in
@@ -12,8 +12,12 @@ product:
       and many others. Stackdriver's Alerting API allows you to create,
       delete, and make back up copies of your alert policies.
 
-required_api_url: https://pantheon.corp.google.com/apis/library/monitoring.googleapis.com
+required_api_url: https://console.cloud.google.com/apis/library/monitoring.googleapis.com
 required_role: Monitoring Admin
+other_required_steps: >
+    Please visit [the Cloud Console UI of this
+    API](https://console.cloud.google.com/monitoring) and create a new
+    Workspace with the same name of your Cloud project.
 
 setup:
 - auth

--- a/monitoring/api/v3/alerts-client/README.rst.in
+++ b/monitoring/api/v3/alerts-client/README.rst.in
@@ -12,6 +12,9 @@ product:
       and many others. Stackdriver's Alerting API allows you to create,
       delete, and make back up copies of your alert policies.
 
+required_api_url: https://pantheon.corp.google.com/apis/library/monitoring.googleapis.com
+required_role: Monitoring Admin
+
 setup:
 - auth
 - install_deps

--- a/scripts/readme-gen/templates/README.tmpl.rst
+++ b/scripts/readme-gen/templates/README.tmpl.rst
@@ -23,6 +23,7 @@ To run the sample, you need to enable the API at: {{required_api_url}}
 To run the sample, you need to have `{{required_role}}` role.
 {% endif %}
 
+{{other_required_steps}}
 
 {% if setup %}
 Setup

--- a/scripts/readme-gen/templates/README.tmpl.rst
+++ b/scripts/readme-gen/templates/README.tmpl.rst
@@ -15,6 +15,15 @@ This directory contains samples for {{product.name}}. {{product.description}}
 
 .. _{{product.name}}: {{product.url}}
 
+{% if required_api_url %}
+To run the sample, you need to enable the API at: {{required_api_url}}
+{% endif %}
+
+{% if required_role %}
+To run the sample, you need to have `{{required_role}}` role.
+{% endif %}
+
+
 {% if setup %}
 Setup
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Also added `required_api_url` and `required_role` field in `README.rst.in`.

A part of #3310 

Note: Now the service account has permission only on the project for py36 build, so py37 build should fail.