### PR TITLE
Fix the call to validate_iap (#4260)

### DIFF
--- a/iap/example_gce_backend.py
+++ b/iap/example_gce_backend.py
@@ -29,9 +29,10 @@ def root():
     jwt = flask.request.headers.get('x-goog-iap-jwt-assertion')
     if jwt is None:
         return 'Unauthorized request.'
+    expected_audience = '/projects/{}/global/backendServices/{}'.format(CLOUD_PROJECT_ID, BACKEND_SERVICE_ID)
     user_id, user_email, error_str = (
         validate_jwt.validate_iap_jwt(
-            jwt, CLOUD_PROJECT_ID, BACKEND_SERVICE_ID))
+            jwt, expected_audience))
     if error_str:
         return 'Error: {}'.format(error_str)
     else:


### PR DESCRIPTION
## Description

Fixes #4260

The method signature for validate_iap changed with 41c173 but the
call to validate_iap from example_gce_backend.py was not changed