### PR TITLE
refactor Cloud SQL samples

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/README.md
+++ b/cloud-sql/mysql/sqlalchemy/README.md
@@ -42,7 +42,8 @@ export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash
@@ -59,7 +60,8 @@ $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
 ```powershell
@@ -92,7 +94,8 @@ export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash

--- a/cloud-sql/mysql/sqlalchemy/README.md
+++ b/cloud-sql/mysql/sqlalchemy/README.md
@@ -17,17 +17,6 @@ name.
 [instructions](https://cloud.google.com/sql/docs/mysql/connect-external-app#4_if_required_by_your_authentication_method_create_a_service_account).
 Download a JSON key to use to authenticate your connection. 
 
-1. Use the information noted in the previous steps:
-```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
-export CLOUD_SQL_CONNECTION_NAME='<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
-export DB_USER='my-db-user'
-export DB_PASS='my-db-pass'
-export DB_NAME='my_db'
-```
-Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
-
 ## Running locally
 
 To run this application locally, download and install the `cloud_sql_proxy` by
@@ -52,6 +41,8 @@ export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
+Note: Saving credentials in environment variables is convenient, but not secure - consider a more
+secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash
@@ -67,6 +58,8 @@ $env:DB_USER="<DB_USER_NAME>"
 $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
 ```
+Note: Saving credentials in environment variables is convenient, but not secure - consider a more
+secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
 ```powershell
@@ -98,6 +91,8 @@ export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
+Note: Saving credentials in environment variables is convenient, but not secure - consider a more
+secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash

--- a/cloud-sql/mysql/sqlalchemy/README.md
+++ b/cloud-sql/mysql/sqlalchemy/README.md
@@ -87,7 +87,7 @@ sudo chown -R $USER /cloudsql
 
 You'll also need to initialize an environment variable containing the directory you just created:
 ```bash
-export DB_SOCKET_PATH=/path/to/the/new/directory
+export DB_SOCKET_DIR=/path/to/the/new/directory
 ```
 
 Use these terminal commands to initialize other environment variables as well:
@@ -101,7 +101,7 @@ export DB_NAME='<DB_NAME>'
 
 Then use this command to launch the proxy in the background:
 ```bash
