### PR TITLE
Add patch call

### DIFF
--- a/storage/cloud-client/storage_set_metadata.py
+++ b/storage/cloud-client/storage_set_metadata.py
@@ -30,6 +30,7 @@ def set_blob_metadata(bucket_name, blob_name):
     blob = bucket.get_blob(blob_name)
     metadata = {'color': 'Red', 'name': 'Test'}
     blob.metadata = metadata
+    blob.patch()
 
     print("The metadata for the blob {} is {}".format(blob.name, blob.metadata))
 


### PR DESCRIPTION
I believe a call to `blob.patch()` is necessary to actually save the metadata back to GCS.

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
