### PR TITLE
fix: use temporary ubuntu image from gcr.io

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -15,7 +15,7 @@
 # Sometimes renovate tries to update it to 16.10. I don't think it's
 # worthwhile because 16.04 is an LTS release. Maybe we should think
 # about upgrading to 18.04 (the next LTS) instead.
-FROM ubuntu:18.04
+FROM gcr.io/cloud-devrel-kokoro-resources/ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Workaround for the docker authentication issue.