### PR TITLE
chore(functions/firebase): add guard against infinite loops

### DIFF
--- a/functions/firebase/main.py
+++ b/functions/firebase/main.py
@@ -106,7 +106,7 @@ def make_upper_case(data, context):
         })
     else:
         # Value is already upper-case
-        # Don't perform a(nother) write to avoid infinite loops
+        # Don't perform a second write (which can trigger an infinite loop)
         print('Value is already upper-case.')
 # [END functions_firebase_reactive]
 

--- a/functions/firebase/main.py
+++ b/functions/firebase/main.py
@@ -98,11 +98,16 @@ def make_upper_case(data, context):
 
     cur_value = data["value"]["fields"]["original"]["stringValue"]
     new_value = cur_value.upper()
-    print(f'Replacing value: {cur_value} --> {new_value}')
 
-    affected_doc.set({
-        u'original': new_value
-    })
+    if cur_value != new_value:
+        print(f'Replacing value: {cur_value} --> {new_value}')
+        affected_doc.set({
+            u'original': new_value
+        })
+    else:
+        # Value is already upper-case
+        # Don't perform a(nother) write to avoid infinite loops
+        print('Value is already upper-case.')
 # [END functions_firebase_reactive]
 
 

--- a/functions/firebase/main_test.py
+++ b/functions/firebase/main_test.py
@@ -119,6 +119,41 @@ def test_make_upper_case(firestore_mock, capsys):
     firestore_mock.set.assert_called_with({'original': 'FOOBAR'})
 
 
+@patch('main.client')
+def test_make_upper_case_ignores_already_uppercased(firestore_mock, capsys):
+
+    firestore_mock.collection = MagicMock(return_value=firestore_mock)
+    firestore_mock.document = MagicMock(return_value=firestore_mock)
+    firestore_mock.set = MagicMock(return_value=firestore_mock)
+
+    user_id = str(uuid.uuid4())
+    date_string = datetime.now().isoformat()
+    email_string = '%s@%s.com' % (uuid.uuid4(), uuid.uuid4())
+
+    data = {
+        'uid': user_id,
+        'metadata': {'createdAt': date_string},
+        'email': email_string,
+        'value': {
+            'fields': {
+                'original': {
+                    'stringValue': 'FOOBAR'
+                }
+            }
+        }
+    }
+
+    context = UserDict()
+    context.resource = '/documents/some_collection/path/some/path'
+
+    main.make_upper_case(data, context)
+
+    out, _ = capsys.readouterr()
+
+    assert 'Value is already upper-case.' in out
+    firestore_mock.set.assert_not_called()
+
+
 def test_analytics(capsys):
     timestamp = int(datetime.utcnow().timestamp())
 


### PR DESCRIPTION
N.B: this doesn't actually fail on Cloud Functions (since Firebase doesn't emit `update` events for documents that don't change) - but it _does_ rely on undocumented (and thus, not necessarily guaranteed!) behavior.