### PR TITLE
Add a simplified inspect string example to DLP code samples

### DIFF
--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -66,11 +66,7 @@ def inspect_string_basic(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            try:
-                if finding.quote:
-                    print("Quote: {}".format(finding.quote))
-            except AttributeError:
-                pass
+            print("Quote: {}".format(finding.quote))
             print("Info type: {}".format(finding.info_type.name))
             print("Likelihood: {}".format(finding.likelihood))
     else:

--- a/dlp/inspect_content.py
+++ b/dlp/inspect_content.py
@@ -22,6 +22,64 @@ import json
 import os
 
 
+# [START dlp_inspect_string_basic]
+def inspect_string_basic(
+    project,
+    content_string,
+    info_types=["PHONE_NUMBER"],
+):
+    """Uses the Data Loss Prevention API to analyze strings for protected data.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+        info_types: A list of strings representing info types to look for.
+            A full list of info type categories can be fetched from the API.
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library.
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries (protos are also accepted).
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Construct the configuration dictionary.
+    inspect_config = {
+        "info_types": info_types,
+        "include_quote": True,
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = dlp.project_path(project)
+
+    # Call the API.
+    response = dlp.inspect_content(parent, inspect_config, item)
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print("Quote: {}".format(finding.quote))
+            except AttributeError:
+                pass
+            print("Info type: {}".format(finding.info_type.name))
+            print("Likelihood: {}".format(finding.likelihood))
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_string_basic]
+
+
 # [START dlp_inspect_string]
 def inspect_string(
     project,

--- a/dlp/inspect_content_test.py
+++ b/dlp/inspect_content_test.py
@@ -161,6 +161,16 @@ def bigquery_project():
     bigquery_client.delete_dataset(dataset_ref, delete_contents=True)
 
 
+def test_inspect_string_basic(capsys):
+    test_string = "String with a phone number: 234-555-6789"
+
+    inspect_content.inspect_string_basic(GCLOUD_PROJECT, test_string)
+
+    out, _ = capsys.readouterr()
+    assert "Info type: PHONE_NUMBER" in out
+    assert "Quote: 234-555-6789" in out
+
+
 def test_inspect_string(capsys):
     test_string = "My name is Gary Smith and my email is gary@example.com"
 


### PR DESCRIPTION
Add a basic DLP code sample that just inspects with an infotype. This sample will be linked to the documentation at http://cloud/dlp/docs/concepts-infotypes#how_to_use_infotypes.

Please merge this PR after approving.