### PR TITLE
chore: also upload the Docker image in py36 and py37 builds

### DIFF
--- a/.kokoro/python3.6/periodic.cfg
+++ b/.kokoro/python3.6/periodic.cfg
@@ -24,3 +24,9 @@ env_vars: {
     key: "REPORT_TO_BUILD_COP_BOT"
     value: "true"
 }
+
+# Tell Trampoline to upload the Docker image after successfull build.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}

--- a/.kokoro/python3.7/periodic.cfg
+++ b/.kokoro/python3.7/periodic.cfg
@@ -31,3 +31,9 @@ env_vars: {
     key: "INJECT_REGION_TAGS"
     value: "true"
 }
+
+# Tell Trampoline to upload the Docker image after successfull build.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "true"
+}


### PR DESCRIPTION
Now we only upload the Docker image after a successful py38 periodic builds. Unfortunately, recently we have been having red py38 periodic builds, our Docker image is becoming old thus all our presubmit builds needs to build the Docker image from scratch.

By allowing other periodic builds to upload the Docker image, we'll have a higher chance of the Docker image being updated.