### PR TITLE
[btlr] testing: use NUM_TEST_WORKERS env var

### DIFF
--- a/.kokoro/python2.7/common.cfg
+++ b/.kokoro/python2.7/common.cfg
@@ -50,6 +50,12 @@ env_vars: {
     value: "python-docs-samples-tests"
 }
 
+# Number of test workers.
+env_vars: {
+    key: "NUM_TEST_WORKERS"
+    value: "1"
+}
+
 env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/Dockerfile"

--- a/.kokoro/python2.7/common.cfg
+++ b/.kokoro/python2.7/common.cfg
@@ -50,12 +50,6 @@ env_vars: {
     value: "python-docs-samples-tests"
 }
 
-# Number of test workers.
-env_vars: {
-    key: "NUM_TEST_WORKERS"
-    value: "1"
-}
-
 env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/Dockerfile"

--- a/.kokoro/python3.6/common.cfg
+++ b/.kokoro/python3.6/common.cfg
@@ -51,6 +51,12 @@ env_vars: {
     value: "python-docs-samples-tests-py36"
 }
 
+# Number of test workers.
+env_vars: {
+    key: "NUM_TEST_WORKERS"
+    value: "10"
+}
+
 env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/Dockerfile"

--- a/.kokoro/python3.6/common.cfg
+++ b/.kokoro/python3.6/common.cfg
@@ -54,7 +54,7 @@ env_vars: {
 # Number of test workers.
 env_vars: {
     key: "NUM_TEST_WORKERS"
-    value: "10"
+    value: "20"
 }
 
 env_vars: {

--- a/.kokoro/python3.6/common.cfg
+++ b/.kokoro/python3.6/common.cfg
@@ -54,7 +54,7 @@ env_vars: {
 # Number of test workers.
 env_vars: {
     key: "NUM_TEST_WORKERS"
-    value: "20"
+    value: "10"
 }
 
 env_vars: {

--- a/.kokoro/python3.7/common.cfg
+++ b/.kokoro/python3.7/common.cfg
@@ -51,6 +51,12 @@ env_vars: {
     value: "python-docs-samples-tests-py37"
 }
 
+# Number of test workers.
+env_vars: {
+    key: "NUM_TEST_WORKERS"
+    value: "10"
+}
+
 env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/Dockerfile"

--- a/.kokoro/python3.7/common.cfg
+++ b/.kokoro/python3.7/common.cfg
@@ -54,7 +54,7 @@ env_vars: {
 # Number of test workers.
 env_vars: {
     key: "NUM_TEST_WORKERS"
-    value: "10"
+    value: "20"
 }
 
 env_vars: {

--- a/.kokoro/python3.7/common.cfg
+++ b/.kokoro/python3.7/common.cfg
@@ -54,7 +54,7 @@ env_vars: {
 # Number of test workers.
 env_vars: {
     key: "NUM_TEST_WORKERS"
-    value: "20"
+    value: "10"
 }
 
 env_vars: {

--- a/.kokoro/python3.8/common.cfg
+++ b/.kokoro/python3.8/common.cfg
@@ -51,6 +51,12 @@ env_vars: {
     value: "python-docs-samples-tests-py38"
 }
 
+# Number of test workers.
+env_vars: {
+    key: "NUM_TEST_WORKERS"
+    value: "10"
+}
+
 env_vars: {
     key: "TRAMPOLINE_DOCKERFILE"
     value: ".kokoro/docker/Dockerfile"

--- a/.kokoro/python3.8/common.cfg
+++ b/.kokoro/python3.8/common.cfg
@@ -54,7 +54,7 @@ env_vars: {
 # Number of test workers.
 env_vars: {
     key: "NUM_TEST_WORKERS"
-    value: "10"
+    value: "20"
 }
 
 env_vars: {

--- a/.kokoro/python3.8/common.cfg
+++ b/.kokoro/python3.8/common.cfg
@@ -54,7 +54,7 @@ env_vars: {
 # Number of test workers.
 env_vars: {
     key: "NUM_TEST_WORKERS"
-    value: "20"
+    value: "10"
 }
 
 env_vars: {

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -51,6 +51,19 @@ if [[ $* == *--only-diff-head* ]]; then
     fi
 fi
 
+# Because Kokoro runs presubmit builds simalteneously, we often see
+# quota related errors. I think we can avoid this by changing the
+# order of tests to execute (e.g. reverse order for py-3.8
+# build). Currently there's no easy way to do that with btlr, so we
+# temporarily wait few minutes to avoid quota issue for py-3.8
+# presubmit build.
+if [[ "${RUN_TESTS_SESSION}" == "py-3.8" ]] \
+       && [[ "${KOKORO_JOB_NAME}" == *presubmit ]]; then
+    echo -n "Detected py-3.8 presubmit build,"
+    echo "Wait few minutes to avoid quota issues."
+    sleep 5m
+fi
+
 if [[ -z "${PROJECT_ROOT:-}" ]]; then
     PROJECT_ROOT="github/python-docs-samples"
 fi

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -108,9 +108,14 @@ test_prog="${PROJECT_ROOT}/.kokoro/tests/run_single_test.sh"
 btlr_args=(
     "run"
     "**/requirements.txt"
-    "--max-concurrency"
-    "30"
 )
+
+if [[ -n "${NUM_TEST_WORKERS:-}" ]]; then
+    btlr_args+=(
+	"--max-concurrency"
+	"${NUM_TEST_WORKERS}"
+    )
+fi
 
 if [[ -n "${DIFF_FROM:-}"  ]]; then
     btlr_args+=(


### PR DESCRIPTION
Experimenting with different number of workers.

lint, py-2.7, py-3.6:
default (I think it's 6 on Kokoro)

py-3.7:
12

py-3.8:
20
