### PR TITLE
Pub/Sub: replace name with id in samples

### DIFF
--- a/pubsub/cloud-client/iam.py
+++ b/pubsub/cloud-client/iam.py
@@ -23,14 +23,18 @@ at https://cloud.google.com/pubsub/docs.
 
 import argparse
 
-from google.cloud import pubsub_v1
 
-
-def get_topic_policy(project, topic_name):
+def get_topic_policy(project, topic_id):
     """Prints the IAM policy for the given topic."""
     # [START pubsub_get_topic_policy]
+    from google.cloud import pubsub_v1
+
+    # TODO(developer)
+    # project_id = "your-project-id"
+    # topic_id = "your-topic-id"
+
     client = pubsub_v1.PublisherClient()
-    topic_path = client.topic_path(project, topic_name)
+    topic_path = client.topic_path(project, topic_id)
 
     policy = client.get_iam_policy(topic_path)
 
@@ -40,11 +44,17 @@ def get_topic_policy(project, topic_name):
     # [END pubsub_get_topic_policy]
 
 
-def get_subscription_policy(project, subscription_name):
+def get_subscription_policy(project, subscription_id):
     """Prints the IAM policy for the given subscription."""
     # [START pubsub_get_subscription_policy]
+    from google.cloud import pubsub_v1
+
+    # TODO(developer)
+    # project_id = "your-project-id"
+    # subscription_id = "your-subscription-id"
+
     client = pubsub_v1.SubscriberClient()
-    subscription_path = client.subscription_path(project, subscription_name)
+    subscription_path = client.subscription_path(project, subscription_id)
 
     policy = client.get_iam_policy(subscription_path)
 
@@ -56,11 +66,17 @@ def get_subscription_policy(project, subscription_name):
     # [END pubsub_get_subscription_policy]
 
 
-def set_topic_policy(project, topic_name):
+def set_topic_policy(project, topic_id):
     """Sets the IAM policy for a topic."""
     # [START pubsub_set_topic_policy]
+    from google.cloud import pubsub_v1
+
+    # TODO(developer)
+    # project_id = "your-project-id"
+    # topic_id = "your-topic-id"
+
     client = pubsub_v1.PublisherClient()
-    topic_path = client.topic_path(project, topic_name)
+    topic_path = client.topic_path(project, topic_id)
 
     policy = client.get_iam_policy(topic_path)
 
@@ -75,15 +91,21 @@ def set_topic_policy(project, topic_name):
     # Set the policy
     policy = client.set_iam_policy(topic_path, policy)
 
-    print("IAM policy for topic {} set: {}".format(topic_name, policy))
+    print("IAM policy for topic {} set: {}".format(topic_id, policy))
     # [END pubsub_set_topic_policy]
 
 
-def set_subscription_policy(project, subscription_name):
+def set_subscription_policy(project, subscription_id):
     """Sets the IAM policy for a topic."""
     # [START pubsub_set_subscription_policy]
+    from google.cloud import pubsub_v1
+
+    # TODO(developer)
+    # project_id = "your-project-id"
+    # subscription_id = "your-subscription-id"
+
     client = pubsub_v1.SubscriberClient()
-    subscription_path = client.subscription_path(project, subscription_name)
+    subscription_path = client.subscription_path(project, subscription_id)
 
     policy = client.get_iam_policy(subscription_path)
 
@@ -91,48 +113,50 @@ def set_subscription_policy(project, subscription_name):
     policy.bindings.add(role="roles/pubsub.viewer", members=["allUsers"])
 
     # Add a group as an editor.
-    policy.bindings.add(
-        role="roles/editor", members=["group:cloud-logs@google.com"]
-    )
+    policy.bindings.add(role="roles/editor", members=["group:cloud-logs@google.com"])
 
     # Set the policy
     policy = client.set_iam_policy(subscription_path, policy)
 
-    print(
-        "IAM policy for subscription {} set: {}".format(
-            subscription_name, policy
-        )
-    )
+    print("IAM policy for subscription {} set: {}".format(subscription_id, policy))
 
     client.close()
     # [END pubsub_set_subscription_policy]
 
 
-def check_topic_permissions(project, topic_name):
+def check_topic_permissions(project, topic_id):
     """Checks to which permissions are available on the given topic."""
     # [START pubsub_test_topic_permissions]
+    from google.cloud import pubsub_v1
+
+    # TODO(developer)
+    # project_id = "your-project-id"
+    # topic_id = "your-topic-id"
+
     client = pubsub_v1.PublisherClient()
-    topic_path = client.topic_path(project, topic_name)
+    topic_path = client.topic_path(project, topic_id)
 
     permissions_to_check = ["pubsub.topics.publish", "pubsub.topics.update"]
 
-    allowed_permissions = client.test_iam_permissions(
-        topic_path, permissions_to_check
-    )
+    allowed_permissions = client.test_iam_permissions(topic_path, permissions_to_check)
 
     print(
-        "Allowed permissions for topic {}: {}".format(
-            topic_path, allowed_permissions
-        )
+        "Allowed permissions for topic {}: {}".format(topic_path, allowed_permissions)
     )
     # [END pubsub_test_topic_permissions]
 
 
-def check_subscription_permissions(project, subscription_name):
+def check_subscription_permissions(project, subscription_id):
     """Checks to which permissions are available on the given subscription."""
     # [START pubsub_test_subscription_permissions]
+    from google.cloud import pubsub_v1
+
+    # TODO(developer)
+    # project_id = "your-project-id"
+    # subscription_id = "your-subscription-id"
+
     client = pubsub_v1.SubscriberClient()
