### PR TITLE
fix: changes a positional to named arg

### DIFF
--- a/video/cloud-client/analyze/beta_snippets.py
+++ b/video/cloud-client/analyze/beta_snippets.py
@@ -62,7 +62,7 @@ def speech_transcription(input_uri):
     )
 
     operation = video_client.annotate_video(
-        input_uri, features=features, video_context=video_context
+        input_uri=input_uri, features=features, video_context=video_context
     )
 
     print("\nProcessing video for speech transcription.")


### PR DESCRIPTION
[Another PR](https://github.com/GoogleCloudPlatform/python-docs-samples/pull/4041) is blocked due to the use of positional arguments in the Video Intelligence samples. This PR changes one sample to use named arguments.

This fix updates the following region tags:

+ `video_speech_transcription_gcs_beta`