### PR TITLE
fix(datastore): longer LRO timeout

### DIFF
--- a/datastore/cloud-client/admin.py
+++ b/datastore/cloud-client/admin.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2016 Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/datastore/cloud-client/admin.py
+++ b/datastore/cloud-client/admin.py
@@ -39,7 +39,7 @@ def export_entities(project_id, output_url_prefix):
     op = client.export_entities(
         {"project_id": project_id, "output_url_prefix": output_url_prefix}
     )
-    response = op.result(timeout=200)
+    response = op.result(timeout=300)
 
     print("Entities were exported\n")
     return response
@@ -58,7 +58,7 @@ def import_entities(project_id, input_url):
     op = client.import_entities(
         {"project_id": project_id, "input_url": input_url}
     )
-    response = op.result(timeout=200)
+    response = op.result(timeout=300)
 
     print("Entities were imported\n")
     return response

--- a/datastore/cloud-client/admin_test.py
+++ b/datastore/cloud-client/admin_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2016 Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/datastore/cloud-client/admin_test.py
+++ b/datastore/cloud-client/admin_test.py
@@ -40,7 +40,7 @@ class TestDatastoreAdminSnippets:
     def test_list_index(self):
         assert admin.list_indexes(PROJECT)
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_tries=3, max_time=540000)
+    @backoff.on_exception(backoff.expo, AssertionError, max_tries=3)
     def test_export_import_entities(self):
         response = admin.export_entities(PROJECT, "gs://" + BUCKET)
         assert response

--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2016 Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/datastore/cloud-client/snippets_test.py
+++ b/datastore/cloud-client/snippets_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google, Inc.
+# Copyright 2015 Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/datastore/cloud-client/snippets_test.py
+++ b/datastore/cloud-client/snippets_test.py
@@ -106,19 +106,19 @@ class TestDatastoreSnippets:
     def test_batch_delete(self, client):
         snippets.batch_delete(client)
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_unindexed_property_query(self, client):
         tasks = snippets.unindexed_property_query(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_basic_query(self, client):
         tasks = snippets.basic_query(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_projection_query(self, client):
         priorities, percents = snippets.projection_query(client)
         client.entities_to_delete.extend(client.query(kind="Task").fetch())
@@ -137,7 +137,7 @@ class TestDatastoreSnippets:
         for n in range(6):
             client.entities_to_delete.append(snippets.insert(client))
 
-        @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+        @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
         def run_sample():
             results = snippets.cursor_paging(client)
             page_one, cursor_one, page_two, cursor_two = results
@@ -148,49 +148,49 @@ class TestDatastoreSnippets:
 
         run_sample()
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_property_filter(self, client):
         tasks = snippets.property_filter(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_composite_filter(self, client):
         tasks = snippets.composite_filter(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_key_filter(self, client):
         tasks = snippets.key_filter(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_ascending_sort(self, client):
         tasks = snippets.ascending_sort(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_descending_sort(self, client):
         tasks = snippets.descending_sort(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_multi_sort(self, client):
         tasks = snippets.multi_sort(client)
         client.entities_to_delete.extend(tasks)
         assert tasks
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_keys_only_query(self, client):
         keys = snippets.keys_only_query(client)
         client.entities_to_delete.extend(client.query(kind="Task").fetch())
         assert keys
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_distinct_on_query(self, client):
         tasks = snippets.distinct_on_query(client)
         client.entities_to_delete.extend(tasks)
@@ -246,33 +246,33 @@ class TestDatastoreSnippets:
         assert task_list
         assert tasks_in_list
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_namespace_run_query(self, client):
         all_namespaces, filtered_namespaces = snippets.namespace_run_query(client)
         assert all_namespaces
         assert filtered_namespaces
         assert "google" in filtered_namespaces
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_kind_run_query(self, client):
         kinds = snippets.kind_run_query(client)
         client.entities_to_delete.extend(client.query(kind="Task").fetch())
         assert kinds
         assert "Task" in kinds
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_property_run_query(self, client):
         kinds = snippets.property_run_query(client)
         client.entities_to_delete.extend(client.query(kind="Task").fetch())
         assert kinds
         assert "Task" in kinds
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_property_by_kind_run_query(self, client):
         reprs = snippets.property_by_kind_run_query(client)
         client.entities_to_delete.extend(client.query(kind="Task").fetch())
         assert reprs
 
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
     def test_index_merge_queries(self, client):
         snippets.index_merge_queries(client)

--- a/datastore/cloud-client/tasks.py
+++ b/datastore/cloud-client/tasks.py
@@ -1,4 +1,4 @@
-# Copyright 2016, Google, Inc.
+# Copyright 2016 Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/datastore/cloud-client/tasks_test.py
+++ b/datastore/cloud-client/tasks_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google, Inc.
+# Copyright 2015 Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/datastore/cloud-client/tasks_test.py
+++ b/datastore/cloud-client/tasks_test.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 import os
+import uuid
 
 import backoff
 from google.cloud import datastore
@@ -25,14 +26,18 @@ PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
 @pytest.yield_fixture
 def client():
     # We use namespace for isolating builds.
-    namespace = os.environ.get("RUN_TESTS_SESSION", "default")
+    namespace = uuid.uuid4().hex
     client = datastore.Client(PROJECT, namespace=namespace)
 
-    # Delete anything created during the previous tests.
+    # Delete anything created during the tests in the past.
     with client.batch():
         client.delete_multi([x.key for x in client.query(kind="Task").fetch()])
 
     yield client
+
+    # Delete anything created during the tests.
+    with client.batch():
+        client.delete_multi([x.key for x in client.query(kind="Task").fetch()])
 
 
 @pytest.mark.flaky

--- a/datastore/cloud-client/tasks_test.py
+++ b/datastore/cloud-client/tasks_test.py
@@ -35,7 +35,6 @@ def client():
     yield client
 
 
-
 @pytest.mark.flaky
 def test_create_client():
     tasks.create_client(PROJECT)

--- a/datastore/cloud-client/tasks_test.py
+++ b/datastore/cloud-client/tasks_test.py
@@ -24,13 +24,16 @@ PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
 
 @pytest.yield_fixture
 def client():
-    client = datastore.Client(PROJECT)
+    # We use namespace for isolating builds.
+    namespace = os.environ.get("RUN_TESTS_SESSION", "default")
+    client = datastore.Client(PROJECT, namespace=namespace)
+
+    # Delete anything created during the previous tests.
+    with client.batch():
+        client.delete_multi([x.key for x in client.query(kind="Task").fetch()])
 
     yield client
 
-    # Delete anything created during the test.
-    with client.batch():
-        client.delete_multi([x.key for x in client.query(kind="Task").fetch()])
 
 
 @pytest.mark.flaky


### PR DESCRIPTION
fixes #5250

also remove unnecessarily long `max_time`.