### PR TITLE
Fix firebase source URLs

### DIFF
--- a/appengine/standard/firebase/firenotes/frontend/index.html
+++ b/appengine/standard/firebase/firenotes/frontend/index.html
@@ -9,8 +9,8 @@ Licensed under the Apache License, Version 2.0 (the "License");
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
   <script src="https://www.gstatic.com/firebasejs/5.6.0/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/5.6.0/firebase-auth.js"></script>
-  <script src="https://cdn.firebase.com/libs/firebaseui/3.4.1/firebaseui.js"></script>
-  <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/3.4.1/firebaseui.css">
+  <script src="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.js"></script>
+  <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.css">
   <link rel="stylesheet" type="text/css" href="style.css">
   <script src="/main.js"></script>
   <title>Firenotes</title>

--- a/appengine/standard_python3/building-an-app/building-an-app-4/templates/index.html
+++ b/appengine/standard_python3/building-an-app/building-an-app-4/templates/index.html
@@ -18,8 +18,8 @@
     }
   </script>
   <!-- [START gae_python38_auth_include_firebaseui] -->
-  <script src="https://cdn.firebase.com/libs/firebaseui/2.6.2/firebaseui.js"></script>
-  <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/2.6.2/firebaseui.css">
+  <script src="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.js"></script>
+  <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.css">
   <!-- [END gae_python38_auth_include_firebaseui] -->
   <script src="{{ url_for('static', filename='script.js') }}"></script>
   <link type="text/css" rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">

--- a/appengine/standard_python37/building-an-app/building-an-app-3/templates/index.html
+++ b/appengine/standard_python37/building-an-app/building-an-app-3/templates/index.html
@@ -4,8 +4,8 @@
   <title>Datastore and Firebase Auth Example</title>
 
    <!-- [START gae_python37_auth_include_firebaseui] -->
-   <script src="https://cdn.firebase.com/libs/firebaseui/4.5.0/firebaseui.js"></script>
-   <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/4.5.0/firebaseui.css">
+   <script src="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.js"></script>
+   <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.css">
    <!-- [END gae_python37_auth_include_firebaseui] -->
 	
   <script src="{{ url_for('static', filename='script.js') }}"></script>

--- a/appengine/standard_python37/building-an-app/building-an-app-4/templates/index.html
+++ b/appengine/standard_python37/building-an-app/building-an-app-4/templates/index.html
@@ -4,8 +4,8 @@
   <title>Datastore and Firebase Auth Example</title>
 
    <!-- [START gae_python37_auth_include_firebaseui] -->
-   <script src="https://cdn.firebase.com/libs/firebaseui/4.5.0/firebaseui.js"></script>
-   <link type="text/css" rel="stylesheet" href="https://cdn.firebase.com/libs/firebaseui/4.5.0/firebaseui.css">
+   <script src="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.js"></script>
+   <link type="text/css" rel="stylesheet" href="https://www.gstatic.com/firebasejs/ui/4.5.0/firebase-ui-auth.css">
    <!-- [END gae_python37_auth_include_firebaseui] -->
 
   <script src="{{ url_for('static', filename='script.js') }}"></script>


### PR DESCRIPTION
## Description

Fixes #4421

Script and stylesheet references pointed to no longer used URLs for Firebase.

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
