### PR TITLE
[iam] testing: use uniqueId instead of email

### DIFF
--- a/iam/api-client/service_accounts_test.py
+++ b/iam/api-client/service_accounts_test.py
@@ -23,7 +23,6 @@ import service_accounts
 def test_service_accounts(capsys):
     project_id = os.environ['GOOGLE_CLOUD_PROJECT']
     name = f'test-{uuid.uuid4().hex[:25]}'
-    email = name + '@' + project_id + '.iam.gserviceaccount.com'
 
     try:
         acct = service_accounts.create_service_account(

--- a/iam/api-client/service_accounts_test.py
+++ b/iam/api-client/service_accounts_test.py
@@ -26,17 +26,20 @@ def test_service_accounts(capsys):
     email = name + '@' + project_id + '.iam.gserviceaccount.com'
 
     try:
-        service_accounts.create_service_account(
+        acct = service_accounts.create_service_account(
             project_id, name, 'Py Test Account')
+        assert('uniqueId' in acct)
+
+        unique_id = acct['uniqueId']
         service_accounts.list_service_accounts(project_id)
         service_accounts.rename_service_account(
-            email, 'Updated Py Test Account')
-        service_accounts.disable_service_account(email)
-        service_accounts.enable_service_account(email)
-        service_accounts.delete_service_account(email)
+            unique_id, 'Updated Py Test Account')
+        service_accounts.disable_service_account(unique_id)
+        service_accounts.enable_service_account(unique_id)
+        service_accounts.delete_service_account(unique_id)
     finally:
         try:
-            service_accounts.delete_service_account(email)
+            service_accounts.delete_service_account(unique_id)
         except HttpError as e:
             # When the service account doesn't exist, the service returns 403.
             if '403' in str(e):

--- a/iam/api-client/service_accounts_test.py
+++ b/iam/api-client/service_accounts_test.py
@@ -22,7 +22,7 @@ import service_accounts
 
 def test_service_accounts(capsys):
     project_id = os.environ['GOOGLE_CLOUD_PROJECT']
-    name = 'python-test-{}'.format(str(uuid.uuid4()).split('-')[0])
+    name = f'test-{uuid.uuid4().hex[:25]}'
     email = name + '@' + project_id + '.iam.gserviceaccount.com'
 
     try:


### PR DESCRIPTION
## Description

Fixes #4087

It turned out that looking up by e-mail is eventual consistent (although normally few seconds, but it can be up to few minutes in the worst case). If we use the uniqueId, the lookup should be strong consistent.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Enviroment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Enviroment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
