### PR TITLE
Update the CreateBook to be transcoding example

### DIFF
--- a/endpoints/bookstore-grpc/http_bookstore.proto
+++ b/endpoints/bookstore-grpc/http_bookstore.proto
@@ -70,7 +70,7 @@ service Bookstore {
     //   curl -d '{"author":"foo","title":"bar"}' http://DOMAIN_NAME/v1/shelves/1/books
     option (google.api.http) = {
       post: "/v1/shelves/{shelf}/books"
-      body: "book"
+      body: "*"
     };
   }
   // Returns a specific book.


### PR DESCRIPTION
The examples under Cloud Endpoints [transcoding section](https://cloud.google.com/endpoints/docs/grpc/transcoding#adding_transcoding_mappings) are based on this file. Update the CreateBook HttpRule for '*' body. The transcoding rule after this change is same as before.

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
