### PR TITLE
fix: make timeout an optional positional arg

### DIFF
--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -309,7 +309,7 @@ def remove_dead_letter_policy(project_id, topic_name, subscription_name):
     return subscription_after_update
 
 
-def receive_messages(project_id, subscription_name, timeout):
+def receive_messages(project_id, subscription_name, timeout=None):
     """Receives messages from a pull subscription."""
     # [START pubsub_subscriber_async_pull]
     # [START pubsub_quickstart_subscriber]

--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -309,7 +309,7 @@ def remove_dead_letter_policy(project_id, topic_name, subscription_name):
     return subscription_after_update
 
 
-def receive_messages(project_id, subscription_name, timeout=None):
+def receive_messages(project_id, subscription_name, timeout):
     """Receives messages from a pull subscription."""
     # [START pubsub_subscriber_async_pull]
     # [START pubsub_quickstart_subscriber]
@@ -678,7 +678,7 @@ if __name__ == "__main__":
 
     receive_parser = subparsers.add_parser("receive", help=receive_messages.__doc__)
     receive_parser.add_argument("subscription_name")
-    receive_parser.add_argument("--timeout", default=None, type=float)
+    receive_parser.add_argument("timeout", default=None, type=float, nargs="?")
 
     receive_with_custom_attributes_parser = subparsers.add_parser(
         "receive-custom-attributes",
@@ -686,14 +686,16 @@ if __name__ == "__main__":
     )
     receive_with_custom_attributes_parser.add_argument("subscription_name")
     receive_with_custom_attributes_parser.add_argument(
-        "--timeout", default=None, type=float
+        "timeout", default=None, type=float, nargs="?"
     )
 
     receive_with_flow_control_parser = subparsers.add_parser(
         "receive-flow-control", help=receive_messages_with_flow_control.__doc__
     )
     receive_with_flow_control_parser.add_argument("subscription_name")
-    receive_with_flow_control_parser.add_argument("--timeout", default=None, type=float)
+    receive_with_flow_control_parser.add_argument(
+        "timeout", default=None, type=float, nargs="?"
+    )
 
     synchronous_pull_parser = subparsers.add_parser(
         "receive-synchronously", help=synchronous_pull.__doc__
@@ -710,7 +712,9 @@ if __name__ == "__main__":
         "listen-for-errors", help=listen_for_errors.__doc__
     )
     listen_for_errors_parser.add_argument("subscription_name")
-    listen_for_errors_parser.add_argument("--timeout", default=None, type=float)
+    listen_for_errors_parser.add_argument(
+        "timeout", default=None, type=float, nargs="?"
+    )
 
     receive_messages_with_delivery_attempts_parser = subparsers.add_parser(
         "receive-messages-with-delivery-attempts",
@@ -718,7 +722,7 @@ if __name__ == "__main__":
     )
     receive_messages_with_delivery_attempts_parser.add_argument("subscription_name")
     receive_messages_with_delivery_attempts_parser.add_argument(
-        "--timeout", default=None, type=float
+        "timeout", default=None, type=float, nargs="?"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Use `nargs='?'` for a positional argument to make it optional. 

Old behavior: 
1. `python subscriber.py $PROJECT receive $SUBSCRIPTION_NAME` complains about `timeout` not set, and one has to add `--timeout`.
1. `python subscriber.py $PROJECT receive $SUBSCRIPTION_NAME --timeout=5` runs with a `timeout` value of 5 seconds.

New behavior: 
1. `python subscriber.py $PROJECT receive $SUBSCRIPTION_NAME` will run with a default `timeout` value, which is `None`.
1. `python subscriber.py $PROJECT receive $SUBSCRIPTION_NAME 5` will run with a `timeout` value of 5 seconds.