### PR TITLE
chore(deps): update Renovate to ignore patches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,10 @@
       "packagePatterns": ["pytest"],
       "updateTypes": ["patch"],
       "enabled": false
+    },
+    {
+      "packagePatterns": ["pytest"],
+      "updateTypes": ["minor", "major"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,12 @@
   "packageRules": [
     {
       "packagePatterns": ["pytest"],
-      "updateTypes": ["minor", "major"]
+      "separateMinorPatch": true
+    },
+    {
+      "packagePatterns": ["pytest"],
+      "updateTypes": ["patch"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description

The problem with RenovateBot currently is that it actually treats `minor` and `patch` releases to be the same. See [separateMinorPatch](https://docs.renovatebot.com/configuration-options/#separateminorpatch) docs for more detail.

To mitigate this, we first include a rule to tell RenovateBot to separate and recognize between `minor` and `patch` releases. Then, we create a second rule to disable `patch` updates. This should now successfully let RenovateBot to only update on `major` and `minor` patches.

Fixes #5873 

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
