### PR TITLE
prepare utils for pypi distribution

### DIFF
--- a/composer/dag_test_utils/README.md
+++ b/composer/dag_test_utils/README.md
@@ -6,7 +6,7 @@ This package is used internally to unit test the validity of all Cloud Composer 
 
 Add the following to your `requirements-test.txt` file:
 
-`git+https://github.com/GoogleCloudPlatform/python-docs-samples.git#egg=dag_test_utils&subdirectory=composer/dag_test_utils`
+`cloud_composer_dag_test_utils`
 
 Import the internal unit testing module
 

--- a/composer/dag_test_utils/pyproject.toml
+++ b/composer/dag_test_utils/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/composer/dag_test_utils/setup.py
+++ b/composer/dag_test_utils/setup.py
@@ -16,12 +16,12 @@ from setuptools import find_packages
 from setuptools import setup
 
 setup(
-    name="dag_test_utils",
+    name="cloud_composer_dag_test_utils",
     version="0.0.1",
-    url="git@github.com:GoogleCloudPlatform/python-docs-samples.git#egg=dag_test_utils&subdirectory=composer/dag_test_utils",
-    author="Google Cloud Platform",
-    description="Utility used to unit test example Apache Airflow DAGs",
+    url="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/composer/dag_test_utils",
+    author="Google LLC",
+    description="Internal utility used to unit test example Apache Airflow DAGs for Google Cloud Composer",
     packages=find_packages(),
     py_modules=['internal_unit_testing'],
-    install_requires=['apache-airflow[gcp]']
+    install_requires=['apache-airflow[google]==1.10.15']
 )

--- a/composer/dag_test_utils/setup.py
+++ b/composer/dag_test_utils/setup.py
@@ -20,7 +20,7 @@ setup(
     version="0.0.1",
     url="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/composer/dag_test_utils",
     author="Google LLC",
-    description="Internal utility used to unit test example Apache Airflow DAGs for Google Cloud Composer",
+    description="Utility used to unit test example Apache Airflow DAGs for Google Cloud Composer. This is not an officially supported Google product.",
     packages=find_packages(),
     py_modules=['internal_unit_testing'],
     install_requires=['apache-airflow[google]==1.10.15']


### PR DESCRIPTION
## Description

I redid the setup.py with a better, more descriptive name, and added a pyproject.toml. I haven't added it to PyPI yet in case we wanted to do something like change the name, but to test locally, you can

- Change to this branch and to `composer/dag_test_utils`
- Build with `python3 -m build` (you might have to `pip install build`)
- Change to `../workflows`
- `pip install ../dag_test_utils/dist/cloud_composer_dag_test_utils-0.0.1.tar.gz`
- Open a python editor and try `import internal_unit_testing` - you may see some deprecation warnings, and those are okay. They're part of underlying Airflow and will be resolved in the next release. If you see any `ModuleNotFoundError` errors, we should talk because I probably got something wrong. 
- (alternative path) go to the `requirements-test.txt` and replace the gross URL with `../dag_test_utils/dist/cloud_composer_dag_test_utils-0.0.1.tar.gz`, then run `nox -s py-3.8 -- quickstart_test.py` (or any of the tests, or the whole test suite - I just suggest doing one for speed reasons because the pip install of Airflow is slow)

I have requested a pywindows cloudtop and will test these distributions on windows and linux as well, and I have properly registered a team account on PyPI for the Cloud Composer DPEs per the OSPO instructions.


*Preview of Coming Attractions*
Once this is merged, I'll
- Make a small PR to requirements-test.txt files under Composer so that it pulls this package not a gross URL
- Make a PR with a major version update that upgrades this code to Airflow 2.0
- Point PR #5782 to that new major version upgrade 

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
