### PR TITLE
Pub/Sub: no need to verify issuer in JWT

### DIFF
--- a/appengine/standard_python3/pubsub/main.py
+++ b/appengine/standard_python3/pubsub/main.py
@@ -85,12 +85,6 @@ def receive_messages_handler():
         # case they would all share the same token for a limited time window.
         claim = id_token.verify_oauth2_token(token, requests.Request(),
                                              audience='example.com')
-        # Must also verify the `iss` claim.
-        if claim['iss'] not in [
-            'accounts.google.com',
-            'https://accounts.google.com'
-        ]:
-            raise ValueError('Wrong issuer.')
         CLAIMS.append(claim)
     except Exception as e:
         return 'Invalid token: {}\n'.format(e), 400


### PR DESCRIPTION
The latest https://github.com/googleapis/google-auth-library-python/releases/tag/v1.19.0 checks the issuer claim automatically via `verify_oauth_token2`. Remove code in the sample that does this check manually. See [PR #500](https://github.com/googleapis/google-auth-library-python/pull/500).