### PR TITLE
chore(composer): readme-only changes

### DIFF
--- a/composer/blog/README.md
+++ b/composer/blog/README.md
@@ -1,3 +1,5 @@
 # Cloud Composer Blog Posts
 
-Beginning in 2021, any code samples written by Cloud Composer DevRel and featured in blog posts are found in this repo. 
+Beginning in 2021, any code samples written by Cloud Composer DevRel and featured in blog posts are found in this repo.
+
+1. [Using Cloud Build to keep Airflow Operators up-to-date in your Composer environment](https://cloud.google.com/blog/topics/developers-practitioners/using-cloud-build-keep-airflow-operators-date-your-composer-environment) - [code](/gcp-tech-blog/unit-test-dags-cloud-build) - March 2021

--- a/composer/blog/README.md
+++ b/composer/blog/README.md
@@ -2,4 +2,4 @@
 
 Beginning in 2021, any code samples written by Cloud Composer DevRel and featured in blog posts are found in this repo.
 
-1. [Using Cloud Build to keep Airflow Operators up-to-date in your Composer environment](https://cloud.google.com/blog/topics/developers-practitioners/using-cloud-build-keep-airflow-operators-date-your-composer-environment) - [code](/gcp-tech-blog/unit-test-dags-cloud-build) - March 2021
+1. [Using Cloud Build to keep Airflow Operators up-to-date in your Composer environment](https://cloud.google.com/blog/topics/developers-practitioners/using-cloud-build-keep-airflow-operators-date-your-composer-environment) - [code](/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build) - March 2021

--- a/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/README.md
+++ b/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/README.md
@@ -1,0 +1,3 @@
+# Using Cloud Build to keep Airflow Operators up-to-date in your Composer environment
+
+Code found in this directory is part of a [blog post](https://cloud.google.com/blog/topics/developers-practitioners/using-cloud-build-keep-airflow-operators-date-your-composer-environment) published in March 2021


### PR DESCRIPTION
## Description

Adds links to now published blog posts for cloud Composer. README-only changes

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
