### PR TITLE
dataflow: allow custom Python version in Dockerfile

### DIFF
--- a/dataflow/gpu-workers/Dockerfile
+++ b/dataflow/gpu-workers/Dockerfile
@@ -39,4 +39,5 @@ RUN apt-get update \
     && pip install --no-cache-dir -r requirements.txt \
     && conda clean -y --all --force-pkgs-dirs
 
+# Set the entrypoint to Apache Beam SDK worker launcher.
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-workers/Dockerfile
+++ b/dataflow/gpu-workers/Dockerfile
@@ -12,22 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:2.4.0-gpu
+FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu20.04
+
+ARG python_version=3.8
 
 WORKDIR /root
 
-# Installing the requirements here makes the workers start faster since they
-# don't need to install the requirements at runtime.
-#   ℹ️ Make sure your requirements.txt includes `apache-beam[gcp]`.
+COPY --from=apache/beam_python3.8_sdk:2.28.0 /opt/apache/beam /opt/apache/beam
 COPY requirements.txt .
 
-# Don't install `tensorflow` since the base image already comes with it.
-RUN egrep -v '^tensorflow([=<>]|$)' requirements.txt > /tmp/requirements.txt \
-    && pip install --no-cache-dir -U pip \
-    && pip install --no-cache-dir -r /tmp/requirements.txt
+ENV PATH=$PATH:/opt/conda/bin
 
-# Copy the Apache Beam required files from the Beam Python SDK image.
-COPY --from=apache/beam_python3.6_sdk:2.28.0 /opt/apache/beam /opt/apache/beam
+RUN apt-get update \
+    && apt-get install -y wget \
+    && rm -rf /var/lib/apt/lists/* \
+    # The nvidia image doesn't come with Python pre-installed.
+    # We use Miniconda to install the Python version of our choice.
+    && wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && sh Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \
+    && rm Miniconda3-latest-Linux-x86_64.sh \
+    # Create a new Python environment and install our requirements.
+    # We don't need to update $PATH since /usr/local is already in $PATH.
+    && conda create -y -p /usr/local python=$python_version pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && conda clean -y --all --force-pkgs-dirs
 
-# Set the entrypoint to Apache Beam SDK worker launcher.
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-workers/Dockerfile
+++ b/dataflow/gpu-workers/Dockerfile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Make sure the CUDA and cuDNN versions are compatible with your TensorFlow version.
+#   https://www.tensorflow.org/install/source#gpu
 FROM nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu20.04
 
 ARG python_version=3.8

--- a/dataflow/gpu-workers/requirements.txt
+++ b/dataflow/gpu-workers/requirements.txt
@@ -1,4 +1,4 @@
 Pillow==8.1.2
-apache-beam[gcp]==2.28.0  # Make sure the version matches the apache/beam_python* image tag referenced in the Dockerfile.
+apache-beam[gcp]==2.28.0
 rasterio==1.2.1
-tensorflow==2.4.1  # Make sure this matches the Dockerfile base image TensorFlow version.
+tensorflow==2.4.1

--- a/dataflow/gpu-workers/requirements.txt
+++ b/dataflow/gpu-workers/requirements.txt
@@ -1,4 +1,4 @@
 Pillow==8.1.2
 apache-beam[gcp]==2.28.0  # Make sure the version matches the apache/beam_python* image tag referenced in the Dockerfile.
 rasterio==1.2.1
-tensorflow==2.4.0  # Make sure this matches the Dockerfile base image TensorFlow version.
+tensorflow==2.4.1  # Make sure this matches the Dockerfile base image TensorFlow version.


### PR DESCRIPTION
## Description

One of the highest friction points in the current GPU sample is that it depends on the Python version that comes pre-installed with the `tensorflow/tensorflow:2.4.0-gpu` image. They currently have Python 3.6 which will be [deprecated by the end of this year](https://endoflife.date/python).

Since TensorFlow 2.4 now uses the newer CUDA 11 and cuDNN 8, there's less configuration needed, so we can now base directly off the `nvidia/cuda` images. They don't come with any Python pre-installed, so we can easily install whichever version we want with Miniconda, and then `pip install` tensorflow and the rest of the dependencies. Installing tensorflow 2.4 in the nvidia images now works out of the box without further configurations.

This way builds faster, is simpler, more flexible, allows any supported Python version, and results in smaller images.

R: @tvalentyn - can you please help us review this whenever you have a chance?

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