-    subscription_path = client.subscription_path(project, subscription_name)
+    subscription_path = client.subscription_path(project, subscription_id)
 
     permissions_to_check = [
         "pubsub.subscriptions.consume",
@@ -155,8 +179,7 @@ def check_subscription_permissions(project, subscription_name):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("project", help="Your Google Cloud project ID")
 
@@ -165,45 +188,44 @@ if __name__ == "__main__":
     get_topic_policy_parser = subparsers.add_parser(
         "get-topic-policy", help=get_topic_policy.__doc__
     )
-    get_topic_policy_parser.add_argument("topic_name")
+    get_topic_policy_parser.add_argument("topic_id")
 
     get_subscription_policy_parser = subparsers.add_parser(
         "get-subscription-policy", help=get_subscription_policy.__doc__
     )
-    get_subscription_policy_parser.add_argument("subscription_name")
+    get_subscription_policy_parser.add_argument("subscription_id")
 
     set_topic_policy_parser = subparsers.add_parser(
         "set-topic-policy", help=set_topic_policy.__doc__
     )
-    set_topic_policy_parser.add_argument("topic_name")
+    set_topic_policy_parser.add_argument("topic_id")
 
     set_subscription_policy_parser = subparsers.add_parser(
         "set-subscription-policy", help=set_subscription_policy.__doc__
     )
-    set_subscription_policy_parser.add_argument("subscription_name")
+    set_subscription_policy_parser.add_argument("subscription_id")
 
     check_topic_permissions_parser = subparsers.add_parser(
         "check-topic-permissions", help=check_topic_permissions.__doc__
     )
-    check_topic_permissions_parser.add_argument("topic_name")
+    check_topic_permissions_parser.add_argument("topic_id")
 
     check_subscription_permissions_parser = subparsers.add_parser(
-        "check-subscription-permissions",
-        help=check_subscription_permissions.__doc__,
+        "check-subscription-permissions", help=check_subscription_permissions.__doc__,
     )
-    check_subscription_permissions_parser.add_argument("subscription_name")
+    check_subscription_permissions_parser.add_argument("subscription_id")
 
     args = parser.parse_args()
 
     if args.command == "get-topic-policy":
-        get_topic_policy(args.project, args.topic_name)
+        get_topic_policy(args.project, args.topic_id)
     elif args.command == "get-subscription-policy":
-        get_subscription_policy(args.project, args.subscription_name)
+        get_subscription_policy(args.project, args.subscription_id)
     elif args.command == "set-topic-policy":
-        set_topic_policy(args.project, args.topic_name)
+        set_topic_policy(args.project, args.topic_id)
     elif args.command == "set-subscription-policy":
-        set_subscription_policy(args.project, args.subscription_name)
+        set_subscription_policy(args.project, args.subscription_id)
     elif args.command == "check-topic-permissions":
-        check_topic_permissions(args.project, args.topic_name)
+        check_topic_permissions(args.project, args.topic_id)
     elif args.command == "check-subscription-permissions":
-        check_subscription_permissions(args.project, args.subscription_name)
+        check_subscription_permissions(args.project, args.subscription_id)

--- a/pubsub/cloud-client/iam_test.py
+++ b/pubsub/cloud-client/iam_test.py
@@ -56,9 +56,7 @@ def subscriber_client():
 
 @pytest.fixture
 def subscription(subscriber_client, topic):
-    subscription_path = subscriber_client.subscription_path(
-        PROJECT, SUBSCRIPTION
-    )
+    subscription_path = subscriber_client.subscription_path(PROJECT, SUBSCRIPTION)
 
     try:
         subscriber_client.delete_subscription(subscription_path)

--- a/pubsub/cloud-client/publisher.py
+++ b/pubsub/cloud-client/publisher.py
@@ -40,7 +40,7 @@ def list_topics(project_id):
     # [END pubsub_list_topics]
 
 
-def create_topic(project_id, topic_name):
+def create_topic(project_id, topic_id):
     """Create a new Pub/Sub topic."""
     # [START pubsub_quickstart_create_topic]
     # [START pubsub_create_topic]
@@ -48,10 +48,10 @@ def create_topic(project_id, topic_name):
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     publisher = pubsub_v1.PublisherClient()
-    topic_path = publisher.topic_path(project_id, topic_name)
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     topic = publisher.create_topic(topic_path)
 
@@ -60,17 +60,17 @@ def create_topic(project_id, topic_name):
     # [END pubsub_create_topic]
 
 
-def delete_topic(project_id, topic_name):
+def delete_topic(project_id, topic_id):
     """Deletes an existing Pub/Sub topic."""
     # [START pubsub_delete_topic]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     publisher = pubsub_v1.PublisherClient()
-    topic_path = publisher.topic_path(project_id, topic_name)
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     publisher.delete_topic(topic_path)
 
@@ -78,7 +78,7 @@ def delete_topic(project_id, topic_name):
     # [END pubsub_delete_topic]
 
 
-def publish_messages(project_id, topic_name):
+def publish_messages(project_id, topic_id):
     """Publishes multiple messages to a Pub/Sub topic."""
     # [START pubsub_quickstart_publisher]
     # [START pubsub_publish]
@@ -86,12 +86,12 @@ def publish_messages(project_id, topic_name):
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     publisher = pubsub_v1.PublisherClient()
     # The `topic_path` method creates a fully qualified identifier
-    # in the form `projects/{project_id}/topics/{topic_name}`
-    topic_path = publisher.topic_path(project_id, topic_name)
+    # in the form `projects/{project_id}/topics/{topic_id}`
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     for n in range(1, 10):
         data = u"Message number {}".format(n)
@@ -106,7 +106,7 @@ def publish_messages(project_id, topic_name):
     # [END pubsub_publish]
 
 
-def publish_messages_with_custom_attributes(project_id, topic_name):
+def publish_messages_with_custom_attributes(project_id, topic_id):
     """Publishes multiple messages with custom attributes
     to a Pub/Sub topic."""
     # [START pubsub_publish_custom_attributes]
@@ -114,10 +114,10 @@ def publish_messages_with_custom_attributes(project_id, topic_name):
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     publisher = pubsub_v1.PublisherClient()
-    topic_path = publisher.topic_path(project_id, topic_name)
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     for n in range(1, 10):
         data = u"Message number {}".format(n)
@@ -133,7 +133,7 @@ def publish_messages_with_custom_attributes(project_id, topic_name):
     # [END pubsub_publish_custom_attributes]
 
 
-def publish_messages_with_error_handler(project_id, topic_name):
+def publish_messages_with_error_handler(project_id, topic_id):
     # [START pubsub_publish_messages_error_handler]
     """Publishes multiple messages to a Pub/Sub topic with an error handler."""
     import time
@@ -142,10 +142,10 @@ def publish_messages_with_error_handler(project_id, topic_name):
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     publisher = pubsub_v1.PublisherClient()
-    topic_path = publisher.topic_path(project_id, topic_name)
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     futures = dict()
 
@@ -178,14 +178,14 @@ def publish_messages_with_error_handler(project_id, topic_name):
     # [END pubsub_publish_messages_error_handler]
 
 
-def publish_messages_with_batch_settings(project_id, topic_name):
+def publish_messages_with_batch_settings(project_id, topic_id):
     """Publishes multiple messages to a Pub/Sub topic with batch settings."""
     # [START pubsub_publisher_batch_settings]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     # Configure the batch to publish as soon as there is ten messages,
     # one kilobyte of data, or one second has passed.
@@ -195,7 +195,7 @@ def publish_messages_with_batch_settings(project_id, topic_name):
         max_latency=1,  # default 10 ms
     )
     publisher = pubsub_v1.PublisherClient(batch_settings)
