### PR TITLE
testing: various cleanups

### DIFF
--- a/scripts/decrypt-secrets.sh
+++ b/scripts/decrypt-secrets.sh
@@ -20,6 +20,14 @@ ROOT=$( dirname "$DIR" )
 # Work from the project root.
 cd $ROOT
 
-gcloud secrets versions access latest --secret="python-docs-samples-test-env" > testing/test-env.sh
-gcloud secrets versions access latest --secret="python-docs-samples-service-account" > testing/service-account.json
-gcloud secrets versions access latest --secret="python-docs-samples-client-secrets" > testing/client-secrets.json
+# Use SECRET_MANAGER_PROJECT if set, fallback to cloud-devrel-kokoro-resources.
+PROJECT_ID="${SECRET_MANAGER_PROJECT:-cloud-devrel-kokoro-resources}"
+
+gcloud secrets versions access latest --secret="python-docs-samples-test-env" \
+       > testing/test-env.sh
+gcloud secrets versions access latest \
+       --secret="python-docs-samples-service-account" \
+       > testing/service-account.json
+gcloud secrets versions access latest \
+       --secret="python-docs-samples-client-secrets" \
+       > testing/client-secrets.json

--- a/scripts/encrypt-secrets.sh
+++ b/scripts/encrypt-secrets.sh
@@ -20,6 +20,17 @@ ROOT=$( dirname "$DIR" )
 # Work from the project root.
 cd $ROOT
 
-gcloud secrets versions add "python-docs-samples-test-env" --data-file="testing/test-env.sh"
-gcloud secrets versions add "python-docs-samples-service-account" --data-file="testing/service-account.json"
-gcloud secrets versions add "python-docs-samples-client-secrets" --data-file="testing/client-secrets.json"
+# Use SECRET_MANAGER_PROJECT if set, fallback to cloud-devrel-kokoro-resources.
+PROJECT_ID="${SECRET_MANAGER_PROJECT:-cloud-devrel-kokoro-resources}"
+
+gcloud secrets versions add "python-docs-samples-test-env" \
+       --project="${PROJECT_ID}" \
+       --data-file="testing/test-env.sh"
+
+gcloud secrets versions add "python-docs-samples-service-account" \
+       --project="${PROJECT_ID}" \
+       --data-file="testing/service-account.json"
+
+gcloud secrets versions add "python-docs-samples-client-secrets" \
+       --project="${PROJECT_ID}" \
+       --data-file="testing/client-secrets.json"


### PR DESCRIPTION
* activate the secret service account only when the key is there
* merge automl_secrets.txt into test-env.sh
* if .kokoro/docker or .kokoro/tests have changes, test everything
* remove stale apt-get command
* use SECRET_MANAGER_PROJECT envvar for secret manager command,
  fallback to cloud-devrel-kokoro-resources

fixes #3820 