### PR TITLE
testing: migrate to trampoline_v2

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -162,8 +162,9 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 RUN sudo systemctl enable redis-server.service
 
 # Create a user and allow sudo
-ARG UID=0
-ARG GID=0
+
+# kbuilder uid on the default Kokoro image
+ARG UID=1000
 ARG USERNAME=kbuilder
 ARG DOCKER_GID=999
 

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -166,19 +166,12 @@ RUN sudo systemctl enable redis-server.service
 # kbuilder uid on the default Kokoro image
 ARG UID=1000
 ARG USERNAME=kbuilder
-ARG DOCKER_GID=999
 
 # Add a new user to the container image.
-# To allow access to the docker socket on the host, we use the docker
-# group on the host.
+# This is needed for ssh and sudo access.
 
-# First make sure the group exists. Ignore a failure in case
-# there is already a group with that id.
-RUN groupadd -g ${DOCKER_GID} "host-docker" | true
-
-# Add a new user with the caller's uid and the docker goup id on the
-# host.
-RUN useradd -d /h -u ${UID} -g ${DOCKER_GID} ${USERNAME}
+# Add a new user with the caller's uid and the username.
+RUN useradd -d /h -u ${UID} ${USERNAME}
 
 # Allow nopasswd sudo
 RUN echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -167,11 +167,19 @@ ARG GID=0
 ARG USERNAME=kbuilder
 ARG DOCKER_GID=999
 
-# Allow access docker socker in the host.
-RUN groupadd -g ${DOCKER_GID} "host-docker"
-RUN groupadd -g ${GID} "${USERNAME}"
-RUN useradd -d /h -u ${UID} -g ${GID} ${USERNAME}
-RUN adduser "${USERNAME}" "host-docker"
+# Add a new user to the container image.
+# To allow access to the docker socket on the host, we use the docker
+# group on the host.
+
+# First make sure the group exists. Ignore a failure in case
+# there is already a group with that id.
+RUN groupadd -g ${DOCKER_GID} "host-docker" | true
+
+# Add a new user with the caller's uid and the docker goup id on the
+# host.
+RUN useradd -d /h -u ${UID} -g ${DOCKER_GID} ${USERNAME}
+
+# Allow nopasswd sudo
 RUN echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 CMD ["python3.6"]

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -161,4 +161,17 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 # Enable redis-server on boot.
 RUN sudo systemctl enable redis-server.service
 
+# Create a user and allow sudo
+ARG UID=0
+ARG GID=0
+ARG USERNAME=kbuilder
+ARG DOCKER_GID=999
+
+# Allow access docker socker in the host.
+RUN groupadd -g ${DOCKER_GID} "host-docker"
+RUN groupadd -g ${GID} "${USERNAME}"
+RUN useradd -d /h -u ${UID} -g ${GID} ${USERNAME}
+RUN adduser "${USERNAME}" "host-docker"
+RUN echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
 CMD ["python3.6"]

--- a/.kokoro/lint/common.cfg
+++ b/.kokoro/lint/common.cfg
@@ -24,7 +24,7 @@ env_vars: {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "python-docs-samples/.kokoro/trampoline.sh"
+build_file: "python-docs-samples/.kokoro/trampoline_v2.sh"
 
 # Download secrets from Cloud Storage.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -40,4 +40,9 @@ action {
 env_vars: {
     key: "RUN_TESTS_SESSION"
     value: "lint"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/Dockerfile"
 }

--- a/.kokoro/lint/continuous.cfg
+++ b/.kokoro/lint/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
+    value: ".kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/lint/periodic.cfg
+++ b/.kokoro/lint/periodic.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: ".kokoro/tests/run_tests.sh"
 }

--- a/.kokoro/lint/presubmit.cfg
+++ b/.kokoro/lint/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
+    value: ".kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python2.7/common.cfg
+++ b/.kokoro/python2.7/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "python-docs-samples/.kokoro/trampoline.sh"
+build_file: "python-docs-samples/.kokoro/trampoline_v2.sh"
 
 # Download secrets from Cloud Storage.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -44,9 +44,13 @@ env_vars: {
     value: "py-2.7"
 }
 
-# Declare build specific Cloud project. It still uses the common one,
-# but we'll update the value once we have more Cloud projects.
+# Declare build specific Cloud project.
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
     value: "python-docs-samples-tests"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/Dockerfile"
 }

--- a/.kokoro/python2.7/continuous.cfg
+++ b/.kokoro/python2.7/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
+    value: ".kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python2.7/periodic.cfg
+++ b/.kokoro/python2.7/periodic.cfg
@@ -17,10 +17,10 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: ".kokoro/tests/run_tests.sh"
 }
 
 env_vars: {
     key: "REPORT_TO_BUILD_COP_BOT"
-    value: "True"
+    value: "true"
 }

--- a/.kokoro/python2.7/presubmit.cfg
+++ b/.kokoro/python2.7/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
+    value: ".kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python3.6/common.cfg
+++ b/.kokoro/python3.6/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "python-docs-samples/.kokoro/trampoline.sh"
+build_file: "python-docs-samples/.kokoro/trampoline_v2.sh"
 
 # Download secrets from Cloud Storage.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -49,4 +49,9 @@ env_vars: {
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
     value: "python-docs-samples-tests-py36"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/Dockerfile"
 }

--- a/.kokoro/python3.6/continuous.cfg
+++ b/.kokoro/python3.6/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
+    value: ".kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python3.6/periodic.cfg
+++ b/.kokoro/python3.6/periodic.cfg
@@ -17,10 +17,10 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: ".kokoro/tests/run_tests.sh"
 }
 
 env_vars: {
     key: "REPORT_TO_BUILD_COP_BOT"
-    value: "True"
+    value: "true"
 }

--- a/.kokoro/python3.6/presubmit.cfg
+++ b/.kokoro/python3.6/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
+    value: ".kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python3.7/common.cfg
+++ b/.kokoro/python3.7/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "python-docs-samples/.kokoro/trampoline.sh"
+build_file: "python-docs-samples/.kokoro/trampoline_v2.sh"
 
 # Download secrets from Cloud Storage.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -49,4 +49,9 @@ env_vars: {
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
     value: "python-docs-samples-tests-py37"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/Dockerfile"
 }

--- a/.kokoro/python3.7/continuous.cfg
+++ b/.kokoro/python3.7/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
+    value: ".kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python3.7/periodic.cfg
+++ b/.kokoro/python3.7/periodic.cfg
@@ -17,10 +17,10 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: ".kokoro/tests/run_tests.sh"
 }
 
 env_vars: {
     key: "REPORT_TO_BUILD_COP_BOT"
-    value: "True"
+    value: "true"
 }

