### PR TITLE
Strip spaces and newlines from secret

### DIFF
--- a/run/deployment-previews/check_status.py
+++ b/run/deployment-previews/check_status.py
@@ -128,8 +128,8 @@ def github_token(project_id: str, ghtoken_secretname: str) -> str:
         error(e, context=f"finding secret {ghtoken_secretname}")
 
     # The secret was encoded for you as part of the secret creation, so decode it now.
-    github_token = response.payload.data.decode("UTF-8")
-    return github_token.strip()
+    github_token = response.payload.data.decode("UTF-8").strip()
+    return github_token
 
 
 @click.group()

--- a/run/deployment-previews/check_status.py
+++ b/run/deployment-previews/check_status.py
@@ -129,7 +129,7 @@ def github_token(project_id: str, ghtoken_secretname: str) -> str:
 
     # The secret was encoded for you as part of the secret creation, so decode it now.
     github_token = response.payload.data.decode("UTF-8")
-    return github_token
+    return github_token.strip()
 
 
 @click.group()


### PR DESCRIPTION
## Description

Based off conversation in PR #5212, stripping the extra spaces/newlines from the secret can help prevent any issues

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
