### PR TITLE
Make predict test more lenient

### DIFF
--- a/ml_engine/online_prediction/predict_test.py
+++ b/ml_engine/online_prediction/predict_test.py
@@ -22,10 +22,13 @@ import predict
 MODEL = 'census'
 JSON_VERSION = 'v2json'
 PROJECT = 'python-docs-samples-tests'
+CONF_KEY = u'confidence'
+PRED_KEY = u'predictions'
 EXPECTED_OUTPUT = {
-    u'confidence': 0.7760370969772339,
-    u'predictions': u' <=50K'
+    CONF_KEY: 0.7760370969772339,
+    PRED_KEY: u' <=50K'
 }
+CONFIDENCE_EPSILON = 1e-4
 
 # Raise the socket timeout. The requests involved in the sample can take
 # a long time to complete.
@@ -40,7 +43,14 @@ with open('resources/census_test_data.json') as f:
 def test_predict_json():
     result = predict.predict_json(
         PROJECT, MODEL, [JSON, JSON], version=JSON_VERSION)
-    assert [EXPECTED_OUTPUT, EXPECTED_OUTPUT] == result
+    # Result contains two identical predictions
+    assert len(result) == 2 and result[0] == result[1]
+    # Each prediction has `confidence` and `predictions`
+    assert result[0].keys() == EXPECTED_OUTPUT.keys()
+    # Prediction matches
+    assert result[0][PRED_KEY] == EXPECTED_OUTPUT[PRED_KEY]
+    # Confidence within epsilon
+    assert abs(result[0][CONF_KEY] - EXPECTED_OUTPUT[CONF_KEY]) < CONFIDENCE_EPSILON
 
 
 @pytest.mark.flaky


### PR DESCRIPTION
## Description

Fixes #4915

I am pretty sure this test output should be deterministic, so I was a bit surprised by this. However, the issue is some floating point error, so I updated the text to check that the `confidence` is close rather than exactly identical.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [N/A] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [N/A] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [N/A] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [N/A] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