-./cloud_sql_proxy -dir=$DB_SOCKET_PATH --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud_sql_proxy -dir=$DB_SOCKET_DIR --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
 ```
 
 ### Testing the application

--- a/cloud-sql/mysql/sqlalchemy/app.flexible.yaml
+++ b/cloud-sql/mysql/sqlalchemy/app.flexible.yaml
@@ -29,7 +29,8 @@ beta_settings:
   cloud_sql_instances: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>=tcp:<PORT>
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-# something like https://cloud.google.com/kms/ to help keep secrets secret.
+# something like https://cloud.google.com/secret-manager/docs/overview to help keep
+# secrets secret.
 env_variables:
   CLOUD_SQL_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
   DB_USER: my-db-user

--- a/cloud-sql/mysql/sqlalchemy/app.standard.yaml
+++ b/cloud-sql/mysql/sqlalchemy/app.standard.yaml
@@ -15,7 +15,8 @@
 runtime: python37
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-# something like https://cloud.google.com/kms/ to help keep secrets secret.
+# something like https://cloud.google.com/secret-manager/docs/overview to help keep
+# secrets secret.
 env_variables:
   CLOUD_SQL_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
   DB_USER: my-db-user

--- a/cloud-sql/mysql/sqlalchemy/main.py
+++ b/cloud-sql/mysql/sqlalchemy/main.py
@@ -63,27 +63,25 @@ def init_tcp_connection_engine(db_config):
     # [START cloud_sql_mysql_sqlalchemy_create_tcp]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
     # something like https://cloud.google.com/kms/ to help keep secrets secret.
-    db_user = os.environ.get("DB_USER")
-    db_pass = os.environ.get("DB_PASS")
-    db_name = os.environ.get("DB_NAME")
-    db_host = os.environ.get("DB_HOST")
+    db_user = os.environ["DB_USER"]
+    db_pass = os.environ["DB_PASS"]
+    db_name = os.environ["DB_NAME"]
+    db_host = os.environ["DB_HOST"]
 
-    db_host_parts = db_host.split(":")
-
-    # Extract host and port from db_host socket address
-    db_hostname = db_host_parts[0]
-    db_port = int(db_host_parts[1])
+    # Extract host and port from db_host
+    host_args = db_host.split(":")
+    db_hostname, db_port = host_args[0], int(host_args[1])
 
     pool = sqlalchemy.create_engine(
         # Equivalent URL:
         # mysql+pymysql://<db_user>:<db_pass>@<db_host>:<db_port>/<db_name>
         sqlalchemy.engine.url.URL(
             drivername="mysql+pymysql",
-            username=db_user,
-            password=db_pass,
-            host=db_hostname,
-            port=db_port,
-            database=db_name,
+            username=db_user,  # e.g. "my-database-user"
+            password=db_pass,  # e.g. "my-database-password"
+            host=db_hostname,  # e.g. "127.0.0.1"
+            port=db_port,  # e.g. 3306
+            database=db_name,  # e.g. "my-database-name"
         ),
         # ... Specify additional properties here.
         # [END cloud_sql_mysql_sqlalchemy_create_tcp]
@@ -99,24 +97,24 @@ def init_unix_connection_engine(db_config):
     # [START cloud_sql_mysql_sqlalchemy_create_socket]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
     # something like https://cloud.google.com/kms/ to help keep secrets secret.
-    db_user = os.environ.get("DB_USER")
-    db_pass = os.environ.get("DB_PASS")
-    db_name = os.environ.get("DB_NAME")
+    db_user = os.environ["DB_USER"]
+    db_pass = os.environ["DB_PASS"]
+    db_name = os.environ["DB_NAME"]
     db_socket_dir = os.environ.get("DB_SOCKET_DIR", "/cloudsql")
-    cloud_sql_connection_name = os.environ.get("CLOUD_SQL_CONNECTION_NAME")
+    cloud_sql_connection_name = os.environ["CLOUD_SQL_CONNECTION_NAME"]
 
     pool = sqlalchemy.create_engine(
         # Equivalent URL:
         # mysql+pymysql://<db_user>:<db_pass>@/<db_name>?unix_socket=<socket_path>/<cloud_sql_instance_name>
         sqlalchemy.engine.url.URL(
             drivername="mysql+pymysql",
-            username=db_user,
-            password=db_pass,
-            database=db_name,
+            username=db_user,  # e.g. "my-database-user"
+            password=db_pass,  # e.g. "my-database-password"
+            database=db_name,  # e.g. "my-database-name"
             query={
                 "unix_socket": "{}/{}".format(
-                    db_socket_dir,
-                    cloud_sql_connection_name)
+                    db_socket_dir,  # e.g. "/cloudsql"
+                    cloud_sql_connection_name)  # i.e "<PROJECT-NAME>:<INSTANCE-REGION>:<INSTANCE-NAME>"
             }
         ),
         # ... Specify additional properties here.

--- a/cloud-sql/mysql/sqlalchemy/main.py
+++ b/cloud-sql/mysql/sqlalchemy/main.py
@@ -62,7 +62,8 @@ def init_connection_engine():
 def init_tcp_connection_engine(db_config):
     # [START cloud_sql_mysql_sqlalchemy_create_tcp]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    # something like https://cloud.google.com/secret-manager/docs/overview to help keep
+    # secrets secret.
     db_user = os.environ["DB_USER"]
     db_pass = os.environ["DB_PASS"]
     db_name = os.environ["DB_NAME"]
@@ -96,7 +97,8 @@ def init_tcp_connection_engine(db_config):
 def init_unix_connection_engine(db_config):
     # [START cloud_sql_mysql_sqlalchemy_create_socket]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    # something like https://cloud.google.com/secret-manager/docs/overview to help keep
+    # secrets secret.
     db_user = os.environ["DB_USER"]
     db_pass = os.environ["DB_PASS"]
     db_name = os.environ["DB_NAME"]

--- a/cloud-sql/mysql/sqlalchemy/main.py
+++ b/cloud-sql/mysql/sqlalchemy/main.py
@@ -20,13 +20,6 @@ from flask import Flask, render_template, request, Response
 import sqlalchemy
 
 
-# Remember - storing secrets in plaintext is potentially unsafe. Consider using
-# something like https://cloud.google.com/kms/ to help keep secrets secret.
-db_user = os.environ.get("DB_USER")
-db_pass = os.environ.get("DB_PASS")
-db_name = os.environ.get("DB_NAME")
-cloud_sql_connection_name = os.environ.get("CLOUD_SQL_CONNECTION_NAME")
-
 app = Flask(__name__)
 
 logger = logging.getLogger()
@@ -68,39 +61,51 @@ def init_connection_engine():
 
 def init_tcp_connection_engine(db_config):
     # [START cloud_sql_mysql_sqlalchemy_create_tcp]
-    db_socket_addr = os.environ.get("DB_HOST").split(":")
+    # Remember - storing secrets in plaintext is potentially unsafe. Consider using
+    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    db_user = os.environ.get("DB_USER")
+    db_pass = os.environ.get("DB_PASS")
+    db_name = os.environ.get("DB_NAME")
+    db_host = os.environ.get("DB_HOST")
 
-    # Extract host and port from socket address
-    db_host = db_socket_addr[0]
-    db_port = int(db_socket_addr[1])
+    db_host_parts = db_host.split(":")
 
-    return sqlalchemy.create_engine(
+    # Extract host and port from db_host socket address
+    db_hostname = db_host_parts[0]
+    db_port = int(db_host_parts[1])
+
+    pool = sqlalchemy.create_engine(
         # Equivalent URL:
         # mysql+pymysql://<db_user>:<db_pass>@<db_host>:<db_port>/<db_name>
         sqlalchemy.engine.url.URL(
             drivername="mysql+pymysql",
             username=db_user,
             password=db_pass,
-            host=db_host,
+            host=db_hostname,
             port=db_port,
             database=db_name,
         ),
         # ... Specify additional properties here.
-        # [START_EXCLUDE]
+        # [END cloud_sql_mysql_sqlalchemy_create_tcp]
         **db_config
-        # [END_EXCLUDE]
+        # [START cloud_sql_mysql_sqlalchemy_create_tcp]
     )
     # [END cloud_sql_mysql_sqlalchemy_create_tcp]
+
+    return pool
 
 
 def init_unix_connection_engine(db_config):
     # [START cloud_sql_mysql_sqlalchemy_create_socket]
-    if os.environ.get("DB_SOCKET_PATH"):
-        socket_path = os.environ.get("DB_SOCKET_PATH")
-    else:
-        socket_path = "/cloudsql"
+    # Remember - storing secrets in plaintext is potentially unsafe. Consider using
+    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    db_user = os.environ.get("DB_USER")
+    db_pass = os.environ.get("DB_PASS")
+    db_name = os.environ.get("DB_NAME")
+    db_socket_dir = os.environ.get("DB_SOCKET_DIR", "/cloudsql")
+    cloud_sql_connection_name = os.environ.get("CLOUD_SQL_CONNECTION_NAME")
 
-    return sqlalchemy.create_engine(
+    pool = sqlalchemy.create_engine(
         # Equivalent URL:
         # mysql+pymysql://<db_user>:<db_pass>@/<db_name>?unix_socket=<socket_path>/<cloud_sql_instance_name>
         sqlalchemy.engine.url.URL(
@@ -110,16 +115,19 @@ def init_unix_connection_engine(db_config):
             database=db_name,
             query={
                 "unix_socket": "{}/{}".format(
-                    socket_path,
+                    db_socket_dir,
                     cloud_sql_connection_name)
             }
         ),
         # ... Specify additional properties here.
-        # [START_EXCLUDE]
+
+        # [END cloud_sql_mysql_sqlalchemy_create_socket]
         **db_config
-        # [END_EXCLUDE]
+        # [START cloud_sql_mysql_sqlalchemy_create_socket]
     )
     # [END cloud_sql_mysql_sqlalchemy_create_socket]
+
+    return pool
 
 
 # The SQLAlchemy engine will help manage interactions, including automatically

--- a/cloud-sql/postgres/sqlalchemy/README.md
+++ b/cloud-sql/postgres/sqlalchemy/README.md
@@ -41,7 +41,8 @@ export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash
@@ -58,7 +59,8 @@ $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
 ```powershell
