### PR TITLE
testing: reliablly fetch gpg keys

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -94,19 +94,12 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && rm -rf /var/lib/apt/lists/* \
   && rm -f /var/cache/apt/archives/*.deb
 
+COPY fetch_gpg_keys.sh /tmp
 # Install the desired versions of Python.
 RUN set -ex \
     && export GNUPGHOME="$(mktemp -d)" \
     && echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
-      # 2.7.17 (Benjamin Peterson)
-      C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF \
-      # 3.4.10, 3.5.9 (Larry Hastings)
-      97FC712E4C024BBEA48A61ED3A5CA953F73C700D \
-      # 3.6.9, 3.7.5 (Ned Deily)
-      0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D \
-      # 3.8.0 (Łukasz Langa)
-      E3FF2839C048B25C084DEBE9B26995E310250568 \
+    && /tmp/fetch_gpg_keys.sh \
     && for PYTHON_VERSION in 2.7.18 3.6.10 3.7.7 3.8.3; do \
         wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
         && wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \

--- a/.kokoro/docker/fetch_gpg_keys.sh
+++ b/.kokoro/docker/fetch_gpg_keys.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script to fetch gpg keys with retry.
+
+function retry {
+    if [[ "${#}" -le 1 ]]; then
+	echo "Usage: ${0} retry_count commands.."
+	exit 1
+    fi
+    local retries=${1}
+    local command="${@:2}"
+    until [[ "${retries}" -le 0 ]]; do
+	$command && return 0
+	if [[ $? -ne 0 ]]; then
+	    echo "command failed, retrying"
+	    ((retries--))
+	fi
+    done
+    return 1
+}
+
+# 2.7.17 (Benjamin Peterson)
+retry 3 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
+      C01E1CAD5EA2C4F0B8E3571504C367C218ADD4FF
+
+# 3.4.10, 3.5.9 (Larry Hastings)
+retry 3 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
+      97FC712E4C024BBEA48A61ED3A5CA953F73C700D
+
+# 3.6.9, 3.7.5 (Ned Deily)
+retry 3 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
+      0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+
+# 3.8.0 (Łukasz Langa)
+retry 3 gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
+      E3FF2839C048B25C084DEBE9B26995E310250568

--- a/vision/automl/edge_container_predict/automl_vision_edge_container_predict_test.py
+++ b/vision/automl/edge_container_predict/automl_vision_edge_container_predict_test.py
@@ -59,7 +59,7 @@ def edge_container_predict_server_port():
         ['docker', 'pull', CPU_DOCKER_GCS_PATH],
         env={'DOCKER_API_VERSION': '1.38'})
 
-    if os.environ.get('TRAMPOLINE_V2') == 'true':
+    if os.environ.get('TRAMPOLINE_VERSION'):
         # Use /tmp
         model_path = tempfile.TemporaryDirectory()
     else:


### PR DESCRIPTION
fixes #4162
fixes #4173 

Also copied the latest `trampoline_v2.sh`, which suppress docker build logs on CI systems.