### PR TITLE
fixed requirements (specified the version of grpcio and setuptools)

### DIFF
--- a/codelabs/flex_and_vision/requirements.txt
+++ b/codelabs/flex_and_vision/requirements.txt
@@ -4,3 +4,5 @@ gunicorn==19.10.0; python_version < '3.0'
 google-cloud-vision==1.0.0
 google-cloud-storage==1.29.0
 google-cloud-datastore==1.12.0
+grpcio==1.27.2
+setuptools==40.3.0


### PR DESCRIPTION
I fixed `codelabs/flex_and_vision/requirements.txt` (specified the version of grpcio and setuptools).

This code sample is used in https://google.qwiklabs.com/focuses/3339?parent=catalog.
If you don't specify the versions of `grpcio` and `setuptools` (= current configuration), build fails and you can't deploy to App Engine as below. So you can't complete the lab.

<img width="564" alt="スクリーンショット 2020-06-20 12 23 58" src="https://user-images.githubusercontent.com/53966025/85190289-cf1f0300-b2f1-11ea-9177-962474698722.png">

After this change, you can deploy the app and get to finish the lab.