### PR TITLE
fix(django): correct default secret name

### DIFF
--- a/run/django/cloudmigrate.yaml
+++ b/run/django/cloudmigrate.yaml
@@ -61,7 +61,7 @@ substitutions:
   _INSTANCE_NAME: django-instance
   _REGION: us-central1
   _SERVICE_NAME: polls-service
-  _SECRET_SETTINGS_NAME: django-settings
+  _SECRET_SETTINGS_NAME: django_settings
 
 images:
   - "gcr.io/${PROJECT_ID}/${_SERVICE_NAME}"


### PR DESCRIPTION
## Description

Correct default settings name for django settings (underscore, not hyphen)

b/178553088

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved.