### PR TITLE
Explicitly pin SQLAlchemy for composer samples

### DIFF
--- a/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/requirements.txt
+++ b/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/requirements.txt
@@ -1,2 +1,3 @@
 apache-airflow[gcp]==1.10.14
+SQLAlchemy==1.3.23 # must be under 1.4 until at least Airflow 2.0 (check airflow setup.py for restrictions)
 apache-airflow-backport-providers-google==2020.11.13

--- a/composer/workflows/requirements.txt
+++ b/composer/workflows/requirements.txt
@@ -1,4 +1,5 @@
 apache-airflow[gcp]==1.10.12
+SQLAlchemy==1.3.23 # must be under 1.4 until at least Airflow 2.0 (check airflow setup.py for restrictions)
 cattrs==1.0.0 #this has to be explicitly pinned to 1.0.0 until airflow 1.10.13 when a fix should be pushed
 kubernetes==12.0.1
 scipy==1.4.1; python_version > '3.0'


### PR DESCRIPTION
## Description
Unblocks #5515 and #5521

I merged a PR this morning that bumped sqlalchemy dependencies in other samples to 1.4. It seems like we're using the cached version of that dependency by the time we get to Composer samples, and Airflow does not play well with SQLalchemy 1.4, so we need to explicitly pin to the latest 1.3.* version until at least Airflow 2.0.


## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
