### PR TITLE
Replace GCLOUD with GOOGLE_CLOUD in error message

### DIFF
--- a/iot/api-client/mqtt_example/gateway_demo.py
+++ b/iot/api-client/mqtt_example/gateway_demo.py
@@ -40,7 +40,7 @@ rsa_private_path = 'resources/rsa_private.pem'
 if ('GOOGLE_CLOUD_PROJECT' not in os.environ or
         'GOOGLE_APPLICATION_CREDENTIALS' not in os.environ):
     print(
-      'You must set GCLOUD_PROJECT and GOOGLE_APPLICATION_CREDENTIALS')
+      'You must set GOOGLE_CLOUD_PROJECT and GOOGLE_APPLICATION_CREDENTIALS')
     quit()
 
 project_id = os.environ['GOOGLE_CLOUD_PROJECT']


### PR DESCRIPTION
GCLOUD_PROJECT was changed to GOOGLE_CLOUD_PROJECT but an error message still mentions the old variable.

Please note that the documentation still mentions GCLOUD_PROJECT:
https://cloud.google.com/iot/docs/how-tos/gateways/mqtt-demo

## Description

Fixes #<ISSUE-NUMBER>

Very minor commit. Just wasted some time hunting down environment variables so I wanted to send you a merge request.

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