-    topic_path = publisher.topic_path(project_id, topic_name)
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     # Resolve the publish future in a separate thread.
     def callback(future):
@@ -214,14 +214,14 @@ def publish_messages_with_batch_settings(project_id, topic_name):
     # [END pubsub_publisher_batch_settings]
 
 
-def publish_messages_with_retry_settings(project_id, topic_name):
+def publish_messages_with_retry_settings(project_id, topic_id):
     """Publishes messages with custom retry settings."""
     # [START pubsub_publisher_retry_settings]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     # Configure the retry settings. Defaults will be overwritten.
     retry_settings = {
@@ -260,7 +260,7 @@ def publish_messages_with_retry_settings(project_id, topic_name):
     }
 
     publisher = pubsub_v1.PublisherClient(client_config=retry_settings)
-    topic_path = publisher.topic_path(project_id, topic_name)
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     for n in range(1, 10):
         data = u"Message number {}".format(n)
@@ -283,52 +283,52 @@ if __name__ == "__main__":
     subparsers.add_parser("list", help=list_topics.__doc__)
 
     create_parser = subparsers.add_parser("create", help=create_topic.__doc__)
-    create_parser.add_argument("topic_name")
+    create_parser.add_argument("topic_id")
 
     delete_parser = subparsers.add_parser("delete", help=delete_topic.__doc__)
-    delete_parser.add_argument("topic_name")
+    delete_parser.add_argument("topic_id")
 
     publish_parser = subparsers.add_parser("publish", help=publish_messages.__doc__)
-    publish_parser.add_argument("topic_name")
+    publish_parser.add_argument("topic_id")
 
     publish_with_custom_attributes_parser = subparsers.add_parser(
         "publish-with-custom-attributes",
         help=publish_messages_with_custom_attributes.__doc__,
     )
-    publish_with_custom_attributes_parser.add_argument("topic_name")
+    publish_with_custom_attributes_parser.add_argument("topic_id")
 
     publish_with_error_handler_parser = subparsers.add_parser(
         "publish-with-error-handler", help=publish_messages_with_error_handler.__doc__,
     )
-    publish_with_error_handler_parser.add_argument("topic_name")
+    publish_with_error_handler_parser.add_argument("topic_id")
 
     publish_with_batch_settings_parser = subparsers.add_parser(
         "publish-with-batch-settings",
         help=publish_messages_with_batch_settings.__doc__,
     )
-    publish_with_batch_settings_parser.add_argument("topic_name")
+    publish_with_batch_settings_parser.add_argument("topic_id")
 
     publish_with_retry_settings_parser = subparsers.add_parser(
         "publish-with-retry-settings",
         help=publish_messages_with_retry_settings.__doc__,
     )
-    publish_with_retry_settings_parser.add_argument("topic_name")
+    publish_with_retry_settings_parser.add_argument("topic_id")
 
     args = parser.parse_args()
 
     if args.command == "list":
         list_topics(args.project_id)
     elif args.command == "create":
-        create_topic(args.project_id, args.topic_name)
+        create_topic(args.project_id, args.topic_id)
     elif args.command == "delete":
-        delete_topic(args.project_id, args.topic_name)
+        delete_topic(args.project_id, args.topic_id)
     elif args.command == "publish":
-        publish_messages(args.project_id, args.topic_name)
+        publish_messages(args.project_id, args.topic_id)
     elif args.command == "publish-with-custom-attributes":
