### PR TITLE
feat: add environment variables for dialogflow samples.

### DIFF
--- a/testing/test-env.tmpl.sh
+++ b/testing/test-env.tmpl.sh
@@ -103,3 +103,7 @@ export GITHUB_USERNAME=
 
 # For run/idp example, a Firebase IDP token
 export IDP_KEY=
+
+# Dialogflow examples.
+export SMART_REPLY_MODEL=
+export SMART_REPLY_ALLOWLIST=


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
