### PR TITLE
fix(run): Clarify the source of GOOGLE_CLOUD_PROJECT var

### DIFF
--- a/run/logging-manual/main.py
+++ b/run/logging-manual/main.py
@@ -23,6 +23,9 @@ app = Flask(__name__)
 
 @app.route("/", methods=["GET"])
 def index():
+    # This is set as a custom environment variable on deployment.
+    # To automatically detect the current project, use the metadata server.
+    # https://cloud.google.com/run/docs/reference/container-contract#metadata-server
     PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
 
     # [START cloudrun_manual_logging]


### PR DESCRIPTION
Responding to developer feedback that it is confusing to come from the docs to the main.py and see `GOOGLE_CLOUD_PROJECT` environment variable. This adds the missing context. For more discussion of this feedback, see b/178792002 (internal).

This applies to both Cloud Run and Cloud Functions, let's see what the bot thinks about my tagging both on the PR.