### PR TITLE
Add Datastore eventual consistency read example

### DIFF
--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -784,7 +784,8 @@ def property_by_kind_run_query(client):
 
 def eventual_consistent_query(client):
     # [START datastore_eventual_consistent_query]
-    # Read consistency cannot be specified in google-cloud-python.
+    query = client.query(kind='Task')
+    query.fetch(eventual=True)
     # [END datastore_eventual_consistent_query]
     pass
 


### PR DESCRIPTION
This snippet shows up here:
https://cloud.google.com/datastore/docs/concepts/structuring_for_strong_consistency#datastore-datastore-eventual-consistent-query-python

The eventual parameter is specified in the docs:
https://googleapis.dev/python/datastore/latest/queries.html

To check this, I ran the snippet:
```
>>> from google.cloud import datastore
>>> client = datastore.Client()
>>> query = client.query(kind='Task')
>>> query.fetch(eventual=True)
<google.cloud.datastore.query.Iterator object at 0x1023a2860>
>>> query.fetch()
<google.cloud.datastore.query.Iterator object at 0x1023a28d0>
```