### PR TITLE
Added GKE deployment yaml file for Cloud Endpoint ESPv2

### DIFF
--- a/endpoints/getting-started-grpc/deployment-esp-v2.yaml
+++ b/endpoints/getting-started-grpc/deployment-esp-v2.yaml
@@ -1,0 +1,54 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: grpc-hello
+spec:
+  ports:
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http
+  selector:
+    app: grpc-hello
+  type: LoadBalancer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: grpc-hello
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: grpc-hello
+    spec:
+      containers:
+      - name: esp
+        image: gcr.io/endpoints-release/endpoints-runtime:2
+        args: [
+          "--listener_port=9000",
+          "--backend=grpc://127.0.0.1:50051",
+          "--service=SERVICE_NAME",
+          "--rollout_strategy=managed",
+        ]
+        ports:
+          - containerPort: 9000
+      - name: python-grpc-hello
+        image: gcr.io/GCLOUD_PROJECT/python-grpc-hello:1.0
+        ports:
+          - containerPort: 50051

--- a/endpoints/getting-started/deployment-esp-v2.yaml
+++ b/endpoints/getting-started/deployment-esp-v2.yaml
@@ -1,0 +1,56 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: esp-echo
+spec:
+  ports:
+  - port: 80
+    targetPort: 8081
+    protocol: TCP
+    name: http
+  selector:
+    app: esp-echo
+  type: LoadBalancer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: esp-echo
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: esp-echo
+    spec:
+      containers:
+      # [START esp]
+      - name: esp
+        image: gcr.io/endpoints-release/endpoints-runtime:2
+        args: [
+          "--listener_port=8081",
+          "--backend=127.0.0.1:8080",
+          "--service=SERVICE_NAME",
+          "--rollout_strategy=managed",
+        ]
+      # [END esp]
+        ports:
+        - containerPort: 8081
+      - name: echo
+        image: gcr.io/endpoints-release/echo-python:1.0
+        ports:
+        - containerPort: 8080

--- a/endpoints/kubernetes/grpc-bookstore-esp-v2.yaml
+++ b/endpoints/kubernetes/grpc-bookstore-esp-v2.yaml
@@ -1,56 +1,59 @@
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License
+
+# Use this file to deploy the container for the grpc-bookstore sample
+# and the container for the Extensible Service Proxy (ESP) to
+# Google Kubernetes Engine (GKE).
 
 apiVersion: v1
 kind: Service
 metadata:
-  name: esp-echo
+  name: esp-grpc-bookstore
 spec:
   ports:
+  # Port that accepts gRPC and JSON/HTTP2 requests over HTTP.
   - port: 80
-    targetPort: 8081
+    targetPort: 9000
     protocol: TCP
-    name: http
+    name: http2
   selector:
-    app: esp-echo
+    app: esp-grpc-bookstore
   type: LoadBalancer
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: esp-echo
+  name: esp-grpc-bookstore
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: esp-echo
+        app: esp-grpc-bookstore
     spec:
       containers:
-      # [START esp]
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:2
         args: [
-          "--listener_port=8081",
-          "--backend=http://127.0.0.1:8080",
+          "--listener_port=9000",
           "--service=SERVICE_NAME",
           "--rollout_strategy=managed",
+          "--backend=grpc://127.0.0.1:8000"
         ]
-      # [END esp]
         ports:
-        - containerPort: 8081
-      - name: echo
-        image: gcr.io/endpoints-release/echo-python:1.0
+          - containerPort: 9000
+      - name: bookstore
+        image: gcr.io/endpointsv2/python-grpc-bookstore-server:1
         ports:
-        - containerPort: 8080
+          - containerPort: 8000

--- a/endpoints/kubernetes/k8s-grpc-bookstore-esp-v2.yaml
+++ b/endpoints/kubernetes/k8s-grpc-bookstore-esp-v2.yaml
@@ -1,0 +1,74 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+# Use this file to deploy the container for the grpc-bookstore sample
+# and the container for the Extensible Service Proxy (ESP) to a
+# Kubernetes cluster that is not on GCP.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: esp-grpc-bookstore
+spec:
+  ports:
+  # Port that accepts gRPC and JSON/HTTP2 requests over HTTP.
+  - port: 80
+    targetPort: 9000
+    protocol: TCP
+    name: http2
+  selector:
+    app: esp-grpc-bookstore
+  type: LoadBalancer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: esp-grpc-bookstore
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: esp-grpc-bookstore
+    spec:
+      # [START secret-1]
+      volumes:
+        - name: service-account-creds
+          secret:
+            secretName: service-account-creds
+      # [END secret-1]
+      # [START service]
+      containers:
+        - name: esp
+          image: gcr.io/endpoints-release/endpoints-runtime:2
+          args: [
+            "--listener_port=9000",
+            "--service=SERVICE_NAME",
+            "--rollout_strategy=managed",
+            "--backend=grpc://127.0.0.1:8000",
+            "--service_account_key=/etc/esp/creds/service-account-creds.json"
+          ]
+      # [END service]
+        ports:
+          - containerPort: 9000
+          # [START secret-2]
+          volumeMounts:
+            - mountPath: /etc/esp/creds
+              name: service-account-creds
+              readOnly: true
+          # [END secret-2]
+      - name: bookstore
+        image: gcr.io/endpointsv2/python-grpc-bookstore-server:1
+        ports:
+          - containerPort: 8000


### PR DESCRIPTION
Cloud Endpoint launch ESPv2 to replace ESPv1.  The start up flags are changed for ESPv2
There are some start-up doc using these yaml files.  The doc are been updated. 
A new version of yaml files are added for ESPv2 doc

cl/321414807 is for the doc update

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Enviroment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Enviroment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
