### PR TITLE
dataflow/run_template: slightly increase max retry time in test

### DIFF
--- a/dataflow/run_template/main_test.py
+++ b/dataflow/run_template/main_test.py
@@ -34,7 +34,7 @@ from werkzeug.urls import url_encode
 import main
 
 
-RETRY_MAX_TIME = 5 * 60 # 5 minutes in seconds
+RETRY_MAX_TIME = 5 * 60  # 5 minutes in seconds
 
 PROJECT = os.environ['GOOGLE_CLOUD_PROJECT']
 BUCKET = os.environ['CLOUD_STORAGE_BUCKET']

--- a/dataflow/run_template/main_test.py
+++ b/dataflow/run_template/main_test.py
@@ -34,6 +34,8 @@ from werkzeug.urls import url_encode
 import main
 
 
+RETRY_MAX_TIME = 5 * 60 # 5 minutes in seconds
+
 PROJECT = os.environ['GOOGLE_CLOUD_PROJECT']
 BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
 
@@ -83,7 +85,7 @@ def get_job_id_from_name(job_name):
 
 
 # We retry the cancel operation a few times until the job is in a state where it can be cancelled
-@backoff.on_exception(backoff.expo, HttpError, max_time=240)
+@backoff.on_exception(backoff.expo, HttpError, max_time=RETRY_MAX_TIME)
 def dataflow_jobs_cancel(job_name):
     # to cancel a dataflow job, we need its ID, not its name
     job_id = get_job_id_from_name(job_name)


### PR DESCRIPTION
## Description

Fixes #4686

It should be an uncommon occurrence that a job hangs in queue for more than 4 minutes (and therefore unable to cancel), probably because many tests were triggered at a similar time.
I'm slightly increasing the max retry time to 5 minutes to leave more room for jobs to be cancelled, but most of the time it will be cancelled much quicker.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
