### PR TITLE
feat(AST parser): use v2 parser architecture

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -143,8 +143,8 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   # https://github.com/docker-library/python/pull/100
     && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
-# Ensure Pip for 3.8.0
-RUN python3.8 /tmp/get-pip.py
+# Ensure Pip for python3
+RUN python3 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
 
 # Install "virtualenv", since the vast majority of users of this image

--- a/.kokoro/tests/run_single_test.sh
+++ b/.kokoro/tests/run_single_test.sh
@@ -51,7 +51,7 @@ if [[ "${INJECT_REGION_TAGS:-}" == "true" ]]; then
     export XUNIT_TMP_PATH="$(mktemp)"
 
     # We use `python3.8` because it is the version pip3 installs to.
-    export PYTHON_CMD="python3.8"
+    export PYTHON_CMD="python3"
 
     if [[ -f "$XUNIT_PATH" ]]; then
         echo "=== Injecting region tags into XUnit output ==="

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -130,14 +130,15 @@ ROOT=$(pwd)
 if [[ "${INJECT_REGION_TAGS:-}" == "true" ]]; then
     echo "=== Setting up DRIFT region tag injector ==="
     # install PyYaml (used by the DRIFT region tag parsing system)
-    echo "--- Installing PyYaml ---"
-    python3 -m pip install --user pyyaml
+    echo "--- Installing pip packages ---"
+    pip3 --version
+    pip3 install --user pyyaml frozendict recordclass
 
     # Use ${HOME} because trampoline will automatically clean up this
     # directory.
-    export REGION_TAG_PARSER_DIR="${HOME}/xunit-autolabeler-v2"
-    export POLYGLOT_PARSER_PATH="${REGION_TAG_PARSER_DIR}/cli_bootstrap.py"
-    export PYTHON_PARSER_PATH="${REGION_TAG_PARSER_DIR}/ast_parser/python_bootstrap.py"
+    export REGION_TAG_PARSER_DIR="${HOME}/region-tag-parser"
+    export POLYGLOT_PARSER_PATH="${REGION_TAG_PARSER_DIR}/xunit-autolabeler-v2/cli_bootstrap.py"
+    export PYTHON_PARSER_PATH="${REGION_TAG_PARSER_DIR}/xunit-autolabeler-v2/ast_parser/python_bootstrap.py"
 
     if [[ ! -f $POLYGLOT_PARSER_PATH ]]; then
         echo "--- Fetching injection script from HEAD (via GitHub) ---"

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -135,13 +135,16 @@ if [[ "${INJECT_REGION_TAGS:-}" == "true" ]]; then
 
     # Use ${HOME} because trampoline will automatically clean up this
     # directory.
-    export REGION_TAG_PARSER_DIR="${HOME}/region-tag-parser"
-    export PARSER_PATH="${REGION_TAG_PARSER_DIR}/wizard-py/cli.py"
+    export REGION_TAG_PARSER_DIR="${HOME}/xunit-autolabeler-v2"
+    export POLYGLOT_PARSER_PATH="${REGION_TAG_PARSER_DIR}/cli_bootstrap.py"
+    export PYTHON_PARSER_PATH="${REGION_TAG_PARSER_DIR}/ast_parser/python_bootstrap.py"
 
-    if [[ ! -f $PARSER_PATH ]]; then
+    if [[ ! -f $POLYGLOT_PARSER_PATH ]]; then
         echo "--- Fetching injection script from HEAD (via GitHub) ---"
         git clone https://github.com/GoogleCloudPlatform/repo-automation-playground "$REGION_TAG_PARSER_DIR" --single-branch
-        chmod +x $PARSER_PATH
+        
+        chmod +x $PYTHON_PARSER_PATH
+        chmod +x $POLYGLOT_PARSER_PATH
     fi
     echo "=== Region tag injector setup complete ==="
 fi

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -131,8 +131,7 @@ if [[ "${INJECT_REGION_TAGS:-}" == "true" ]]; then
     echo "=== Setting up DRIFT region tag injector ==="
     # install PyYaml (used by the DRIFT region tag parsing system)
     echo "--- Installing pip packages ---"
-    pip3 --version
-    pip3 install --user pyyaml frozendict recordclass
+    python3 -m pip install --user pyyaml frozendict recordclass
 
     # Use ${HOME} because trampoline will automatically clean up this
     # directory.
@@ -143,7 +142,7 @@ if [[ "${INJECT_REGION_TAGS:-}" == "true" ]]; then
     if [[ ! -f $POLYGLOT_PARSER_PATH ]]; then
         echo "--- Fetching injection script from HEAD (via GitHub) ---"
         git clone https://github.com/GoogleCloudPlatform/repo-automation-playground "$REGION_TAG_PARSER_DIR" --single-branch
-        
+
         chmod +x $PYTHON_PARSER_PATH
         chmod +x $POLYGLOT_PARSER_PATH
     fi


### PR DESCRIPTION
This migrates the `python-docs-samples` repo off the Python-only `v1` AST parser architecture and onto the more language-agnostic `v2` (or "polyglot parser") architecture.