### PR TITLE
test(storage): fix S3 SDK tests (again)

### DIFF
--- a/storage/s3-sdk/s3_sdk_test.py
+++ b/storage/s3-sdk/s3_sdk_test.py
@@ -65,29 +65,27 @@ def test_blob(test_bucket):
     yield blob
 
 
+# Retry request because the created key may not be fully propagated for up
+# to 15s.
+@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
 def test_list_buckets(capsys, hmac_fixture, test_bucket):
-    # Retry request because the created key may not be fully propagated for up
-    # to 15s.
-    @backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
-    def list_buckets():
-        list_gcs_buckets.list_gcs_buckets(
-            google_access_key_id=hmac_fixture[0].access_id, google_access_key_secret=hmac_fixture[1]
-        )
-        out, _ = capsys.readouterr()
-        assert "Buckets:" in out
-        assert test_bucket.name in out
+    list_gcs_buckets.list_gcs_buckets(
+        google_access_key_id=hmac_fixture[0].access_id, google_access_key_secret=hmac_fixture[1]
+    )
+    out, _ = capsys.readouterr()
+    assert "Buckets:" in out
+    assert test_bucket.name in out
 
 
+# Retry request because the created key may not be fully propagated for up
+# to 15s.
+@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
 def test_list_blobs(capsys, hmac_fixture, test_bucket, test_blob):
-    # Retry request because the created key may not be fully propagated for up
-    # to 15s.
-    @backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
-    def list_objects():
-        list_gcs_objects.list_gcs_objects(
-            google_access_key_id=hmac_fixture[0].access_id,
-            google_access_key_secret=hmac_fixture[1],
-            bucket_name=test_bucket.name,
-        )
-        out, _ = capsys.readouterr()
-        assert "Objects:" in out
-        assert test_blob.name in out
+    list_gcs_objects.list_gcs_objects(
+        google_access_key_id=hmac_fixture[0].access_id,
+        google_access_key_secret=hmac_fixture[1],
+        bucket_name=test_bucket.name,
+    )
+    out, _ = capsys.readouterr()
+    assert "Objects:" in out
+    assert test_blob.name in out

--- a/storage/s3-sdk/s3_sdk_test.py
+++ b/storage/s3-sdk/s3_sdk_test.py
@@ -67,7 +67,7 @@ def test_blob(test_bucket):
 
 # Retry request because the created key may not be fully propagated for up
 # to 15s.
-@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
+@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=25)
 def test_list_buckets(capsys, hmac_fixture, test_bucket):
     list_gcs_buckets.list_gcs_buckets(
         google_access_key_id=hmac_fixture[0].access_id, google_access_key_secret=hmac_fixture[1]
@@ -79,7 +79,7 @@ def test_list_buckets(capsys, hmac_fixture, test_bucket):
 
 # Retry request because the created key may not be fully propagated for up
 # to 15s.
-@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
+@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=25)
 def test_list_blobs(capsys, hmac_fixture, test_bucket, test_blob):
     list_gcs_objects.list_gcs_objects(
         google_access_key_id=hmac_fixture[0].access_id,

--- a/storage/s3-sdk/s3_sdk_test.py
+++ b/storage/s3-sdk/s3_sdk_test.py
@@ -67,7 +67,7 @@ def test_blob(test_bucket):
 
 # Retry request because the created key may not be fully propagated for up
 # to 15s.
-@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=25)
+@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
 def test_list_buckets(capsys, hmac_fixture, test_bucket):
     list_gcs_buckets.list_gcs_buckets(
         google_access_key_id=hmac_fixture[0].access_id, google_access_key_secret=hmac_fixture[1]
@@ -79,7 +79,7 @@ def test_list_buckets(capsys, hmac_fixture, test_bucket):
 
 # Retry request because the created key may not be fully propagated for up
 # to 15s.
-@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=25)
+@backoff.on_exception(backoff.constant, ClientError, interval=1, max_time=15)
 def test_list_blobs(capsys, hmac_fixture, test_bucket, test_blob):
     list_gcs_objects.list_gcs_objects(
         google_access_key_id=hmac_fixture[0].access_id,


### PR DESCRIPTION
I realized that the tests weren't actually running as I wrote them
previously. Whoops! With this change they should be running as
expected.


## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
