### PR TITLE
fix(samples): v1 and v1beta1 region tags collide

### DIFF
--- a/healthcare/api-client/v1beta1/fhir/fhir_resources.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_resources.py
@@ -45,8 +45,6 @@ def get_session(service_account_json):
     return session
 
 
-
-
 def create_patient(
     service_account_json, base_url, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -77,8 +75,6 @@ def create_patient(
     print("Created Patient resource with ID {}".format(resource["id"]))
 
     return response
-
-
 
 
 def create_encounter(
@@ -129,8 +125,6 @@ def create_encounter(
     return response
 
 
-
-
 def create_observation(
     service_account_json,
     base_url,
@@ -176,8 +170,6 @@ def create_observation(
     return response
 
 
-
-
 def delete_resource(
     service_account_json,
     base_url,
@@ -207,8 +199,6 @@ def delete_resource(
     print("Deleted {} resource with ID {}.".format(resource_type, resource_id))
 
     return response
-
-
 
 
 # [START healthcare_conditional_update_resource]

--- a/healthcare/api-client/v1beta1/fhir/fhir_resources.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_resources.py
@@ -23,7 +23,7 @@ from google.oauth2 import service_account
 _BASE_URL = "https://healthcare.googleapis.com/v1beta1"
 
 
-# [START healthcare_get_session]
+# [START healthcare_v1beta1_get_session]
 def get_session(service_account_json):
     """
     Returns an authorized Requests Session class using the service account
@@ -46,10 +46,10 @@ def get_session(service_account_json):
     return session
 
 
-# [END healthcare_get_session]
+# [END healthcare_v1beta1_get_session]
 
 
-# [START healthcare_create_resource]
+# [START healthcare_v1beta1_create_resource]
 def create_patient(
     service_account_json, base_url, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -82,10 +82,10 @@ def create_patient(
     return response
 
 
-# [END healthcare_create_resource]
+# [END healthcare_v1beta1_create_resource]
 
 
-# [START healthcare_create_encounter]
+# [START healthcare_v1beta1_create_encounter]
 def create_encounter(
     service_account_json,
     base_url,
@@ -134,10 +134,10 @@ def create_encounter(
     return response
 
 
-# [END healthcare_create_encounter]
+# [END healthcare_v1beta1_create_encounter]
 
 
-# [START healthcare_create_observation]
+# [START healthcare_v1beta1_create_observation]
 def create_observation(
     service_account_json,
     base_url,
@@ -183,10 +183,10 @@ def create_observation(
     return response
 
 
-# [END healthcare_create_observation]
+# [END healthcare_v1beta1_create_observation]
 
 
-# [START healthcare_delete_resource]
+# [START healthcare_v1beta1_delete_resource]
 def delete_resource(
     service_account_json,
     base_url,
@@ -218,7 +218,7 @@ def delete_resource(
     return response
 
 
-# [END healthcare_delete_resource]
+# [END healthcare_v1beta1_delete_resource]
 
 
 # [START healthcare_conditional_update_resource]

--- a/healthcare/api-client/v1beta1/fhir/fhir_resources.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_resources.py
@@ -23,7 +23,6 @@ from google.oauth2 import service_account
 _BASE_URL = "https://healthcare.googleapis.com/v1beta1"
 
 
-# [START healthcare_v1beta1_get_session]
 def get_session(service_account_json):
     """
     Returns an authorized Requests Session class using the service account
@@ -46,10 +45,8 @@ def get_session(service_account_json):
     return session
 
 
-# [END healthcare_v1beta1_get_session]
 
 
-# [START healthcare_v1beta1_create_resource]
 def create_patient(
     service_account_json, base_url, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -82,10 +79,8 @@ def create_patient(
     return response
 
 
-# [END healthcare_v1beta1_create_resource]
 
 
-# [START healthcare_v1beta1_create_encounter]
 def create_encounter(
     service_account_json,
     base_url,
@@ -134,10 +129,8 @@ def create_encounter(
     return response
 
 
-# [END healthcare_v1beta1_create_encounter]
 
 
-# [START healthcare_v1beta1_create_observation]
 def create_observation(
     service_account_json,
     base_url,
@@ -183,10 +176,8 @@ def create_observation(
     return response
 
 
-# [END healthcare_v1beta1_create_observation]
 
 
-# [START healthcare_v1beta1_delete_resource]
 def delete_resource(
     service_account_json,
     base_url,
@@ -218,7 +209,6 @@ def delete_resource(
     return response
 
 
-# [END healthcare_v1beta1_delete_resource]
 
 
 # [START healthcare_conditional_update_resource]

--- a/healthcare/api-client/v1beta1/fhir/fhir_stores.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_stores.py
@@ -43,8 +43,6 @@ def get_client(service_account_json):
     )
 
 
-
-
 def create_dataset(service_account_json, project_id, cloud_region, dataset_id):
     """Creates a dataset."""
     client = get_client(service_account_json)
@@ -68,8 +66,6 @@ def create_dataset(service_account_json, project_id, cloud_region, dataset_id):
         return ""
 
 
-
-
 def delete_dataset(service_account_json, project_id, cloud_region, dataset_id):
     """Deletes a dataset."""
     client = get_client(service_account_json)
@@ -86,8 +82,6 @@ def delete_dataset(service_account_json, project_id, cloud_region, dataset_id):
     except HttpError as e:
         print("Error, dataset not deleted: {}".format(e))
         return ""
-
-
 
 
 def create_fhir_store(
@@ -114,8 +108,6 @@ def create_fhir_store(
     return response
 
 
-
-
 def delete_fhir_store(
     service_account_json, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -137,8 +129,6 @@ def delete_fhir_store(
     response = request.execute()
     print("Deleted FHIR store: {}".format(fhir_store_id))
     return response
-
-
 
 
 def parse_command_line_args():

--- a/healthcare/api-client/v1beta1/fhir/fhir_stores.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_stores.py
@@ -20,7 +20,7 @@ from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 
 
-# [START healthcare_get_client]
+# [START healthcare_v1beta1_get_client]
 def get_client(service_account_json):
     """Returns an authorized API client by discovering the Healthcare API and
     creating a service object using the service account credentials JSON."""
@@ -44,10 +44,10 @@ def get_client(service_account_json):
     )
 
 
-# [END healthcare_get_client]
+# [END healthcare_v1beta1_get_client]
 
 
-# [START healthcare_create_dataset]
+# [START healthcare_v1beta1_create_dataset]
 def create_dataset(service_account_json, project_id, cloud_region, dataset_id):
     """Creates a dataset."""
     client = get_client(service_account_json)
@@ -71,10 +71,10 @@ def create_dataset(service_account_json, project_id, cloud_region, dataset_id):
         return ""
 
 
-# [END healthcare_create_dataset]
+# [END healthcare_v1beta1_create_dataset]
 
 
-# [START healthcare_delete_dataset]
+# [START healthcare_v1beta1_delete_dataset]
 def delete_dataset(service_account_json, project_id, cloud_region, dataset_id):
     """Deletes a dataset."""
     client = get_client(service_account_json)
@@ -93,10 +93,10 @@ def delete_dataset(service_account_json, project_id, cloud_region, dataset_id):
         return ""
 
 
-# [END healthcare_delete_dataset]
+# [END healthcare_v1beta1_delete_dataset]
 
 
-# [START healthcare_create_fhir_store]
+# [START healthcare_v1beta1_create_fhir_store]
 def create_fhir_store(
     service_account_json, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -121,10 +121,10 @@ def create_fhir_store(
     return response
 
 
-# [END healthcare_create_fhir_store]
+# [END healthcare_v1beta1_create_fhir_store]
 
 
-# [START healthcare_delete_fhir_store]
+# [START healthcare_v1beta1_delete_fhir_store]
 def delete_fhir_store(
     service_account_json, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -148,7 +148,7 @@ def delete_fhir_store(
     return response
 
 
-# [END healthcare_delete_fhir_store]
+# [END healthcare_v1beta1_delete_fhir_store]
 
 
 def parse_command_line_args():

--- a/healthcare/api-client/v1beta1/fhir/fhir_stores.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_stores.py
@@ -20,7 +20,6 @@ from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 
 
-# [START healthcare_v1beta1_get_client]
 def get_client(service_account_json):
     """Returns an authorized API client by discovering the Healthcare API and
     creating a service object using the service account credentials JSON."""
@@ -44,10 +43,8 @@ def get_client(service_account_json):
     )
 
 
-# [END healthcare_v1beta1_get_client]
 
 
-# [START healthcare_v1beta1_create_dataset]
 def create_dataset(service_account_json, project_id, cloud_region, dataset_id):
     """Creates a dataset."""
     client = get_client(service_account_json)
@@ -71,10 +68,8 @@ def create_dataset(service_account_json, project_id, cloud_region, dataset_id):
         return ""
 
 
-# [END healthcare_v1beta1_create_dataset]
 
 
-# [START healthcare_v1beta1_delete_dataset]
 def delete_dataset(service_account_json, project_id, cloud_region, dataset_id):
     """Deletes a dataset."""
     client = get_client(service_account_json)
@@ -93,10 +88,8 @@ def delete_dataset(service_account_json, project_id, cloud_region, dataset_id):
         return ""
 
 
-# [END healthcare_v1beta1_delete_dataset]
 
 
-# [START healthcare_v1beta1_create_fhir_store]
 def create_fhir_store(
     service_account_json, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -121,10 +114,8 @@ def create_fhir_store(
     return response
 
 
-# [END healthcare_v1beta1_create_fhir_store]
 
 
-# [START healthcare_v1beta1_delete_fhir_store]
 def delete_fhir_store(
     service_account_json, project_id, cloud_region, dataset_id, fhir_store_id
 ):
@@ -148,7 +139,6 @@ def delete_fhir_store(
     return response
 
 
-# [END healthcare_v1beta1_delete_fhir_store]
 
 
 def parse_command_line_args():


### PR DESCRIPTION
## Description

The `v1` healthcare region tags collide with the `v1beta1` region tags.

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
