### PR TITLE
[tables/automl] fix: update the csv file and the dataset name

### DIFF
--- a/tables/automl/dataset_test.py
+++ b/tables/automl/dataset_test.py
@@ -26,8 +26,9 @@ import automl_tables_dataset
 
 PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
 REGION = "us-central1"
-STATIC_DATASET = "do_not_delete_this_table"
-GCS_DATASET = "gs://cloud-ml-tables-data/bank-marketing.csv"
+STATIC_DATASET = "do_not_delete_this_table_python"
+GCS_DATASET = ("gs://python-docs-samples-tests-automl-tables-test"
+               "/bank-marketing.csv")
 
 ID = "{rand}_{time}".format(
     rand="".join(


### PR DESCRIPTION
fixes #4177
fixes #4178

I needed to modify the csv file to only have positive values in the `Balance` column. I don't have a permission on the `cloud-ml-tables-data`, so I created a new bucket and uploaded the file there. Here is a throw-away python script to modify the csv:

```python
from tempfile import NamedTemporaryFile
import shutil
import csv

filename = 'bank-marketing.csv'
tempfile = NamedTemporaryFile(mode='w', delete=False)

fields = ['Age','Job','MaritalStatus','Education','Default','Balance','Housing','Loan','Contact','Day','Month','Duration','Campaign','PDays','Previous','POutcome','Deposit']

with open(filename, 'r') as csvfile, tempfile:
    reader = csv.DictReader(csvfile, fieldnames=fields)
    writer = csv.DictWriter(tempfile, fieldnames=fields)
    for row in reader:
        if row['Age'] != 'Age' and int(row['Balance']) == 0:
            row['Balance'] = 1
        if row['Age'] != 'Age' and int(row['Balance']) < 0:
            print('updating row')
            row['Balance'] = int(row['Balance']) * -1
        writer.writerow(row)

shutil.move(tempfile.name, filename)

```