@@ -90,7 +92,8 @@ export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash

--- a/cloud-sql/postgres/sqlalchemy/README.md
+++ b/cloud-sql/postgres/sqlalchemy/README.md
@@ -17,17 +17,6 @@ name.
 [instructions](https://cloud.google.com/sql/docs/postgres/connect-external-app#4_if_required_by_your_authentication_method_create_a_service_account).
 Download a JSON key to use to authenticate your connection. 
 
-1. Use the information noted in the previous steps:
-```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
-export CLOUD_SQL_CONNECTION_NAME='<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
-export DB_USER='my-db-user'
-export DB_PASS='my-db-pass'
-export DB_NAME='my_db'
-```
-Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
-
 ## Running locally
 
 To run this application locally, download and install the `cloud_sql_proxy` by
@@ -51,6 +40,8 @@ export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
+Note: Saving credentials in environment variables is convenient, but not secure - consider a more
+secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash
@@ -66,6 +57,8 @@ $env:DB_USER="<DB_USER_NAME>"
 $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
 ```
+Note: Saving credentials in environment variables is convenient, but not secure - consider a more
+secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
 ```powershell
@@ -96,6 +89,8 @@ export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 ```
+Note: Saving credentials in environment variables is convenient, but not secure - consider a more
+secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
 ```bash

--- a/cloud-sql/postgres/sqlalchemy/README.md
+++ b/cloud-sql/postgres/sqlalchemy/README.md
@@ -85,7 +85,7 @@ sudo chown -R $USER /path/to/the/new/directory
 
 You'll also need to initialize an environment variable containing the directory you just created:
 ```bash
-export DB_SOCKET_PATH=/path/to/the/new/directory
+export DB_SOCKET_DIR=/path/to/the/new/directory
 ```
 
 Use these terminal commands to initialize other environment variables as well:
@@ -99,7 +99,7 @@ export DB_NAME='<DB_NAME>'
 
 Then use this command to launch the proxy in the background:
 ```bash
-./cloud_sql_proxy -dir=$DB_SOCKET_PATH --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud_sql_proxy -dir=$DB_SOCKET_DIR --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
 ```
 
 ### Testing the application

--- a/cloud-sql/postgres/sqlalchemy/app.flexible.yaml
+++ b/cloud-sql/postgres/sqlalchemy/app.flexible.yaml
@@ -29,7 +29,8 @@ beta_settings:
   cloud_sql_instances: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>=tcp:<PORT>
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-# something like https://cloud.google.com/kms/ to help keep secrets secret.
+# something like https://cloud.google.com/secret-manager/docs/overview to help keep
+# secrets secret.
 env_variables:
   CLOUD_SQL_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
   DB_USER: my-db-user

--- a/cloud-sql/postgres/sqlalchemy/app.standard.yaml
+++ b/cloud-sql/postgres/sqlalchemy/app.standard.yaml
@@ -15,7 +15,8 @@
 runtime: python37
 
 # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-# something like https://cloud.google.com/kms/ to help keep secrets secret.
+# something like https://cloud.google.com/secret-manager/docs/overview to help keep
+# secrets secret.
 env_variables:
   CLOUD_SQL_CONNECTION_NAME: <MY-PROJECT>:<INSTANCE-REGION>:<MY-DATABASE>
   DB_USER: my-db-user

--- a/cloud-sql/postgres/sqlalchemy/main.py
+++ b/cloud-sql/postgres/sqlalchemy/main.py
@@ -66,27 +66,25 @@ def init_tcp_connection_engine(db_config):
     # [START cloud_sql_postgres_sqlalchemy_create_tcp]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
     # something like https://cloud.google.com/kms/ to help keep secrets secret.
-    db_user = os.environ.get("DB_USER")
-    db_pass = os.environ.get("DB_PASS")
-    db_name = os.environ.get("DB_NAME")
-    db_host = os.environ.get("DB_HOST")
+    db_user = os.environ["DB_USER"]
+    db_pass = os.environ["DB_PASS"]
+    db_name = os.environ["DB_NAME"]
+    db_host = os.environ["DB_HOST"]
 
-    db_host_parts = db_host.split(":")
-
-    # Extract host and port from db_host socket address
-    db_host = db_host_parts[0]
-    db_port = int(db_host_parts[1])
+    # Extract host and port from db_host
+    host_args = db_host.split(":")
+    db_hostname, db_port = host_args[0], int(host_args[1])
 
     pool = sqlalchemy.create_engine(
         # Equivalent URL:
         # postgres+pg8000://<db_user>:<db_pass>@<db_host>:<db_port>/<db_name>
         sqlalchemy.engine.url.URL(
             drivername="postgres+pg8000",
-            username=db_user,
-            password=db_pass,
-            host=db_host,
-            port=db_port,
-            database=db_name
+            username=db_user,  # e.g. "my-database-user"
+            password=db_pass,  # e.g. "my-database-password"
+            host=db_host,  # e.g. "127.0.0.1"
+            port=db_port,  # e.g. 5432
+            database=db_name  # e.g. "my-database-name"
         ),
         # ... Specify additional properties here.
         # [END cloud_sql_postgres_sqlalchemy_create_tcp]
@@ -102,11 +100,11 @@ def init_unix_connection_engine(db_config):
     # [START cloud_sql_postgres_sqlalchemy_create_socket]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
     # something like https://cloud.google.com/kms/ to help keep secrets secret.
-    db_user = os.environ.get("DB_USER")
-    db_pass = os.environ.get("DB_PASS")
-    db_name = os.environ.get("DB_NAME")
+    db_user = os.environ["DB_USER"]
+    db_pass = os.environ["DB_PASS"]
+    db_name = os.environ["DB_NAME"]
     db_socket_dir = os.environ.get("DB_SOCKET_DIR", "/cloudsql")
-    cloud_sql_connection_name = os.environ.get("CLOUD_SQL_CONNECTION_NAME")
+    cloud_sql_connection_name = os.environ["CLOUD_SQL_CONNECTION_NAME"]
 
     pool = sqlalchemy.create_engine(
         # Equivalent URL:
@@ -114,13 +112,13 @@ def init_unix_connection_engine(db_config):
         #                         ?unix_sock=<socket_path>/<cloud_sql_instance_name>/.s.PGSQL.5432
         sqlalchemy.engine.url.URL(
             drivername="postgres+pg8000",
-            username=db_user,
-            password=db_pass,
-            database=db_name,
+            username=db_user,  # e.g. "my-database-user"
+            password=db_pass,  # e.g. "my-database-password"
+            database=db_name,  # e.g. "my-database-name"
             query={
                 "unix_sock": "{}/{}/.s.PGSQL.5432".format(
-                    db_socket_dir,
-                    cloud_sql_connection_name)
+                    db_socket_dir,  # e.g. "/cloudsql"
+                    cloud_sql_connection_name)  # i.e "<PROJECT-NAME>:<INSTANCE-REGION>:<INSTANCE-NAME>"
             }
         ),
         # ... Specify additional properties here.

--- a/cloud-sql/postgres/sqlalchemy/main.py
+++ b/cloud-sql/postgres/sqlalchemy/main.py
@@ -83,7 +83,7 @@ def init_tcp_connection_engine(db_config):
             drivername="postgres+pg8000",
             username=db_user,  # e.g. "my-database-user"
             password=db_pass,  # e.g. "my-database-password"
-            host=db_host,  # e.g. "127.0.0.1"
+            host=db_hostname,  # e.g. "127.0.0.1"
             port=db_port,  # e.g. 5432
             database=db_name  # e.g. "my-database-name"
         ),

--- a/cloud-sql/postgres/sqlalchemy/main.py
+++ b/cloud-sql/postgres/sqlalchemy/main.py
@@ -65,7 +65,8 @@ def init_connection_engine():
 def init_tcp_connection_engine(db_config):
     # [START cloud_sql_postgres_sqlalchemy_create_tcp]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    # something like https://cloud.google.com/secret-manager/docs/overview to help keep
+    # secrets secret.
     db_user = os.environ["DB_USER"]
     db_pass = os.environ["DB_PASS"]
     db_name = os.environ["DB_NAME"]
@@ -99,7 +100,8 @@ def init_tcp_connection_engine(db_config):
 def init_unix_connection_engine(db_config):
     # [START cloud_sql_postgres_sqlalchemy_create_socket]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    # something like https://cloud.google.com/secret-manager/docs/overview to help keep
+    # secrets secret.
     db_user = os.environ["DB_USER"]
     db_pass = os.environ["DB_PASS"]
     db_name = os.environ["DB_NAME"]

--- a/cloud-sql/sql-server/sqlalchemy/README.md
+++ b/cloud-sql/sql-server/sqlalchemy/README.md
@@ -31,29 +31,48 @@
 [instructions](https://cloud.google.com/sql/docs/postgres/connect-external-app#4_if_required_by_your_authentication_method_create_a_service_account).
 Download a JSON key to use to authenticate your connection. 
 
-1. Use the information noted in the previous steps:
+## Running locally
+To run this application locally, download and install the `cloud_sql_proxy` by
+following the instructions [here](https://cloud.google.com/sql/docs/mysql/sql-proxy#install). 
+
+### Linux / MacOS
+Use these terminal commands to initialize environment variables:
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export CLOUD_SQL_CONNECTION_NAME='<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export DB_USER='my-db-user'
 export DB_PASS='my-db-pass'
 export DB_NAME='my_db'
+export DB_HOST='127.0.0.1:1433'
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
 
-## Running locally
-
-To run this application locally, download and install the `cloud_sql_proxy` by
-following the instructions [here](https://cloud.google.com/sql/docs/mysql/sql-proxy#install). 
-
-Then, use the following command to start the proxy in the
-background using TCP:
+Then, use the following command to start the proxy in the background using TCP:
 ```bash
-./cloud_sql_proxy -instances=${CLOUD_SQL_CONNECTION_NAME}=tcp:1433 sqlserver -u ${DB_USER} --host 127.0.0.1
+./cloud_sql_proxy -instances=${CLOUD_SQL_CONNECTION_NAME}=tcp:1433 sqlserver -u ${DB_USER} --host 127.0.0.1 &
 ```
 
-Next, setup install the requirements into a virtual enviroment:
+### Windows / PowerShell
+Use these PowerShell commands to initialize environment variables:
+```powershell
+$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
+$env:CLOUD_SQL_CONNECTION_NAME="<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>"
+$env:DB_USER="my-db-user"
+$env:DB_PASS="my-db-pass"
+$env:DB_NAME="my_db"
+$env:DB_HOST="127.0.0.1:1433"
+```
+Note: Saving credentials in environment variables is convenient, but not secure - consider a more
+secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+
+Then use this command to launch the proxy in a separate PowerShell session:
+```powershell
+Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>=tcp:1433 -credential_file=<CREDENTIALS_JSON_FILE>"
+```
+
+### Testing the application
+Next, setup a virtual environment and install the application's requirements:
 ```bash
 virtualenv --python python3 env
 source env/bin/activate

--- a/cloud-sql/sql-server/sqlalchemy/README.md
+++ b/cloud-sql/sql-server/sqlalchemy/README.md
@@ -46,7 +46,8 @@ export DB_NAME='my_db'
 export DB_HOST='127.0.0.1:1433'
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then, use the following command to start the proxy in the background using TCP:
 ```bash
@@ -64,7 +65,8 @@ $env:DB_NAME="my_db"
 $env:DB_HOST="127.0.0.1:1433"
 ```
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
-secure solution such as [Cloud KMS](https://cloud.google.com/kms/) to help keep secrets safe.
+secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
+help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
 ```powershell

--- a/cloud-sql/sql-server/sqlalchemy/app.yaml
+++ b/cloud-sql/sql-server/sqlalchemy/app.yaml
@@ -21,8 +21,7 @@ env_variables:
   DB_USER: <your-username>
   DB_PASS: <your-password>
   DB_NAME: <your-db-name>
-  # Whether the app is deployed or running locally
-  DEPLOYED: true
+  DB_HOST: 172.17.0.1:<PORT>
 
 beta_settings:
-  cloud_sql_instances: <project-name>:<region-name>:<instance-name>=tcp:1433
+  cloud_sql_instances: <project-name>:<region-name>:<instance-name>=tcp:<PORT>

--- a/cloud-sql/sql-server/sqlalchemy/main.py
+++ b/cloud-sql/sql-server/sqlalchemy/main.py
@@ -38,10 +38,11 @@ def init_tcp_connection_engine():
     db_user = os.environ["DB_USER"]
     db_pass = os.environ["DB_PASS"]
     db_name = os.environ["DB_NAME"]
+    db_host = os.environ["DB_HOST"]
 
     # Extract host and port from environment variable DB_HOST
-    host_args = os.environ["DB_HOST"].split(":")
-    host, port = host_args[0], int(host_args[1])
+    host_args = db_host.split(":")
+    db_hostname, db_port = host_args[0], int(host_args[1])
 
     # The SQLAlchemy engine will help manage interactions, including automatically
     # managing a pool of connections to your database
@@ -53,8 +54,8 @@ def init_tcp_connection_engine():
             username=db_user,
             password=db_pass,
             database=db_name,
-            host=host,
-            port=port,
+            host=db_hostname,
+            port=db_port,
             query={"driver": "ODBC Driver 17 for SQL Server"},
         ),
         # ... Specify additional properties here.

--- a/cloud-sql/sql-server/sqlalchemy/main.py
+++ b/cloud-sql/sql-server/sqlalchemy/main.py
@@ -29,60 +29,68 @@ app = Flask(__name__)
 
 logger = logging.getLogger()
 
-# [START cloud_sql_server_sqlalchemy_create]
-# Remember - storing secrets in plaintext is potentially unsafe. Consider using
-# something like https://cloud.google.com/kms/ to help keep secrets secret.
-db_user = os.environ.get("DB_USER")
-db_pass = os.environ.get("DB_PASS")
-db_name = os.environ.get("DB_NAME")
 
-# When deployed to GAE Flex for TCP, use "172.17.0.1" to connect
-host = "172.17.0.1" if os.environ.get("DEPLOYED") else "127.0.0.1"
+def init_tcp_connection_engine():
+    # [START cloud_sql_server_sqlalchemy_create_tcp]
+    # Remember - storing secrets in plaintext is potentially unsafe. Consider using
+    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    db_user = os.environ["DB_USER"]
+    db_pass = os.environ["DB_PASS"]
+    db_name = os.environ["DB_NAME"]
 
-# The SQLAlchemy engine will help manage interactions, including automatically
-# managing a pool of connections to your database
-db = sqlalchemy.create_engine(
-    # Equivalent URL:
-    # mssql+pyodbc://<db_user>:<db_pass>@/<host>:<port>/<db_name>?driver=ODBC+Driver+17+for+SQL+Server
-    sqlalchemy.engine.url.URL(
-        "mssql+pyodbc",
-        username=db_user,
-        password=db_pass,
-        database=db_name,
-        host=host,
-        port=1433,
-        query={"driver": "ODBC Driver 17 for SQL Server"},
-    ),
-    # ... Specify additional properties here.
-    # [START_EXCLUDE]
-    # [START cloud_sql_server_sqlalchemy_limit]
-    # Pool size is the maximum number of permanent connections to keep.
-    pool_size=5,
-    # Temporarily exceeds the set pool_size if no connections are available.
-    max_overflow=2,
-    # The total number of concurrent connections for your application will be
-    # a total of pool_size and max_overflow.
-    # [END cloud_sql_server_sqlalchemy_limit]
-    # [START cloud_sql_server_sqlalchemy_backoff]
-    # SQLAlchemy automatically uses delays between failed connection attempts,
-    # but provides no arguments for configuration.
-    # [END cloud_sql_server_sqlalchemy_backoff]
-    # [START cloud_sql_server_sqlalchemy_timeout]
-    # 'pool_timeout' is the maximum number of seconds to wait when retrieving a
-    # new connection from the pool. After the specified amount of time, an
-    # exception will be thrown.
-    pool_timeout=30,  # 30 seconds
-    # [END cloud_sql_server_sqlalchemy_timeout]
-    # [START cloud_sql_server_sqlalchemy_lifetime]
-    # 'pool_recycle' is the maximum number of seconds a connection can persist.
-    # Connections that live longer than the specified amount of time will be
-    # reestablished
-    pool_recycle=1800,  # 30 minutes
-    # [END cloud_sql_server_sqlalchemy_lifetime]
-    echo=True  # debug
-    # [END_EXCLUDE]
-)
-# [END cloud_sql_server_sqlalchemy_create]
+    # Extract host and port from environment variable DB_HOST
+    host_args = os.environ["DB_HOST"].split(":")
+    host, port = host_args[0], int(host_args[1])
+
+    # The SQLAlchemy engine will help manage interactions, including automatically
+    # managing a pool of connections to your database
+    pool = sqlalchemy.create_engine(
+        # Equivalent URL:
+        # mssql+pyodbc://<db_user>:<db_pass>@/<host>:<port>/<db_name>?driver=ODBC+Driver+17+for+SQL+Server
+        sqlalchemy.engine.url.URL(
+            "mssql+pyodbc",
+            username=db_user,
+            password=db_pass,
+            database=db_name,
+            host=host,
+            port=port,
+            query={"driver": "ODBC Driver 17 for SQL Server"},
+        ),
+        # ... Specify additional properties here.
+        # [START_EXCLUDE]
+        # [START cloud_sql_server_sqlalchemy_limit]
+        # Pool size is the maximum number of permanent connections to keep.
+        pool_size=5,
+        # Temporarily exceeds the set pool_size if no connections are available.
+        max_overflow=2,
+        # The total number of concurrent connections for your application will be
+        # a total of pool_size and max_overflow.
+        # [END cloud_sql_server_sqlalchemy_limit]
+        # [START cloud_sql_server_sqlalchemy_backoff]
+        # SQLAlchemy automatically uses delays between failed connection attempts,
+        # but provides no arguments for configuration.
+        # [END cloud_sql_server_sqlalchemy_backoff]
+        # [START cloud_sql_server_sqlalchemy_timeout]
+        # 'pool_timeout' is the maximum number of seconds to wait when retrieving a
+        # new connection from the pool. After the specified amount of time, an
+        # exception will be thrown.
+        pool_timeout=30,  # 30 seconds
+        # [END cloud_sql_server_sqlalchemy_timeout]
+        # [START cloud_sql_server_sqlalchemy_lifetime]
+        # 'pool_recycle' is the maximum number of seconds a connection can persist.
+        # Connections that live longer than the specified amount of time will be
+        # reestablished
+        pool_recycle=1800,  # 30 minutes
+        # [END cloud_sql_server_sqlalchemy_lifetime]
+        echo=True  # debug
+        # [END_EXCLUDE]
+    )
+    # [END cloud_sql_server_sqlalchemy_create_tcp]
+
+    return pool
+
+
+db = init_tcp_connection_engine()
 
 
 @app.before_first_request

--- a/cloud-sql/sql-server/sqlalchemy/main.py
+++ b/cloud-sql/sql-server/sqlalchemy/main.py
@@ -33,7 +33,8 @@ logger = logging.getLogger()
 def init_tcp_connection_engine():
     # [START cloud_sql_server_sqlalchemy_create_tcp]
     # Remember - storing secrets in plaintext is potentially unsafe. Consider using
-    # something like https://cloud.google.com/kms/ to help keep secrets secret.
+    # something like https://cloud.google.com/secret-manager/docs/overview to help keep
+    # secrets secret.
     db_user = os.environ["DB_USER"]
     db_pass = os.environ["DB_PASS"]
     db_name = os.environ["DB_NAME"]


### PR DESCRIPTION
* Rename environment variable DB_SOCKET_PATH to  DB_SOCKET_DIR for better description of its contents
* Move region tags and refactor code so as to give users a better sample experience