--- a/.kokoro/python3.7/presubmit.cfg
+++ b/.kokoro/python3.7/presubmit.cfg
@@ -14,8 +14,7 @@
 
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
+    value: ".kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/python3.8/common.cfg
+++ b/.kokoro/python3.8/common.cfg
@@ -26,7 +26,7 @@ env_vars: {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "python-docs-samples/.kokoro/trampoline.sh"
+build_file: "python-docs-samples/.kokoro/trampoline_v2.sh"
 
 # Download secrets from Cloud Storage.
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/python-docs-samples"
@@ -49,4 +49,9 @@ env_vars: {
 env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
     value: "python-docs-samples-tests-py38"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_DOCKERFILE"
+    value: ".kokoro/docker/Dockerfile"
 }

--- a/.kokoro/python3.8/continuous.cfg
+++ b/.kokoro/python3.8/continuous.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_head.sh"
+    value: ".kokoro/tests/run_tests_diff_head.sh"
 }

--- a/.kokoro/python3.8/periodic.cfg
+++ b/.kokoro/python3.8/periodic.cfg
@@ -17,10 +17,10 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests.sh"
+    value: ".kokoro/tests/run_tests.sh"
 }
 
 env_vars: {
     key: "REPORT_TO_BUILD_COP_BOT"
-    value: "True"
+    value: "true"
 }

--- a/.kokoro/python3.8/presubmit.cfg
+++ b/.kokoro/python3.8/presubmit.cfg
@@ -17,5 +17,5 @@
 # Tell the trampoline which build file to use.
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-docs-samples/.kokoro/tests/run_tests_diff_master.sh"
+    value: ".kokoro/tests/run_tests_diff_master.sh"
 }

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -175,4 +175,9 @@ for file in **/requirements.txt; do
 done
 cd "$ROOT"
 
+# Remove secrets if we used decrypt-secrets.sh.
+if [[ -f "${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" ]]; then
+    rm testing/{test-env.sh,client-secrets.json,service-account.json}
+fi
+
 exit "$RTN"

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -136,13 +136,16 @@ for file in **/requirements.txt; do
 
     # If no local noxfile exists, copy the one from root
     if [[ ! -f "noxfile.py" ]]; then
-      PARENT_DIR=$(cd ../ && pwd)
-      while [[ "$PARENT_DIR" != "$ROOT" && ! -f "$PARENT_DIR/noxfile-template.py" ]];
-      do
-        PARENT_DIR=$(dirname "$PARENT_DIR")
-      done
-      cp "$PARENT_DIR/noxfile-template.py" "./noxfile.py"
-      echo -e "\n Using noxfile-template from parent folder ($PARENT_DIR). \n"
+	PARENT_DIR=$(cd ../ && pwd)
+	while [[ "$PARENT_DIR" != "$ROOT" && ! -f "$PARENT_DIR/noxfile-template.py" ]];
+	do
+            PARENT_DIR=$(dirname "$PARENT_DIR")
+	done
+	cp "$PARENT_DIR/noxfile-template.py" "./noxfile.py"
+	echo -e "\n Using noxfile-template from parent folder ($PARENT_DIR). \n"
+	cleanup_noxfile=1
+    else
+	cleanup_noxfile=0
     fi
 
     # Use nox to execute the tests for the project.
@@ -165,8 +168,10 @@ for file in **/requirements.txt; do
       echo -e "\n Testing completed.\n"
     fi
 
-    # Remove noxfile.py if it's not tracked by git.
-    git ls-files --error-unmatch noxfile.py > /dev/null 2>&1 | rm noxfile.py
+    # Remove noxfile.py if we copied.
+    if [[ $cleanup_noxfile -eq 1 ]]; then
+	rm noxfile.py
+    fi
 
 done
 cd "$ROOT"

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -152,11 +152,11 @@ for file in **/requirements.txt; do
     nox -s "$RUN_TESTS_SESSION"
     EXIT=$?
 
-    # If REPORT_TO_BUILD_COP_BOT is set to "True", send the test log
+    # If REPORT_TO_BUILD_COP_BOT is set to "true", send the test log
     # to the Build Cop Bot.
     # See:
     # https://github.com/googleapis/repo-automation-bots/tree/master/packages/buildcop.
-    if [[ "${REPORT_TO_BUILD_COP_BOT:-}" == "True" ]]; then
+    if [[ "${REPORT_TO_BUILD_COP_BOT:-}" == "true" ]]; then
       chmod +x $KOKORO_GFILE_DIR/linux_amd64/buildcop
       $KOKORO_GFILE_DIR/linux_amd64/buildcop
     fi

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -136,16 +136,16 @@ for file in **/requirements.txt; do
 
     # If no local noxfile exists, copy the one from root
     if [[ ! -f "noxfile.py" ]]; then
-	PARENT_DIR=$(cd ../ && pwd)
-	while [[ "$PARENT_DIR" != "$ROOT" && ! -f "$PARENT_DIR/noxfile-template.py" ]];
-	do
+        PARENT_DIR=$(cd ../ && pwd)
+        while [[ "$PARENT_DIR" != "$ROOT" && ! -f "$PARENT_DIR/noxfile-template.py" ]];
+        do
             PARENT_DIR=$(dirname "$PARENT_DIR")
-	done
-	cp "$PARENT_DIR/noxfile-template.py" "./noxfile.py"
-	echo -e "\n Using noxfile-template from parent folder ($PARENT_DIR). \n"
-	cleanup_noxfile=1
+        done
+        cp "$PARENT_DIR/noxfile-template.py" "./noxfile.py"
+        echo -e "\n Using noxfile-template from parent folder ($PARENT_DIR). \n"
+        cleanup_noxfile=1
     else
-	cleanup_noxfile=0
+        cleanup_noxfile=0
     fi
 
     # Use nox to execute the tests for the project.
@@ -170,7 +170,7 @@ for file in **/requirements.txt; do
 
     # Remove noxfile.py if we copied.
     if [[ $cleanup_noxfile -eq 1 ]]; then
-	rm noxfile.py
+        rm noxfile.py
     fi
 
 done

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -43,18 +43,17 @@ export PATH="${HOME}/.local/bin:${PATH}"
 # install nox for testing
 pip install --user -q nox
 
-# Use secrets acessor service account to get secrets
+# Use secrets acessor service account to get secrets.
 if [[ -f "${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" ]]; then
     gcloud auth activate-service-account \
 	   --key-file="${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" \
 	   --project="cloud-devrel-kokoro-resources"
+    # This script will create 3 files:
+    # - testing/test-env.sh
+    # - testing/service-account.json
+    # - testing/client-secrets.json
+    ./scripts/decrypt-secrets.sh
 fi