-        publish_messages_with_custom_attributes(args.project_id, args.topic_name)
+        publish_messages_with_custom_attributes(args.project_id, args.topic_id)
     elif args.command == "publish-with-error-handler":
-        publish_messages_with_error_handler(args.project_id, args.topic_name)
+        publish_messages_with_error_handler(args.project_id, args.topic_id)
     elif args.command == "publish-with-batch-settings":
-        publish_messages_with_batch_settings(args.project_id, args.topic_name)
+        publish_messages_with_batch_settings(args.project_id, args.topic_id)
     elif args.command == "publish-with-retry-settings":
-        publish_messages_with_retry_settings(args.project_id, args.topic_name)
+        publish_messages_with_retry_settings(args.project_id, args.topic_id)

--- a/pubsub/cloud-client/quickstart/pub.py
+++ b/pubsub/cloud-client/quickstart/pub.py
@@ -46,15 +46,15 @@ def get_callback(api_future, data, ref):
     return callback
 
 
-def pub(project_id, topic_name):
+def pub(project_id, topic_id):
     """Publishes a message to a Pub/Sub topic."""
     # [START pubsub_quickstart_pub_client]
     # Initialize a Publisher client.
     client = pubsub_v1.PublisherClient()
     # [END pubsub_quickstart_pub_client]
     # Create a fully qualified identifier in the form of
-    # `projects/{project_id}/topics/{topic_name}`
-    topic_path = client.topic_path(project_id, topic_name)
+    # `projects/{project_id}/topics/{topic_id}`
+    topic_path = client.topic_path(project_id, topic_id)
 
     # Data sent to Cloud Pub/Sub must be a bytestring.
     data = b"Hello, World!"
@@ -75,13 +75,12 @@ def pub(project_id, topic_name):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("project_id", help="Google Cloud project ID")
-    parser.add_argument("topic_name", help="Pub/Sub topic name")
+    parser.add_argument("topic_id", help="Pub/Sub topic ID")
 
     args = parser.parse_args()
 
-    pub(args.project_id, args.topic_name)
+    pub(args.project_id, args.topic_id)
 # [END pubsub_quickstart_pub_all]

--- a/pubsub/cloud-client/quickstart/sub.py
+++ b/pubsub/cloud-client/quickstart/sub.py
@@ -23,23 +23,19 @@ from google.cloud import pubsub_v1
 # [END pubsub_quickstart_sub_deps]
 
 
-def sub(project_id, subscription_name):
+def sub(project_id, subscription_id):
     """Receives messages from a Pub/Sub subscription."""
     # [START pubsub_quickstart_sub_client]
     # Initialize a Subscriber client
     subscriber_client = pubsub_v1.SubscriberClient()
     # [END pubsub_quickstart_sub_client]
     # Create a fully qualified identifier in the form of
-    # `projects/{project_id}/subscriptions/{subscription_name}`
-    subscription_path = subscriber_client.subscription_path(
-        project_id, subscription_name
-    )
+    # `projects/{project_id}/subscriptions/{subscription_id}`
+    subscription_path = subscriber_client.subscription_path(project_id, subscription_id)
 
     def callback(message):
         print(
-            "Received message {} of message ID {}\n".format(
-                message, message.message_id
-            )
+            "Received message {} of message ID {}\n".format(message, message.message_id)
         )
         # Acknowledge the message. Unack'ed messages will be redelivered.
         message.ack()
@@ -62,13 +58,12 @@ def sub(project_id, subscription_name):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description=__doc__,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("project_id", help="Google Cloud project ID")
-    parser.add_argument("subscription_name", help="Pub/Sub subscription name")
+    parser.add_argument("subscription_id", help="Pub/Sub subscription ID")
 
     args = parser.parse_args()
 
-    sub(args.project_id, args.subscription_name)
+    sub(args.project_id, args.subscription_id)
 # [END pubsub_quickstart_sub_all]

--- a/pubsub/cloud-client/quickstart/sub_test.py
+++ b/pubsub/cloud-client/quickstart/sub_test.py
@@ -48,9 +48,7 @@ def topic_path():
 
 @pytest.fixture(scope="module")
 def subscription_path(topic_path):
