### PR TITLE
chore: add note about preference of stream() to get()

### DIFF
--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -239,7 +239,9 @@ def get_custom_class():
 def get_simple_query():
     db = firestore.Client()
     # [START get_simple_query]
-    docs = db.collection(u'cities').where(u'capital', u'==', True).stream()
+    collection_ref = db.collection(u'cities').where(u'capital', u'==', True)
+    # Note: the CollectionReference get() method is a deprecated alias for stream()
+    docs = collection_ref.stream()
 
     for doc in docs:
         print(u'{} => {}'.format(doc.id, doc.to_dict()))

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -239,9 +239,8 @@ def get_custom_class():
 def get_simple_query():
     db = firestore.Client()
     # [START get_simple_query]
-    collection_ref = db.collection(u'cities').where(u'capital', u'==', True)
-    # Note: the CollectionReference get() method is a deprecated alias for stream()
-    docs = collection_ref.stream()
+    # Note: Use of CollectionRef stream() is prefered to get()
+    docs = db.collection(u'cities').where(u'capital', u'==', True).stream()
 
     for doc in docs:
         print(u'{} => {}'.format(doc.id, doc.to_dict()))


### PR DESCRIPTION
This snippet is used in these docs:
https://cloud.google.com/firestore/docs/query-data/queries#python_3

Which say:
> After creating a query object, use the get() function to retrieve the results:

That's true for the other languages, but not for Python, which has deprecated get() and replaced it with stream(), based on these docs:
https://googleapis.dev/python/firestore/latest/collection.html#google.cloud.firestore_v1.collection.CollectionReference.get