### PR TITLE
feat(idp) - add IDP_KEY to test setup

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -118,6 +118,9 @@ ${HOME}/cloud_sql_proxy -instances="${SQLSERVER_INSTANCE}"=tcp:1433 &>> \
        ${HOME}/cloud_sql_proxy-sqlserver.log &
 echo -e "\Cloud SQL proxy started for SQL Server."
 
+# For run/idp example, a Firebase IDP token
+export IDP_KEY=$(gcloud secrets versions access latest --secret="python-docs-samples-idp-key" --project="${GOOGLE_CLOUD_PROJECT}")
+
 echo -e "\n******************** TESTING PROJECTS ********************"
 # Switch to 'fail at end' to allow all tests to complete before exiting.
 set +e


### PR DESCRIPTION
## Description

Helps #5256 

Tests are taking 45min each, rather than 3 minutes; this change should ensure that the new sample PR tests run 15x faster as they are only running the new sample's tests. cc @averikitsch 