-
-# This script will create 3 files:
-# - testing/test-env.sh
-# - testing/service-account.json
-# - testing/client-secrets.json
-./scripts/decrypt-secrets.sh
 
 source ./testing/test-env.sh
 export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/testing/service-account.json
@@ -175,8 +174,5 @@ for file in **/requirements.txt; do
 
 done
 cd "$ROOT"
-
-# Workaround for Kokoro permissions issue: delete secrets
-rm testing/{test-env.sh,client-secrets.json,service-account.json}
 
 exit "$RTN"

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -68,11 +68,11 @@ export GOOGLE_CLIENT_SECRETS=$(pwd)/testing/client-secrets.json
 export DATALABELING_ENDPOINT="test-datalabeling.sandbox.googleapis.com:443"
 
 # Run Cloud SQL proxy (background process exit when script does)
-sudo wget --quiet https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
-     -O /bin/cloud_sql_proxy && sudo chmod +x /bin/cloud_sql_proxy
-cloud_sql_proxy -instances="${MYSQL_INSTANCE}"=tcp:3306 &>> \
+wget --quiet https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
+     -O ${HOME}/cloud_sql_proxy && chmod +x ${HOME}/cloud_sql_proxy
+${HOME}/cloud_sql_proxy -instances="${MYSQL_INSTANCE}"=tcp:3306 &>> \
        ${HOME}/cloud_sql_proxy.log &
-cloud_sql_proxy -instances="${POSTGRES_INSTANCE}"=tcp:5432 &>> \
+${HOME}/cloud_sql_proxy -instances="${POSTGRES_INSTANCE}"=tcp:5432 &>> \
        ${HOME}/cloud_sql_proxy-postgres.log &
 echo -e "\nCloud SQL proxy started."
 

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -116,6 +116,9 @@ function repo_root() {
     echo "${dir}"
 }
 
+# Temporarily limit the test to vision/automl
+RUN_TESTS_DIRS="vision/automl"
+
 PROGRAM_PATH="$(realpath "$0")"
 PROGRAM_DIR="$(dirname "${PROGRAM_PATH}")"
 PROJECT_ROOT="$(repo_root "${PROGRAM_DIR}")"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -240,9 +240,7 @@ if [[ "${TRAMPOLINE_DOCKERFILE:-none}" != "none" ]]; then
 	"-f" "${TRAMPOLINE_DOCKERFILE}"
 	"-t" "${TRAMPOLINE_IMAGE}"
 	"--build-arg" "UID=${user_uid}"
-	"--build-arg" "GID=${user_gid}"
 	"--build-arg" "USERNAME=${user_name}"
-	"--build-arg" "DOCKER_GID=${docker_gid}"
     )
     if [[ "${has_cache}" == "true" ]]; then
 	docker_build_flags+=("--cache-from" "${TRAMPOLINE_IMAGE}")
