### PR TITLE
chore: sync test-env.tmpl.sh with test-env.sh

### DIFF
--- a/testing/test-env.tmpl.sh
+++ b/testing/test-env.tmpl.sh
@@ -79,10 +79,13 @@ export OBJECT_DETECTION_DATASET_ID=
 # and centralized models remove duplicate work across all languages.
 export OBJECT_DETECTION_MODEL_ID=
 
-# Transcoder API
-export GOOGLE_CLOUD_PROJECT_NUMBER=
+# Firebase IDP token for run/idp
+export IDP_KEY=
 
 # For git operations in the test driver(testing/run_tests.sh).
 # These are optional, but for avoiding flakes in Kokoro builds.
 export GITHUB_ACCESS_TOKEN=
 export GITHUB_USERNAME=
+
+# Pub/Sub Lite. For project `python-docs-samples-tests`.
+export GOOGLE_CLOUD_PROJECT_NUMBER

--- a/testing/test-env.tmpl.sh
+++ b/testing/test-env.tmpl.sh
@@ -88,4 +88,4 @@ export GITHUB_ACCESS_TOKEN=
 export GITHUB_USERNAME=
 
 # Pub/Sub Lite. For project `python-docs-samples-tests`.
-export GOOGLE_CLOUD_PROJECT_NUMBER
+export GOOGLE_CLOUD_PROJECT_NUMBER=


### PR DESCRIPTION
Add `IDP_KEY` and move `GOOGLE_CLOUD_PROJECT_NUMBER` to match the current version of `test-env.sh` in [secret manager](https://console.cloud.google.com/security/secret-manager/secret/python-docs-samples-test-env/versions?project=cloud-devrel-kokoro-resources).

Follow up to discussion in #5256