### PR TITLE
fix(storage): Update comment, prefix should include delimiter

### DIFF
--- a/storage/cloud-client/storage_list_files_with_prefix.py
+++ b/storage/cloud-client/storage_list_files_with_prefix.py
@@ -32,12 +32,12 @@ def list_blobs_with_prefix(bucket_name, prefix, delimiter=None):
         a/1.txt
         a/b/2.txt
 
-    If you just specify prefix = 'a', you'll get back:
+    If you specify prefix ='a/', without a delimiter, you'll get back:
 
         a/1.txt
         a/b/2.txt
 
-    However, if you specify prefix='a' and delimiter='/', you'll get back:
+    However, if you specify prefix='a/' and delimiter='/', you'll get back:
 
         a/1.txt
 


### PR DESCRIPTION
The comment doesn't specify that a prefix should end in the delimiter if using a delimiter.