### PR TITLE
fix: increase batch translation timeout to 300

### DIFF
--- a/translate/cloud-client/translate_v3_batch_translate_text_test.py
+++ b/translate/cloud-client/translate_v3_batch_translate_text_test.py
@@ -42,7 +42,7 @@ def test_batch_translate_text(capsys, bucket):
         "gs://cloud-samples-data/translation/text.txt",
         "gs://{}/translation/BATCH_TRANSLATION_OUTPUT/".format(bucket.name),
         PROJECT_ID,
-        timeout=240
+        timeout=300
     )
     out, _ = capsys.readouterr()
     assert "Total Characters" in out

--- a/translate/cloud-client/translate_v3_batch_translate_text_with_glossary_test.py
+++ b/translate/cloud-client/translate_v3_batch_translate_text_with_glossary_test.py
@@ -73,7 +73,7 @@ def test_batch_translate_text_with_glossary(capsys, bucket, glossary):
         "gs://{}/translation/BATCH_TRANSLATION_OUTPUT/".format(bucket.name),
         PROJECT_ID,
         glossary,
-        240
+        300
     )
 
     out, _ = capsys.readouterr()


### PR DESCRIPTION
This PR increases the timeout for the `translate_v3_batch_translate_text_test` from 240 to 300.

Fixes #4221
Fixes #4239
