### PR TITLE
chore: upgrade to trampoline 2.0.3

### DIFF
--- a/scripts/run_tests_local.sh
+++ b/scripts/run_tests_local.sh
@@ -70,7 +70,4 @@ for session in "${sessions[@]}"
 do
     export RUN_TESTS_SESSION="${session}"
     "${PROJECT_ROOT}/.kokoro/trampoline_v2.sh"
-    # We can re-use the image after the first iteration.
-    export TRAMPOLINE_SKIP_DOWNLOAD_IMAGE="true"
-    export TRAMPOLINE_DOCKERFILE="none"
 done


### PR DESCRIPTION
Upgrade to Trampoline 2.0.3.

This version has a nice cleanup. It makes the script `run_tests_local.sh` cleaner and faster for most cases.

Note:
The changes in `trampoline_v2.sh` is reviewed (and tested) in [another repo](https://github.com/GoogleCloudPlatform/docker-ci-helper). We're copying the script into this repo.