@@ -280,6 +278,8 @@ docker_flags=(
 
     # Run the docker script with the user id. Because the docker image gets to
     # write in ${PWD} you typically want this to be your user id.
+    # To allow docker in docker, we need to use docker gid on the host.
+    # Now we passing the wrong one in order to see the build report failure.
     "--user" "${user_uid}:${user_gid}"
 
     # Pass down the USER.

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -35,7 +35,7 @@
 # You can optionally change these environment variables:
 #
 # TRAMPOLINE_IMAGE: The docker image to use.
-# TRAMPOLINE_IMAGE_SOURCE: The location of the Dockerfile.
+# TRAMPOLINE_DOCKERFILE: The location of the Dockerfile.
 # TRAMPOLINE_IMAGE_UPLOAD:
 #     (true|false): Whether to upload the Docker image after the
 #                   successful builds.
@@ -219,11 +219,11 @@ user_name="$(id -un)"
 docker_gid=$(cut -d: -f3 < <(getent group docker))
 
 update_cache="false"
-if [[ "${TRAMPOLINE_IMAGE_SOURCE:-none}" != "none" ]]; then
+if [[ "${TRAMPOLINE_DOCKERFILE:-none}" != "none" ]]; then
     # Build the Docker image from the source.
-    context_dir=$(dirname "${TRAMPOLINE_IMAGE_SOURCE}")
+    context_dir=$(dirname "${TRAMPOLINE_DOCKERFILE}")
     docker_build_flags=(
-	"-f" "${TRAMPOLINE_IMAGE_SOURCE}"
+	"-f" "${TRAMPOLINE_DOCKERFILE}"
 	"-t" "${TRAMPOLINE_IMAGE}"
 	"--build-arg" "UID=${user_uid}"
 	"--build-arg" "GID=${user_gid}"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -133,7 +133,7 @@ if [[ -n "${KOKORO_BUILD_ID:-}" ]]; then
 fi
 
 # Configure the service account for pulling the docker image.
-if [[ -n "${KOKORO_GFILE_DIR:-}" ]]; then
+if [[ "${TRAMPOLINE_CI:-}" == "kokoro" ]]; then
     # Now we're re-using the trampoline service account.
     # Potentially we can pass down this key into Docker for
     # bootstrapping secret.

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -148,7 +148,14 @@ required_envvars=(
 )
 
 pass_down_envvars=(
-    # Default empty list.
+    # KOKORO dynamic variables.
+    "KOKORO_BUILD_NUMBER"
+    "KOKORO_BUILD_ID"
+    "KOKORO_JOB_NAME"
+    "KOKORO_GIT_COMMIT"
+    "KOKORO_GITHUB_COMMIT"
+    "KOKORO_GITHUB_PULL_REQUEST_NUMBER"
+    "KOKORO_GITHUB_PULL_REQUEST_COMMIT"
 )
 
 if [[ -f "${PROJECT_ROOT}/.trampolinerc" ]]; then

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -252,9 +252,9 @@ docker_flags=(
     # Mount the project directory inside the Docker container.  To
     # allow docker in docker correctly mount the volume, we use the
     # same path for the volume.
-    "--volume" "${PWD}:${PWD}"
-    "--workdir" "${PWD}"
-    "--env" "PROJECT_ROOT=${PWD}"
+    "--volume" "${PWD}:/v"
+    "--workdir" "/v"
+    "--env" "PROJECT_ROOT=/v"
 
     # Mount the temporary home directory.
     "--volume" "${tmphome}:/h"
@@ -262,6 +262,10 @@ docker_flags=(
 
     # Allow docker in docker.
     "--volume" "/var/run/docker.sock:/var/run/docker.sock"
+
+    # Mount the /tmp so that docker in docker can mount the files
+    # there correctly.
+    "--volume" "/tmp:/tmp"
 )
 
 # Add an option for nicer output if the build gets a tty.
@@ -284,7 +288,7 @@ if [[ $# -ge 1 ]]; then
     readonly commands=("${@:1}")
 else
     log_yellow "Running the tests in a Docker container."
-    readonly commands=("${PWD}/${TRAMPOLINE_BUILD_FILE}")
+    readonly commands=("/v/${TRAMPOLINE_BUILD_FILE}")
 fi
 
 echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -88,6 +88,15 @@ function log_red() {
   log_impl "${IO_COLOR_RED}" "$@"
 }
 
+readonly tmpdir=$(mktemp -d -t ci-XXXXXXXX)
+readonly tmphome="${tmpdir}/h"
+mkdir -p "${tmphome}"
+
+function cleanup() {
+    rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
 function repo_root() {
     local dir="$1"
     while [[ ! -d "${dir}/.git" ]]; do
@@ -95,10 +104,6 @@ function repo_root() {
     done
     echo "${dir}"
 }
-
-readonly tmpdir=$(mktemp -d -t ci-XXXXXXXX)
-readonly tmphome="${tmpdir}/h"
-mkdir -p "${tmphome}"
 
 PROGRAM_PATH="$(realpath "$0")"
 PROGRAM_DIR="$(dirname "${PROGRAM_PATH}")"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -279,8 +279,7 @@ docker_flags=(
     # Run the docker script with the user id. Because the docker image gets to
     # write in ${PWD} you typically want this to be your user id.
     # To allow docker in docker, we need to use docker gid on the host.
-    # Now we passing the wrong one in order to see the build report failure.
-    "--user" "${user_uid}:${user_gid}"
+    "--user" "${user_uid}:${docker_gid}"
 
     # Pass down the USER.
     "--env" "USER=${user_name}"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -116,9 +116,6 @@ function repo_root() {
     echo "${dir}"
 }
 
-# Temporarily limit the test to vision/automl
-RUN_TESTS_DIRS="vision/automl"
-
 PROGRAM_PATH="$(realpath "$0")"
 PROGRAM_DIR="$(dirname "${PROGRAM_PATH}")"
 PROJECT_ROOT="$(repo_root "${PROGRAM_DIR}")"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -306,15 +306,17 @@ done
 if [[ $# -ge 1 ]]; then
     log_yellow "Running the given commands '" "${@:1}" "' in the container."
     readonly commands=("${@:1}")
+    echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
+    docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
 else
     log_yellow "Running the tests in a Docker container."
     # Temporary workaround to remove unnecessary prefix.
     real_build_file=${TRAMPOLINE_BUILD_FILE#"github/python-docs-samples/"}
-    readonly commands=("/v/${real_build_file}")
+    docker_flags+=("--entrypoint=${real_build_file}")
+    echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
+    docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
 fi
 
-echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
-docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
 
 test_retval=$?
 

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# trampoline_v2.sh
+#
+# This script does 3 things.
+#
+# 1. Prepare the Docker image for the test
+# 2. Run the Docker with appropriate flags to run the test
+# 3. Upload the newly built Docker image
+#
+# in a way that is somewhat compatible with trampoline_v1.
+#
+# To run this script, first download few files from gcs to /dev/shm.
+# (/dev/shm is passed into the container as KOKORO_GFILE_DIR).
+#
+# gsutil cp gs://cloud-devrel-kokoro-resources/python-docs-samples/secrets_viewer_service_account.json /dev/shm
+# gsutil cp gs://cloud-devrel-kokoro-resources/python-docs-samples/automl_secrets.txt /dev/shm
+#
+# Then run the script.
+# .kokoro/trampoline_v2.sh
+#
+# You can optionally change these environment variables:
+#
+# TRAMPOLINE_IMAGE: The docker image to use.
+# TRAMPOLINE_IMAGE_SOURCE: The location of the Dockerfile.
+# RUN_TESTS_SESSION: The nox session to run.
+# TRAMPOLINE_BUILD_FILE: The script to run in the docker container.
+
+set -euo pipefail
+
+if command -v tput >/dev/null && [[ -n "${TERM:-}" ]]; then
+  readonly IO_COLOR_RED="$(tput setaf 1)"
+  readonly IO_COLOR_GREEN="$(tput setaf 2)"
+  readonly IO_COLOR_YELLOW="$(tput setaf 3)"
+  readonly IO_COLOR_RESET="$(tput sgr0)"
+else
+  readonly IO_COLOR_RED=""
+  readonly IO_COLOR_GREEN=""
+  readonly IO_COLOR_YELLOW=""
+  readonly IO_COLOR_RESET=""
+fi
+
+# Logs a message using the given color. The first argument must be one of the
+# IO_COLOR_* variables defined above, such as "${IO_COLOR_YELLOW}". The
+# remaining arguments will be logged in the given color. The log message will
+# also have an RFC-3339 timestamp prepended (in UTC).
+function log_impl() {
+    local color="$1"
+    shift
+    local timestamp="$(date -u "+%Y-%m-%dT%H:%M:%SZ")"
+    echo "================================================================"
+    echo "${color}${timestamp}:" "$@" "${IO_COLOR_RESET}"
+    echo "================================================================"
+}
+
+# Logs the given message with normal coloring and a timestamp.
+function log() {
+  log_impl "${IO_COLOR_RESET}" "$@"
+}
+
+# Logs the given message in green with a timestamp.
+function log_green() {
+  log_impl "${IO_COLOR_GREEN}" "$@"
+}
+
+# Logs the given message in yellow with a timestamp.
+function log_yellow() {
+  log_impl "${IO_COLOR_YELLOW}" "$@"
+}
+
+# Logs the given message in red with a timestamp.
+function log_red() {
+  log_impl "${IO_COLOR_RED}" "$@"
+}
+
+function repo_root() {
+    local dir="$1"
+    while [[ ! -d "${dir}/.git" ]]; do
+	dir="$(dirname "$dir")"
+    done
+    echo "${dir}"
+}
+
+readonly tmpdir=$(mktemp -d -t ci-XXXXXXXX)
+readonly tmphome="${tmpdir}/h"
+mkdir -p "${tmphome}"
+
+PROGRAM_PATH="$(realpath "$0")"
+PROGRAM_DIR="$(dirname "${PROGRAM_PATH}")"
+PROJECT_ROOT="$(repo_root "${PROGRAM_DIR}")"
+
+RUNNING_IN_CI="false"
+
+if [[ -n "${KOKORO_GFILE_DIR:-}" ]]; then
+    # descriptive env var for indicating it's on CI.
+    RUNNING_IN_CI="true"
+
+    # Now we're re-using the trampoline service account.
+    # Potentially we can pass down this key into Docker for
+    # bootstrapping secret.
+    SERVICE_ACCOUNT_KEY_FILE="${KOKORO_GFILE_DIR}/kokoro-trampoline.service-account.json"
+
+    mkdir -p "${tmpdir}/gcloud"
+    gcloud_config_dir="${tmpdir}/gcloud"
+
+    log "Using isolated gcloud config: ${gcloud_config_dir}."
+    export CLOUDSDK_CONFIG="${gcloud_config_dir}"
+
+    log "Using ${SERVICE_ACCOUNT_KEY_FILE} for authentication."
+    gcloud auth activate-service-account \
+	   --key-file "${SERVICE_ACCOUNT_KEY_FILE}"
+    gcloud auth configure-docker --quiet
+fi
+
+log_yellow "Changing to the project root: ${PROJECT_ROOT}."
+cd "${PROJECT_ROOT}"
+
+required_envvars=(
+    # The basic trampoline configurations.
+    "TRAMPOLINE_IMAGE"
+    "TRAMPOLINE_BUILD_FILE"
+)
+
+pass_down_envvars=(
+    # Default empty list.
+)
+
+if [[ -f "${PROJECT_ROOT}/.trampolinerc" ]]; then
+    source "${PROJECT_ROOT}/.trampolinerc"
+fi
+
+log_yellow "Checking environment variables."
+for e in "${required_envvars[@]}"
+do
+    if [[ -z "${!e:-}" ]]; then
+	log "Missing ${e} env var. Aborting."
+	exit 1
+    fi
+done
+
+log_yellow "Preparing Docker image."
+# Download the docker image specified by `TRAMPOLINE_IMAGE`
+
+set +e  # ignore error on docker operations
+# We may want to add --max-concurrent-downloads flag.
+
+log_yellow "Start pulling the Docker image: ${TRAMPOLINE_IMAGE}."
+if docker pull "${TRAMPOLINE_IMAGE}"; then
+    log_green "Finished pulling the Docker image: ${TRAMPOLINE_IMAGE}."
+    has_cache="true"
+else
+    log_red "Failed pulling the Docker image: ${TRAMPOLINE_IMAGE}."
+    has_cache="false"
+fi
+
+
+update_cache="false"
+if [[ -n "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
+    # Build the Docker image from the source.
+    context_dir=$(dirname "${TRAMPOLINE_IMAGE_SOURCE}")
+    docker_build_flags=(
+	"-f" "${TRAMPOLINE_IMAGE_SOURCE}"
+	"-t" "${TRAMPOLINE_IMAGE}"
+    )
+    if [[ "${has_cache}" == "true" ]]; then
+	docker_build_flags+=("--cache-from" "${TRAMPOLINE_IMAGE}")
+    fi
+
+    log_yellow "Start building the docker image."
+    if docker build "${docker_build_flags[@]}" "${context_dir}"; then
+	log_green "Finished building the docker image."
+	update_cache="true"
+    else
+	log_red "Failed to build the Docker image. Aborting."
+	exit 1
+    fi
+else
+    if [[ "${has_cache}" != "true" ]]; then
+	log_red "failed to download the image ${TRAMPOLINE_IMAGE}, aborting."
+	exit 1
+    fi
+fi
+
+# The default user for a Docker container has uid 0 (root). To avoid
+# creating root-owned files in the build directory we tell docker to
+# use the current user ID.
+docker_uid="$(id -u)"
+docker_gid="$(id -g)"
+docker_user="$(id -un)"
+
+# We use an array for the flags so they are easier to document.
+docker_flags=(
+    # Remove the container after it exists.
+    "--rm"
+
+    # Use the host network.
+    "--network=host"
+
+    # Run in priviledged mode. We are not using docker for sandboxing or
+    # isolation, just for packaging our dev tools.
+    "--privileged"
+
+    # Pass down the KOKORO_GFILE_DIR
+    "--volume" "${KOKORO_GFILE_DIR:-/dev/shm}:/gfile"
+    "--env" "KOKORO_GFILE_DIR=/gfile"
+
+    # Tells scripts whether they are running as part of CI or not.
+    "--env" "RUNNING_IN_CI=${RUNNING_IN_CI:-no}"
+
+    # Run the docker script and this user id. Because the docker image gets to
+    # write in ${PWD} you typically want this to be your user id.
+    "--user" "${docker_uid}:${docker_gid}"
+
+    # Pass down the USER.
+    "--env" "USER=${docker_user}"
+
+    # Mount the project directory inside the Docker container.
+    "--volume" "${PWD}:/v"
+    "--workdir" "/v"
+    "--env" "PROJECT_ROOT=/v"
+
+    # Mount the temporary home directory.
+    "--volume" "${tmphome}:/h"
+    "--env" "HOME=/h"
+)
+
+# Add an option for nicer output if the build gets a tty.
+if [[ -t 0 ]]; then
+    docker_flags+=("-it")
+fi
+
+# Passing down env vars
+for e in "${pass_down_envvars[@]}"
+do
+    docker_flags+=("--env" "${e}=${!e}")
+done
+
+# If arguments are given, all arguments will become the commands run
+# in the container, otherwise run TRAMPOLINE_BUILD_FILE.
+
+if [[ $# -ge 1 ]]; then
+    log_yellow "Running the given commands '" "${@:1}" "' in the container."
+    readonly commands=("${@:1}")
+else
+    log_yellow "Running the tests in a Docker container."
+    readonly commands=("/v/${TRAMPOLINE_BUILD_FILE}")
+fi
+
+echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
+docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
+
+test_retval=$?
+
+if [[ ${test_retval} -eq 0 ]]; then
+    log_green "Build finished with ${test_retval}"
+else
+    log_red "Build finished with ${test_retval}"
+fi
+
+if [[ "${RUNNING_IN_CI}" == "true" ]] && \
+       [[ "${update_cache}" == "true" ]] && \
+       [[ -z "${KOKORO_GITHUB_PULL_REQUEST_NUMBER:-}" ]] && \
+       [[ $test_retval == 0 ]]; then
+    # Only upload it when the test passes.
+    log_yellow "Uploading the Docker image."
+    if docker push "${TRAMPOLINE_IMAGE}"; then
+	log_green "Finished uploading the Docker image."
+    else
+	log_red "Failed uploading the Docker image."
+    fi
+fi

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -170,7 +170,7 @@ fi
 
 
 update_cache="false"
-if [[ -n "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
+if [[ "${TRAMPOLINE_IMAGE_SOURCE:-none}" != "none" ]]; then
     # Build the Docker image from the source.
     context_dir=$(dirname "${TRAMPOLINE_IMAGE_SOURCE}")
     docker_build_flags=(

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -269,8 +269,7 @@ docker_flags=(
 
     # Run the docker script with the user id. Because the docker image gets to
     # write in ${PWD} you typically want this to be your user id.
-    # Also to allow docker in docker, we use docker gid on the host.
-    "--user" "${user_uid}:${docker_gid}"
+    "--user" "${user_uid}:${user_gid}"
 
     # Pass down the USER.
     "--env" "USER=${user_name}"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -320,9 +320,7 @@ if [[ $# -ge 1 ]]; then
     docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
 else
     log_yellow "Running the tests in a Docker container."
-    # Temporary workaround to remove unnecessary prefix.
-    real_build_file=${TRAMPOLINE_BUILD_FILE#"github/python-docs-samples/"}
-    docker_flags+=("--entrypoint=${real_build_file}")
+    docker_flags+=("--entrypoint=${TRAMPOLINE_BUILD_FILE}")
     if [[ "${TRAMPOLINE_SHOW_COMMAND:-false}" == "true" ]]; then
 	echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
     fi

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -176,6 +176,9 @@ pass_down_envvars=(
     "KOKORO_GITHUB_COMMIT"
     "KOKORO_GITHUB_PULL_REQUEST_NUMBER"
     "KOKORO_GITHUB_PULL_REQUEST_COMMIT"
+    # For Build Cop Bot
+    "KOKORO_GITHUB_COMMIT_URL"
+    "KOKORO_GITHUB_PULL_REQUEST_URL"
 )
 
 if [[ -f "${PROJECT_ROOT}/.trampolinerc" ]]; then

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -286,7 +286,9 @@ if [[ $# -ge 1 ]]; then
     readonly commands=("${@:1}")
 else
     log_yellow "Running the tests in a Docker container."
-    readonly commands=("/v/${TRAMPOLINE_BUILD_FILE}")
+    # Temporary workaround to remove unnecessary prefix.
+    real_build_file=${TRAMPOLINE_BUILD_FILE#"github/python-docs-samples/"}
+    readonly commands=("/v/${real_build_file}")
 fi
 
 echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -357,3 +357,5 @@ if [[ "${update_cache}" == "true" ]] && \
 	log_red "Failed uploading the Docker image."
     fi
 fi
+
+exit "${test_retval}"

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -230,6 +230,9 @@ if [[ "${TRAMPOLINE_IMAGE_SOURCE:-none}" != "none" ]]; then
     fi
 
     log_yellow "Start building the docker image."
+    if [[ "${TRAMPOLINE_SHOW_COMMAND:-false}" == "true" ]]; then
+	echo "docker build" "${docker_build_flags[@]}" "${context_dir}"
+    fi
     if docker build "${docker_build_flags[@]}" "${context_dir}"; then
 	log_green "Finished building the docker image."
 	update_cache="true"
@@ -306,14 +309,18 @@ done
 if [[ $# -ge 1 ]]; then
     log_yellow "Running the given commands '" "${@:1}" "' in the container."
     readonly commands=("${@:1}")
-    echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
+    if [[ "${TRAMPOLINE_SHOW_COMMAND:-false}" == "true" ]]; then
+	echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
+    fi
     docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}" "${commands[@]}"
 else
     log_yellow "Running the tests in a Docker container."
     # Temporary workaround to remove unnecessary prefix.
     real_build_file=${TRAMPOLINE_BUILD_FILE#"github/python-docs-samples/"}
     docker_flags+=("--entrypoint=${real_build_file}")
-    echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
+    if [[ "${TRAMPOLINE_SHOW_COMMAND:-false}" == "true" ]]; then
+	echo docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
+    fi
     docker run "${docker_flags[@]}" "${TRAMPOLINE_IMAGE}"
 fi
 

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -234,10 +234,6 @@ docker_flags=(
     # isolation, just for packaging our dev tools.
     "--privileged"
 
-    # Pass down the KOKORO_GFILE_DIR
-    "--volume" "${KOKORO_GFILE_DIR:-/dev/shm}:/gfile"
-    "--env" "KOKORO_GFILE_DIR=/gfile"
-
     # Tells scripts whether they are running as part of CI or not.
     "--env" "RUNNING_IN_CI=${RUNNING_IN_CI:-no}"
 
@@ -264,7 +260,16 @@ docker_flags=(
     # Mount the /tmp so that docker in docker can mount the files
     # there correctly.
     "--volume" "/tmp:/tmp"
+
+    # Pass down the KOKORO_GFILE_DIR and KOKORO_KEYSTORE_DIR
+    # TODO(tmatsuo): This part is not portable.
+    "--env" "TRAMPOLINE_SECRET_DIR=/secrets"
+    "--volume" "${KOKORO_GFILE_DIR:-/dev/shm}:/secrets/gfile"
+    "--env" "KOKORO_GFILE_DIR=/secrets/gfile"
+    "--volume" "${KOKORO_KEYSTORE_DIR:-/dev/shm}:/secrets/keystore"
+    "--env" "KOKORO_KEYSTORE_DIR=/secrets/keystore"
 )
+
 
 # Add an option for nicer output if the build gets a tty.
 if [[ -t 0 ]]; then

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -38,6 +38,8 @@
 # TRAMPOLINE_IMAGE_SOURCE: The location of the Dockerfile.
 # RUN_TESTS_SESSION: The nox session to run.
 # TRAMPOLINE_BUILD_FILE: The script to run in the docker container.
+# RUN_TESTS_DIR: A colon separated directory list relative to the
+#                project root.
 
 set -euo pipefail
 
@@ -245,12 +247,13 @@ fi
 # Passing down env vars
 for e in "${pass_down_envvars[@]}"
 do
-    docker_flags+=("--env" "${e}=${!e}")
+    if [[ -n "${!e:-}" ]]; then
+	docker_flags+=("--env" "${e}=${!e}")
+    fi
 done
 
 # If arguments are given, all arguments will become the commands run
 # in the container, otherwise run TRAMPOLINE_BUILD_FILE.
-
 if [[ $# -ge 1 ]]; then
     log_yellow "Running the given commands '" "${@:1}" "' in the container."
     readonly commands=("${@:1}")

--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -249,10 +249,8 @@ docker_flags=(
     # Pass down the USER.
     "--env" "USER=${user_name}"
 
-    # Mount the project directory inside the Docker container.  To
-    # allow docker in docker correctly mount the volume, we use the
-    # same path for the volume.
-    "--volume" "${PWD}:/v"
+    # Mount the project directory inside the Docker container.
+    "--volume" "${PROJECT_ROOT}:/v"
     "--workdir" "/v"
     "--env" "PROJECT_ROOT=/v"
 

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -60,3 +60,9 @@ fi
 if [[ -z "${TRAMPOLINE_IMAGE_UPLOAD:-}" ]]; then
     TRAMPOLINE_IMAGE_UPLOAD="false"
 fi
+
+if [[ -z "${TRAMPOLINE_SHOW_COMMAND:-}" ]]; then
+    # We are sure there's no secrets in the command line in docker
+    # bulid and docker run commands.
+    TRAMPOLINE_SHOW_COMMAND="true"
+fi

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+required_envvars+=(
+    # The nox session to run.
+    "RUN_TESTS_SESSION"
+)
+
+pass_down_envvars+=(
+    "RUN_TESTS_SESSION"
+)
+
+# Set default values. You can override them with env vars.
+if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+    # Set default image.
+    TRAMPOLINE_IMAGE="gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
+fi
+
+if [[ -z "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
+    TRAMPOLINE_IMAGE_SOURCE=".kokoro/docker/Dockerfile"
+fi
+
+if [[ -z "${RUN_TESTS_SESSION:-}" ]]; then
+    RUN_TESTS_SESSION="py-3.7"
+fi
+
+if [[ -z "${TRAMPOLINE_BUILD_FILE:-}" ]]; then
+   TRAMPOLINE_BUILD_FILE=".kokoro/tests/run_tests_diff_head.sh"
+fi

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -25,8 +25,9 @@ required_envvars+=(
 pass_down_envvars+=(
     "BUILD_SPECIFIC_GCLOUD_PROJECT"
     "REPORT_TO_BUILD_COP_BOT"
-    # The nox session to run.
+    # Target directories.
     "RUN_TESTS_DIRS"
+    # The nox session to run.
     "RUN_TESTS_SESSION"
 )
 

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -18,6 +18,10 @@ required_envvars+=(
 )
 
 pass_down_envvars+=(
+    "BUILD_SPECIFIC_GCLOUD_PROJECT"
+    "REPORT_TO_BUILD_COP_BOT"
+    # The nox session to run.
+    "RUN_TESTS_DIRS"
     "RUN_TESTS_SESSION"
 )
 

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -45,8 +45,8 @@ if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
     TRAMPOLINE_IMAGE="gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 fi
 
-if [[ -z "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
-    TRAMPOLINE_IMAGE_SOURCE=".kokoro/docker/Dockerfile"
+if [[ -z "${TRAMPOLINE_DOCKERFILE:-}" ]]; then
+    TRAMPOLINE_DOCKERFILE=".kokoro/docker/Dockerfile"
 fi
 
 if [[ -z "${RUN_TESTS_SESSION:-}" ]]; then

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Environment variables for python-docs-samples:
+# RUN_TESTS_SESSION: The nox session to run.
+# RUN_TESTS_DIR: A colon separated directory list relative to the
+# project root.
+
 required_envvars+=(
     # The nox session to run.
     "RUN_TESTS_SESSION"
@@ -24,6 +29,14 @@ pass_down_envvars+=(
     "RUN_TESTS_DIRS"
     "RUN_TESTS_SESSION"
 )
+
+# Prevent unintentional override on the default image.
+
+if [[ "${TRAMPOLINE_IMAGE_UPLOAD:-false}" == "true" ]] && \
+   [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+   echo "Please set TRAMPOLINE_IMAGE if you want to upload the Docker image."
+   exit 1
+fi
 
 # Set default values. You can override them with env vars.
 if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
@@ -41,4 +54,8 @@ fi
 
 if [[ -z "${TRAMPOLINE_BUILD_FILE:-}" ]]; then
    TRAMPOLINE_BUILD_FILE=".kokoro/tests/run_tests_diff_head.sh"
+fi
+
+if [[ -z "${TRAMPOLINE_IMAGE_UPLOAD:-}" ]]; then
+    TRAMPOLINE_IMAGE_UPLOAD="false"
 fi

--- a/.trampolinerc_tmpl
+++ b/.trampolinerc_tmpl
@@ -37,8 +37,8 @@ if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
     # TRAMPOLINE_IMAGE="gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
 fi
 
-if [[ -z "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
-    # TRAMPOLINE_IMAGE_SOURCE=".kokoro/docker/Dockerfile"
+if [[ -z "${TRAMPOLINE_DOCKERFILE:-}" ]]; then
+    # TRAMPOLINE_DOCKERFILE=".kokoro/docker/Dockerfile"
 fi
 
 if [[ -z "${TRAMPOLINE_BUILD_FILE:-}" ]]; then

--- a/.trampolinerc_tmpl
+++ b/.trampolinerc_tmpl
@@ -1,0 +1,46 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Template for .trampolinerc
+
+# Add required env vars here.
+required_envvars+=(
+)
+
+# Add env vars which are passed down into the container here.
+pass_down_envvars+=(
+)
+
+# Prevent unintentional override on the default image.
+if [[ "${TRAMPOLINE_IMAGE_UPLOAD:-false}" == "true" ]] && \
+   [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+   echo "Please set TRAMPOLINE_IMAGE if you want to upload the Docker image."
+   exit 1
+fi
+
+if [[ -z "${TRAMPOLINE_IMAGE_UPLOAD:-}" ]]; then
+    TRAMPOLINE_IMAGE_UPLOAD="false"
+fi
+
+if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
+    # TRAMPOLINE_IMAGE="gcr.io/cloud-devrel-kokoro-resources/python-samples-testing-docker"
+fi
+
+if [[ -z "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
+    # TRAMPOLINE_IMAGE_SOURCE=".kokoro/docker/Dockerfile"
+fi
+
+if [[ -z "${TRAMPOLINE_BUILD_FILE:-}" ]]; then
+    # TRAMPOLINE_BUILD_FILE=".kokoro/build.sh"
+fi

--- a/scripts/decrypt-secrets.sh
+++ b/scripts/decrypt-secrets.sh
@@ -20,6 +20,14 @@ ROOT=$( dirname "$DIR" )
 # Work from the project root.
 cd $ROOT
 
+# Prevent it from overriding files.
+if [[ -f "testing/test-env.sh" ]] || \
+       [[ -f "testing/service-account.json" ]] || \
+       [[ -f "testing/client-secrets.json" ]]; then
+    echo "One or more target files exist, aborting."
+    exit 1
+fi
+
 # Use SECRET_MANAGER_PROJECT if set, fallback to cloud-devrel-kokoro-resources.
 PROJECT_ID="${SECRET_MANAGER_PROJECT:-cloud-devrel-kokoro-resources}"
 

--- a/scripts/run_tests_local.sh
+++ b/scripts/run_tests_local.sh
@@ -50,6 +50,10 @@ directory="$(realpath "$1")"
 relative_dir=${directory#"${PROJECT_ROOT}/"}
 export RUN_TESTS_DIRS="${relative_dir}"
 
+if [[ -z "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
+    export TRAMPOLINE_IMAGE_SOURCE="none"
+fi
+
 if [[ $# -ge 2 ]]; then
     sessions=("${@:2}")
 fi

--- a/scripts/run_tests_local.sh
+++ b/scripts/run_tests_local.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# run_tests_local.sh
+#
+# This script is a helper script for running tests with
+# .kokoro/trampoline_v2.sh.
+# run_tests_local.sh directory (sessions..)
+
+set -euo pipefail
+
+sessions=(
+    "lint"
+    "py-3.6"
+    "py-3.7"
+)
+
+# The only required argument is a directory for running the tests.
+if [[ $# -lt 1 ]]; then
+    echo "Please provide at least one argument."
+    echo "Usage: run_tests_local.sh directory (sessions..)"
+    exit 1
+fi
+
+function repo_root() {
+    local dir="$1"
+    while [[ ! -d "${dir}/.git" ]]; do
+	dir="$(dirname "$dir")"
+    done
+    echo "${dir}"
+}
+
+PROGRAM_PATH="$(realpath "$0")"
+PROGRAM_DIR="$(dirname "${PROGRAM_PATH}")"
+PROJECT_ROOT="$(repo_root "${PROGRAM_DIR}")"
+
+directory="$(realpath "$1")"
+relative_dir=${directory#"${PROJECT_ROOT}/"}
+export RUN_TESTS_DIRS="${relative_dir}"
+
+if [[ $# -ge 2 ]]; then
+    sessions=("${@:2}")
+fi
+
+echo "Running tests for directory: ${directory}"
+echo "Sessions: ${sessions[@]}"
+
+for session in "${sessions[@]}"
+do
+    export RUN_TESTS_SESSION="${session}"
+    "${PROJECT_ROOT}/.kokoro/trampoline_v2.sh"
+done

--- a/scripts/run_tests_local.sh
+++ b/scripts/run_tests_local.sh
@@ -54,8 +54,8 @@ directory="$(realpath "$1")"
 relative_dir=${directory#"${PROJECT_ROOT}/"}
 export RUN_TESTS_DIRS="${relative_dir}"
 
-if [[ -z "${TRAMPOLINE_IMAGE_SOURCE:-}" ]]; then
-    export TRAMPOLINE_IMAGE_SOURCE="none"
+if [[ -z "${TRAMPOLINE_DOCKERFILE:-}" ]]; then
+    export TRAMPOLINE_DOCKERFILE="none"
 fi
 
 if [[ $# -ge 2 ]]; then

--- a/scripts/run_tests_local.sh
+++ b/scripts/run_tests_local.sh
@@ -54,9 +54,8 @@ directory="$(realpath "$1")"
 relative_dir=${directory#"${PROJECT_ROOT}/"}
 export RUN_TESTS_DIRS="${relative_dir}"
 
-if [[ -z "${TRAMPOLINE_DOCKERFILE:-}" ]]; then
-    export TRAMPOLINE_DOCKERFILE="none"
-fi
+# We want to test this directory regardless of whether there's a change.
+export TRAMPOLINE_BUILD_FILE=".kokoro/tests/run_tests.sh"
 
 if [[ $# -ge 2 ]]; then
     sessions=("${@:2}")
@@ -71,4 +70,7 @@ for session in "${sessions[@]}"
 do
     export RUN_TESTS_SESSION="${session}"
     "${PROJECT_ROOT}/.kokoro/trampoline_v2.sh"
+    # We can re-use the image after the first iteration.
+    export TRAMPOLINE_SKIP_DOWNLOAD_IMAGE="true"
+    export TRAMPOLINE_DOCKERFILE="none"
 done

--- a/scripts/run_tests_local.sh
+++ b/scripts/run_tests_local.sh
@@ -18,10 +18,14 @@
 # This script is a helper script for running tests with
 # .kokoro/trampoline_v2.sh.
 # run_tests_local.sh directory (sessions..)
+#
+# Example for running lint, py-3.6 and py-3.7 for cdn directory:
+# $ cd cdn
+# $ ../scripts/run_tests_local.sh .
 
 set -euo pipefail
 
-sessions=(
+default_sessions=(
     "lint"
     "py-3.6"
     "py-3.7"
@@ -56,6 +60,8 @@ fi
 
 if [[ $# -ge 2 ]]; then
     sessions=("${@:2}")
+else
+    sessions=("${default_sessions[@]}")
 fi
 
 echo "Running tests for directory: ${directory}"


### PR DESCRIPTION
This PR changes the build file to `trampoline_v2.sh` for all the jobs.

`trampoline_v2.sh` does 3 things.
1. Prepare the Docker image for the test
2. Run the Docker with appropriate flags to run the test
3. Upload the newly built Docker image
                                                                                                                                                                  
in a way that is somewhat compatible with trampoline_v1.

It also behaves better in many ways.
1. It uses the same uid as the caller, use the same gid as docker group on the host.
2. No permission change required upon cleanup.
3. It's bit more portable so that much easier to run somewhere other than Kokoro including local env.
4. It can optionally build the docker image from the source then use the built image for the test, so that you can have a single PR for changing the Dockerfile and tests.
5. Logging with timestamp. Easier to determine the bottleneck.
6. Only passing down minimum envvars.
7. Somewhat configurable with `.trampolinerc`.

## Python specific info
To run this script, first decrypt our test secret by running `scripts/decrypt-secrets.sh`. This need secret-accessor role on our Cloud Project.
                                                                                                                                                                
Then run the script:
```bash
.kokoro/trampoline_v2.sh
```
You can optionally change these environment variables:
- TRAMPOLINE_IMAGE: The docker image to use.
- TRAMPOLINE_IMAGE_SOURCE: The location of the Dockerfile.
- RUN_TESTS_SESSION: The nox session to run.
- RUN_TESTS_DIRS: colon separated values for which directory you want to run the tests.
- TRAMPOLINE_BUILD_FILE: The script to run in the docker container.

I also added a handy script for running tests locally.

`scripts/run_tests_local.sh` takes only one required argument, and run test sessions for that directory. Example:

```bash
$ pwd
/home/tmatsuo/work/python-docs-samples
$ cd cdn
$ ../scripts/run_tests_local.sh .  # it will runs lint, py-3.6, and py-3.7 
# or
$ ../scripts/run_tests_local.sh . lint py-3.6  # it will only run lint and py-3.6
```