### PR TITLE
test(firestore): add asserts into samples tests

### DIFF
--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -29,15 +29,15 @@ def quickstart_new_instance():
     return db
 
 
-def quickstart_add_data_one():
+def quickstart_add_data_one(collection_id, document_id, data):
     db = firestore.Client()
     # [START quickstart_add_data_one]
-    doc_ref = db.collection(u'users').document(u'alovelace')
-    doc_ref.set({
-        u'first': u'Ada',
-        u'last': u'Lovelace',
-        u'born': 1815
-    })
+    # collection_id = "users"
+    # document_id = "alovelace"
+    # data = {"first": "Ada", "last": "Lovelace", "born": 1815}
+
+    doc_ref = db.collection(collection_id).document(document_id)
+    doc_ref.set(data)
     # [END quickstart_add_data_one]
 
 

--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -44,7 +44,8 @@ def db():
 
 
 def test_quickstart_new_instance():
-    snippets.quickstart_new_instance()
+    client = snippets.quickstart_new_instance()
+    assert isinstance(client, firestore.Client)
 
 
 def test_quickstart_add_data_two():
@@ -55,8 +56,15 @@ def test_quickstart_get_collection():
     snippets.quickstart_get_collection()
 
 
-def test_quickstart_add_data_one():
-    snippets.quickstart_add_data_one()
+def test_quickstart_add_data_one(db):
+    collection_id = "users"
+    document_id = "alovelace"
+    data = {"first": "Ada", "last": "Lovelace", "born": 1815}
+
+    snippets.quickstart_add_data_one(collection_id, document_id, data)
+
+    doc_ref = db.collection(collection_id).document(document_id)
+    assert doc_ref.get().to_dict() == data
 
 
 def test_add_from_dict():


### PR DESCRIPTION
Towards #4362

Opening a preliminary PR to check if we're all okay with such a samples/tests style. I'm mimicking the [Storage fashion](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/2c15a82cc7a245513ccfb84419ba19e8dc165a1e/storage/cloud-client/storage_add_bucket_default_owner.py#L23-L33), where they send all the ids and data with sample function args. Within sample itself they write comments to describe, which values variables has.

If there are no counter-arguments on this, I'll do the same for all the other tests.