### PR TITLE
fix: add a comment to draw attention to using get_blob, not blob

### DIFF
--- a/storage/cloud-client/storage_download_file.py
+++ b/storage/cloud-client/storage_download_file.py
@@ -29,6 +29,11 @@ def download_blob(bucket_name, source_blob_name, destination_file_name):
     storage_client = storage.Client()
 
     bucket = storage_client.bucket(bucket_name)
+
+    # Construct a client side representation of a blob. 
+    # Note `Bucket.blob` differs from `Bucket.get_blob` as it doesn't retreive
+    # any content from Google Cloud Storage. As we don't need additional data,
+    # using `Bucket.blob` is preferred here.
     blob = bucket.blob(source_blob_name)
     blob.download_to_filename(destination_file_name)
 

--- a/storage/cloud-client/storage_download_file.py
+++ b/storage/cloud-client/storage_download_file.py
@@ -30,7 +30,7 @@ def download_blob(bucket_name, source_blob_name, destination_file_name):
 
     bucket = storage_client.bucket(bucket_name)
 
-    # Construct a client side representation of a blob. 
+    # Construct a client side representation of a blob.
     # Note `Bucket.blob` differs from `Bucket.get_blob` as it doesn't retrieve
     # any content from Google Cloud Storage. As we don't need additional data,
     # using `Bucket.blob` is preferred here.

--- a/storage/cloud-client/storage_download_file.py
+++ b/storage/cloud-client/storage_download_file.py
@@ -31,7 +31,7 @@ def download_blob(bucket_name, source_blob_name, destination_file_name):
     bucket = storage_client.bucket(bucket_name)
 
     # Construct a client side representation of a blob. 
-    # Note `Bucket.blob` differs from `Bucket.get_blob` as it doesn't retreive
+    # Note `Bucket.blob` differs from `Bucket.get_blob` as it doesn't retrieve
     # any content from Google Cloud Storage. As we don't need additional data,
     # using `Bucket.blob` is preferred here.
     blob = bucket.blob(source_blob_name)

--- a/storage/cloud-client/storage_get_metadata.py
+++ b/storage/cloud-client/storage_get_metadata.py
@@ -27,6 +27,8 @@ def blob_metadata(bucket_name, blob_name):
 
     storage_client = storage.Client()
     bucket = storage_client.bucket(bucket_name)
+
+    # Retrieve a blob, and its metadata, from Google Cloud Storage.
     blob = bucket.get_blob(blob_name)
 
     print("Blob: {}".format(blob.name))

--- a/storage/cloud-client/storage_get_metadata.py
+++ b/storage/cloud-client/storage_get_metadata.py
@@ -29,6 +29,8 @@ def blob_metadata(bucket_name, blob_name):
     bucket = storage_client.bucket(bucket_name)
 
     # Retrieve a blob, and its metadata, from Google Cloud Storage.
+    # Note that `get_blob` differs from `Bucket.blob`, which does not
+    # make an HTTP request.
     blob = bucket.get_blob(blob_name)
 
     print("Blob: {}".format(blob.name))


### PR DESCRIPTION
There have been reports that perhaps `blob` and `get_blob` and there differences can be confusing to users. This attempts to bring in some context to popular samples to help clarify.