### PR TITLE
dataflow: simplify enabled APIs list

### DIFF
--- a/dataflow/README.md
+++ b/dataflow/README.md
@@ -33,9 +33,7 @@ The following instructions help you prepare your Google Cloud project.
 
 1. [Enable billing](https://cloud.google.com/billing/docs/how-to/modify-project).
 
-1. [Enable the APIs](https://console.cloud.google.com/flows/enableapi?apiid=dataflow,compute_component,storage_component,storage_api,logging,cloudresourcemanager.googleapis.com,iam.googleapis.com):
-   Dataflow, Compute Engine, Cloud Storage, Cloud Storage JSON,
-   Stackdriver Logging, Cloud Resource Manager, and IAM API.
+1. [Enable the Dataflow API](https://console.cloud.google.com/flows/enableapi?apiid=dataflow).
 
 1. Create a service account JSON key via the
    [*Create service account key* page](https://console.cloud.google.com/apis/credentials/serviceaccountkey),


### PR DESCRIPTION
Many of the APIs are already enabled or are automatically added by the `dataflow` API.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