-    subscription_path = subscriber_client.subscription_path(
-        PROJECT, SUBSCRIPTION
-    )
+    subscription_path = subscriber_client.subscription_path(PROJECT, SUBSCRIPTION)
 
     try:
         subscription = subscriber_client.create_subscription(
@@ -82,9 +80,7 @@ def test_sub(monkeypatch, topic_path, subscription_path, capsys):
     monkeypatch.setattr(pubsub_v1, "SubscriberClient", mock_client_constructor)
 
     def mock_subscribe(subscription_path, callback=None):
-        real_future = real_client.subscribe(
-            subscription_path, callback=callback
-        )
+        real_future = real_client.subscribe(subscription_path, callback=callback)
         mock_future = mock.Mock(spec=real_future, wraps=real_future)
 
         def mock_result():

--- a/pubsub/cloud-client/subscriber.py
+++ b/pubsub/cloud-client/subscriber.py
@@ -24,17 +24,17 @@ at https://cloud.google.com/pubsub/docs.
 import argparse
 
 
-def list_subscriptions_in_topic(project_id, topic_name):
+def list_subscriptions_in_topic(project_id, topic_id):
     """Lists all subscriptions for a given topic."""
     # [START pubsub_list_topic_subscriptions]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
 
     publisher = pubsub_v1.PublisherClient()
-    topic_path = publisher.topic_path(project_id, topic_name)
+    topic_path = publisher.topic_path(project_id, topic_id)
 
     for subscription in publisher.list_topic_subscriptions(topic_path):
         print(subscription)
@@ -59,19 +59,19 @@ def list_subscriptions_in_project(project_id):
     # [END pubsub_list_subscriptions]
 
 
-def create_subscription(project_id, topic_name, subscription_name):
+def create_subscription(project_id, topic_id, subscription_id):
     """Create a new pull subscription on the given topic."""
     # [START pubsub_create_pull_subscription]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
-    # subscription_name = "your-subscription-id"
+    # topic_id = "your-topic-id"
+    # subscription_id = "your-subscription-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    topic_path = subscriber.topic_path(project_id, topic_name)
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    topic_path = subscriber.topic_path(project_id, topic_id)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     subscription = subscriber.create_subscription(subscription_path, topic_path)
 
@@ -82,7 +82,7 @@ def create_subscription(project_id, topic_name, subscription_name):
 
 
 def create_subscription_with_dead_letter_topic(
-    project_id, topic_name, subscription_name, dead_letter_topic_name
+    project_id, topic_id, subscription_id, dead_letter_topic_id
 ):
     """Create a subscription with dead letter policy."""
     # [START pubsub_dead_letter_create_subscription]
@@ -94,17 +94,17 @@ def create_subscription_with_dead_letter_topic(
     # endpoint = "https://my-test-project.appspot.com/push"
     # TODO(developer): This is an existing topic that the subscription
     # with dead letter policy is attached to.
-    # topic_name = "your-topic-id"
+    # topic_id = "your-topic-id"
     # TODO(developer): This is an existing subscription with a dead letter policy.
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
     # TODO(developer): This is an existing dead letter topic that the subscription
     # with dead letter policy will forward dead letter messages to.
-    # dead_letter_topic_name = "your-dead-letter-topic-id"
+    # dead_letter_topic_id = "your-dead-letter-topic-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    topic_path = subscriber.topic_path(project_id, topic_name)
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
-    dead_letter_topic_path = subscriber.topic_path(project_id, dead_letter_topic_name)
+    topic_path = subscriber.topic_path(project_id, topic_id)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
+    dead_letter_topic_path = subscriber.topic_path(project_id, dead_letter_topic_id)
 
     dead_letter_policy = DeadLetterPolicy(
         dead_letter_topic=dead_letter_topic_path, max_delivery_attempts=10
@@ -129,20 +129,20 @@ def create_subscription_with_dead_letter_topic(
     # [END pubsub_dead_letter_create_subscription]
 
 
-def create_push_subscription(project_id, topic_name, subscription_name, endpoint):
+def create_push_subscription(project_id, topic_id, subscription_id, endpoint):
     """Create a new push subscription on the given topic."""
     # [START pubsub_create_push_subscription]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
-    # subscription_name = "your-subscription-id"
+    # topic_id = "your-topic-id"
+    # subscription_id = "your-subscription-id"
     # endpoint = "https://my-test-project.appspot.com/push"
 
     subscriber = pubsub_v1.SubscriberClient()
-    topic_path = subscriber.topic_path(project_id, topic_name)
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    topic_path = subscriber.topic_path(project_id, topic_id)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     push_config = pubsub_v1.types.PushConfig(push_endpoint=endpoint)
 
@@ -157,17 +157,17 @@ def create_push_subscription(project_id, topic_name, subscription_name, endpoint
     # [END pubsub_create_push_subscription]
 
 
-def delete_subscription(project_id, subscription_name):
+def delete_subscription(project_id, subscription_id):
     """Deletes an existing Pub/Sub topic."""
     # [START pubsub_delete_subscription]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     subscriber.delete_subscription(subscription_path)
 
@@ -177,7 +177,7 @@ def delete_subscription(project_id, subscription_name):
     # [END pubsub_delete_subscription]
 
 
-def update_push_subscription(project_id, topic_name, subscription_name, endpoint):
+def update_push_subscription(project_id, topic_id, subscription_id, endpoint):
     """
     Updates an existing Pub/Sub subscription's push endpoint URL.
     Note that certain properties of a subscription, such as
@@ -188,17 +188,17 @@ def update_push_subscription(project_id, topic_name, subscription_name, endpoint
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # topic_name = "your-topic-id"
-    # subscription_name = "your-subscription-id"
+    # topic_id = "your-topic-id"
+    # subscription_id = "your-subscription-id"
     # endpoint = "https://my-test-project.appspot.com/push"
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     push_config = pubsub_v1.types.PushConfig(push_endpoint=endpoint)
 
     subscription = pubsub_v1.types.Subscription(
-        name=subscription_path, topic=topic_name, push_config=push_config
+        name=subscription_path, topic=topic_id, push_config=push_config
     )
 
     update_mask = {"paths": {"push_config"}}
@@ -213,7 +213,7 @@ def update_push_subscription(project_id, topic_name, subscription_name, endpoint
 
 
 def update_subscription_with_dead_letter_policy(
-    project_id, topic_name, subscription_name, dead_letter_topic_name
+    project_id, topic_id, subscription_id, dead_letter_topic_id
 ):
     """Update a subscription's dead letter policy."""
     # [START pubsub_dead_letter_update_subscription]
@@ -224,17 +224,17 @@ def update_subscription_with_dead_letter_policy(
     # project_id = "your-project-id"
     # TODO(developer): This is an existing topic that the subscription
     # with dead letter policy is attached to.
-    # topic_name = "your-topic-name"
+    # topic_id = "your-topic-id"
     # TODO(developer): This is an existing subscription with a dead letter policy.
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
     # TODO(developer): This is an existing dead letter topic that the subscription
     # with dead letter policy will forward dead letter messages to.
-    # dead_letter_topic_name = "your-dead-letter-topic-id"
+    # dead_letter_topic_id = "your-dead-letter-topic-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    topic_path = subscriber.topic_path(project_id, topic_name)
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
-    dead_letter_topic_path = subscriber.topic_path(project_id, dead_letter_topic_name)
+    topic_path = subscriber.topic_path(project_id, topic_id)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
+    dead_letter_topic_path = subscriber.topic_path(project_id, dead_letter_topic_id)
 
     subscription_before_update = subscriber.get_subscription(subscription_path)
     print("Before the update: {}".format(subscription_before_update))
@@ -264,7 +264,7 @@ def update_subscription_with_dead_letter_policy(
     return subscription_after_update
 
 
-def remove_dead_letter_policy(project_id, topic_name, subscription_name):
+def remove_dead_letter_policy(project_id, topic_id, subscription_id):
     """Remove dead letter policy from a subscription."""
     # [START pubsub_dead_letter_remove]
     from google.cloud import pubsub_v1
@@ -274,13 +274,13 @@ def remove_dead_letter_policy(project_id, topic_name, subscription_name):
     # project_id = "your-project-id"
     # TODO(developer): This is an existing topic that the subscription
     # with dead letter policy is attached to.
-    # topic_name = "your-topic-name"
+    # topic_id = "your-topic-id"
     # TODO(developer): This is an existing subscription with a dead letter policy.
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    topic_path = subscriber.topic_path(project_id, topic_name)
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    topic_path = subscriber.topic_path(project_id, topic_id)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     subscription_before_update = subscriber.get_subscription(subscription_path)
     print("Before removing the policy: {}".format(subscription_before_update))
@@ -309,7 +309,7 @@ def remove_dead_letter_policy(project_id, topic_name, subscription_name):
     return subscription_after_update
 
 
-def receive_messages(project_id, subscription_name, timeout=None):
+def receive_messages(project_id, subscription_id, timeout=None):
     """Receives messages from a pull subscription."""
     # [START pubsub_subscriber_async_pull]
     # [START pubsub_quickstart_subscriber]
@@ -318,14 +318,14 @@ def receive_messages(project_id, subscription_name, timeout=None):
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
     # Number of seconds the subscriber should listen for messages
     # timeout = 5.0
 
     subscriber = pubsub_v1.SubscriberClient()
     # The `subscription_path` method creates a fully qualified identifier
-    # in the form `projects/{project_id}/subscriptions/{subscription_name}`
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    # in the form `projects/{project_id}/subscriptions/{subscription_id}`
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message):
         print("Received message: {}".format(message))
@@ -346,9 +346,7 @@ def receive_messages(project_id, subscription_name, timeout=None):
     # [END pubsub_quickstart_subscriber]
 
 
-def receive_messages_with_custom_attributes(
-    project_id, subscription_name, timeout=None
-):
+def receive_messages_with_custom_attributes(project_id, subscription_id, timeout=None):
     """Receives messages from a pull subscription."""
     # [START pubsub_subscriber_sync_pull_custom_attributes]
     # [START pubsub_subscriber_async_pull_custom_attributes]
@@ -357,12 +355,12 @@ def receive_messages_with_custom_attributes(
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
     # Number of seconds the subscriber should listen for messages
     # timeout = 5.0
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message):
         print("Received message: {}".format(message.data))
@@ -388,7 +386,7 @@ def receive_messages_with_custom_attributes(
     # [END pubsub_subscriber_sync_pull_custom_attributes]
 
 
-def receive_messages_with_flow_control(project_id, subscription_name, timeout=None):
+def receive_messages_with_flow_control(project_id, subscription_id, timeout=None):
     """Receives messages from a pull subscription with flow control."""
     # [START pubsub_subscriber_flow_settings]
     from concurrent.futures import TimeoutError
@@ -396,12 +394,12 @@ def receive_messages_with_flow_control(project_id, subscription_name, timeout=No
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
     # Number of seconds the subscriber should listen for messages
     # timeout = 5.0
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message):
         print("Received message: {}".format(message.data))
@@ -426,17 +424,17 @@ def receive_messages_with_flow_control(project_id, subscription_name, timeout=No
     # [END pubsub_subscriber_flow_settings]
 
 
-def synchronous_pull(project_id, subscription_name):
+def synchronous_pull(project_id, subscription_id):
     """Pulling messages synchronously."""
     # [START pubsub_subscriber_sync_pull]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     NUM_MESSAGES = 3
 
@@ -461,7 +459,7 @@ def synchronous_pull(project_id, subscription_name):
     # [END pubsub_subscriber_sync_pull]
 
 
-def synchronous_pull_with_lease_management(project_id, subscription_name):
+def synchronous_pull_with_lease_management(project_id, subscription_id):
     """Pulling messages synchronously with lease management"""
     # [START pubsub_subscriber_sync_pull_with_lease]
     import logging
@@ -473,10 +471,10 @@ def synchronous_pull_with_lease_management(project_id, subscription_name):
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     NUM_MESSAGES = 2
     ACK_DEADLINE = 30
@@ -547,19 +545,19 @@ def synchronous_pull_with_lease_management(project_id, subscription_name):
     # [END pubsub_subscriber_sync_pull_with_lease]
 
 
-def listen_for_errors(project_id, subscription_name, timeout=None):
+def listen_for_errors(project_id, subscription_id, timeout=None):
     """Receives messages and catches errors from a pull subscription."""
     # [START pubsub_subscriber_error_listener]
     from google.cloud import pubsub_v1
 
     # TODO(developer)
-    # project_id = "Your Google Cloud Project ID"
-    # subscription_name = "Your Pubsub subscription name"
+    # project_id = "your-project-id"
+    # subscription_id = "your-subscription-id"
     # Number of seconds the subscriber should listen for messages
     # timeout = 5.0
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message):
         print("Received message: {}".format(message))
@@ -578,25 +576,23 @@ def listen_for_errors(project_id, subscription_name, timeout=None):
             streaming_pull_future.cancel()
             print(
                 "Listening for messages on {} threw an exception: {}.".format(
-                    subscription_name, e
+                    subscription_id, e
                 )
             )
     # [END pubsub_subscriber_error_listener]
 
 
-def receive_messages_with_delivery_attempts(
-    project_id, subscription_name, timeout=None
-):
+def receive_messages_with_delivery_attempts(project_id, subscription_id, timeout=None):
     # [START  pubsub_dead_letter_delivery_attempt]
     from concurrent.futures import TimeoutError
     from google.cloud import pubsub_v1
 
     # TODO(developer)
     # project_id = "your-project-id"
-    # subscription_name = "your-subscription-id"
+    # subscription_id = "your-subscription-id"
 
     subscriber = pubsub_v1.SubscriberClient()
-    subscription_path = subscriber.subscription_path(project_id, subscription_name)
+    subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
     def callback(message):
         print("Received message: {}".format(message))
@@ -627,64 +623,64 @@ if __name__ == "__main__":
     list_in_topic_parser = subparsers.add_parser(
         "list-in-topic", help=list_subscriptions_in_topic.__doc__
     )
-    list_in_topic_parser.add_argument("topic_name")
+    list_in_topic_parser.add_argument("topic_id")
 
     list_in_project_parser = subparsers.add_parser(
         "list-in-project", help=list_subscriptions_in_project.__doc__
     )
 
     create_parser = subparsers.add_parser("create", help=create_subscription.__doc__)
-    create_parser.add_argument("topic_name")
-    create_parser.add_argument("subscription_name")
+    create_parser.add_argument("topic_id")
+    create_parser.add_argument("subscription_id")
 
     create_with_dead_letter_policy_parser = subparsers.add_parser(
         "create-with-dead-letter-policy",
         help=create_subscription_with_dead_letter_topic.__doc__,
     )
-    create_with_dead_letter_policy_parser.add_argument("topic_name")
-    create_with_dead_letter_policy_parser.add_argument("subscription_name")
-    create_with_dead_letter_policy_parser.add_argument("dead_letter_topic_name")
+    create_with_dead_letter_policy_parser.add_argument("topic_id")
+    create_with_dead_letter_policy_parser.add_argument("subscription_id")
+    create_with_dead_letter_policy_parser.add_argument("dead_letter_topic_id")
 
     create_push_parser = subparsers.add_parser(
         "create-push", help=create_push_subscription.__doc__
     )
-    create_push_parser.add_argument("topic_name")
-    create_push_parser.add_argument("subscription_name")
+    create_push_parser.add_argument("topic_id")
+    create_push_parser.add_argument("subscription_id")
     create_push_parser.add_argument("endpoint")
 
     delete_parser = subparsers.add_parser("delete", help=delete_subscription.__doc__)
-    delete_parser.add_argument("subscription_name")
+    delete_parser.add_argument("subscription_id")
 
     update_push_parser = subparsers.add_parser(
         "update-push", help=update_push_subscription.__doc__
     )
-    update_push_parser.add_argument("topic_name")
-    update_push_parser.add_argument("subscription_name")
+    update_push_parser.add_argument("topic_id")
+    update_push_parser.add_argument("subscription_id")
     update_push_parser.add_argument("endpoint")
 
     update_dead_letter_policy_parser = subparsers.add_parser(
         "update-dead-letter-policy",
         help=update_subscription_with_dead_letter_policy.__doc__,
     )
-    update_dead_letter_policy_parser.add_argument("topic_name")
-    update_dead_letter_policy_parser.add_argument("subscription_name")
-    update_dead_letter_policy_parser.add_argument("dead_letter_topic_name")
+    update_dead_letter_policy_parser.add_argument("topic_id")
+    update_dead_letter_policy_parser.add_argument("subscription_id")
+    update_dead_letter_policy_parser.add_argument("dead_letter_topic_id")
 
     remove_dead_letter_policy_parser = subparsers.add_parser(
         "remove-dead-letter-policy", help=remove_dead_letter_policy.__doc__
     )
-    remove_dead_letter_policy_parser.add_argument("topic_name")
-    remove_dead_letter_policy_parser.add_argument("subscription_name")
+    remove_dead_letter_policy_parser.add_argument("topic_id")
+    remove_dead_letter_policy_parser.add_argument("subscription_id")
 
     receive_parser = subparsers.add_parser("receive", help=receive_messages.__doc__)
-    receive_parser.add_argument("subscription_name")
+    receive_parser.add_argument("subscription_id")
     receive_parser.add_argument("timeout", default=None, type=float, nargs="?")
 
     receive_with_custom_attributes_parser = subparsers.add_parser(
         "receive-custom-attributes",
         help=receive_messages_with_custom_attributes.__doc__,
     )
-    receive_with_custom_attributes_parser.add_argument("subscription_name")
+    receive_with_custom_attributes_parser.add_argument("subscription_id")
     receive_with_custom_attributes_parser.add_argument(
         "timeout", default=None, type=float, nargs="?"
     )
@@ -692,7 +688,7 @@ if __name__ == "__main__":
     receive_with_flow_control_parser = subparsers.add_parser(
         "receive-flow-control", help=receive_messages_with_flow_control.__doc__
     )
-    receive_with_flow_control_parser.add_argument("subscription_name")
+    receive_with_flow_control_parser.add_argument("subscription_id")
     receive_with_flow_control_parser.add_argument(
         "timeout", default=None, type=float, nargs="?"
     )
@@ -700,18 +696,18 @@ if __name__ == "__main__":
     synchronous_pull_parser = subparsers.add_parser(
         "receive-synchronously", help=synchronous_pull.__doc__
     )
-    synchronous_pull_parser.add_argument("subscription_name")
+    synchronous_pull_parser.add_argument("subscription_id")
 
     synchronous_pull_with_lease_management_parser = subparsers.add_parser(
         "receive-synchronously-with-lease",
         help=synchronous_pull_with_lease_management.__doc__,
     )
-    synchronous_pull_with_lease_management_parser.add_argument("subscription_name")
+    synchronous_pull_with_lease_management_parser.add_argument("subscription_id")
 
     listen_for_errors_parser = subparsers.add_parser(
         "listen-for-errors", help=listen_for_errors.__doc__
     )
-    listen_for_errors_parser.add_argument("subscription_name")
+    listen_for_errors_parser.add_argument("subscription_id")
     listen_for_errors_parser.add_argument(
         "timeout", default=None, type=float, nargs="?"
     )
@@ -720,7 +716,7 @@ if __name__ == "__main__":
         "receive-messages-with-delivery-attempts",
         help=receive_messages_with_delivery_attempts.__doc__,
     )
-    receive_messages_with_delivery_attempts_parser.add_argument("subscription_name")
+    receive_messages_with_delivery_attempts_parser.add_argument("subscription_id")
     receive_messages_with_delivery_attempts_parser.add_argument(
         "timeout", default=None, type=float, nargs="?"
     )
@@ -728,56 +724,54 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.command == "list-in-topic":
-        list_subscriptions_in_topic(args.project_id, args.topic_name)
+        list_subscriptions_in_topic(args.project_id, args.topic_id)
     elif args.command == "list-in-project":
         list_subscriptions_in_project(args.project_id)
     elif args.command == "create":
-        create_subscription(args.project_id, args.topic_name, args.subscription_name)
+        create_subscription(args.project_id, args.topic_id, args.subscription_id)
     elif args.command == "create-with-dead-letter-policy":
         create_subscription_with_dead_letter_topic(
             args.project_id,
-            args.topic_name,
-            args.subscription_name,
-            args.dead_letter_topic_name,
+            args.topic_id,
+            args.subscription_id,
+            args.dead_letter_topic_id,
         )
     elif args.command == "create-push":
         create_push_subscription(
-            args.project_id, args.topic_name, args.subscription_name, args.endpoint,
+            args.project_id, args.topic_id, args.subscription_id, args.endpoint,
         )
     elif args.command == "delete":
-        delete_subscription(args.project_id, args.subscription_name)
+        delete_subscription(args.project_id, args.subscription_id)
     elif args.command == "update-push":
         update_push_subscription(
-            args.project_id, args.topic_name, args.subscription_name, args.endpoint,
+            args.project_id, args.topic_id, args.subscription_id, args.endpoint,
         )
     elif args.command == "update-dead-letter-policy":
         update_subscription_with_dead_letter_policy(
             args.project_id,
-            args.topic_name,
-            args.subscription_name,
-            args.dead_letter_topic_name,
+            args.topic_id,
+            args.subscription_id,
+            args.dead_letter_topic_id,
         )
     elif args.command == "remove-dead-letter-policy":
-        remove_dead_letter_policy(
-            args.project_id, args.topic_name, args.subscription_name
-        )
+        remove_dead_letter_policy(args.project_id, args.topic_id, args.subscription_id)
     elif args.command == "receive":
-        receive_messages(args.project_id, args.subscription_name, args.timeout)
+        receive_messages(args.project_id, args.subscription_id, args.timeout)
     elif args.command == "receive-custom-attributes":
         receive_messages_with_custom_attributes(
-            args.project_id, args.subscription_name, args.timeout
+            args.project_id, args.subscription_id, args.timeout
         )
     elif args.command == "receive-flow-control":
         receive_messages_with_flow_control(
-            args.project_id, args.subscription_name, args.timeout
+            args.project_id, args.subscription_id, args.timeout
         )
     elif args.command == "receive-synchronously":
-        synchronous_pull(args.project_id, args.subscription_name)
+        synchronous_pull(args.project_id, args.subscription_id)
     elif args.command == "receive-synchronously-with-lease":
-        synchronous_pull_with_lease_management(args.project_id, args.subscription_name)
+        synchronous_pull_with_lease_management(args.project_id, args.subscription_id)
     elif args.command == "listen-for-errors":
-        listen_for_errors(args.project_id, args.subscription_name, args.timeout)
+        listen_for_errors(args.project_id, args.subscription_id, args.timeout)
     elif args.command == "receive-messages-with-delivery-attempts":
         receive_messages_with_delivery_attempts(
-            args.project_id, args.subscription_name, args.timeout
+            args.project_id, args.subscription_id, args.timeout
         )


### PR DESCRIPTION
Users have pointed out that when we say topic name and subscription name in the samples, we actually mean topic id and subscription id. Updating the samples to reflect this. 