### PR TITLE
chore: Cleaning up the vm identity sample.

### DIFF
--- a/compute/metadata/vm_identity.py
+++ b/compute/metadata/vm_identity.py
@@ -12,10 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Example of verifying Google Compute Engine virtual machine identity.
 
-# [START compute_vm_identity_verify_token]
+This sample will work only on a GCE virtual machine, as it relies on
+communication with metadata server (https://cloud.google.com/compute/docs/storing-retrieving-metadata).
+
+Example is used on: https://cloud.google.com/compute/docs/instances/verifying-instance-identity
+"""
 import pprint
 
+# [START compute_vm_identity_verify_token]
 import google.auth.transport.requests
 from google.oauth2 import id_token
 
@@ -47,13 +54,12 @@ def acquire_token(audience: str = AUDIENCE_URL) -> str:
 # [END compute_vm_identity_acquire_token]
 
 # [START compute_vm_identity_verify_token]
-
-
 def verity_token(token: str, audience: str) -> dict:
     """Verify token signature and return the token payload"""
     request = google.auth.transport.requests.Request()
     payload = id_token.verify_token(token, request=request, audience=audience)
     return payload
+
 
 # [END compute_vm_identity_verify_token]
 

--- a/compute/metadata/vm_identity.py
+++ b/compute/metadata/vm_identity.py
@@ -25,7 +25,6 @@ import pprint
 # [START compute_vm_identity_verify_token]
 import google.auth.transport.requests
 from google.oauth2 import id_token
-
 # [END compute_vm_identity_verify_token]
 
 # [START compute_vm_identity_acquire_token]
@@ -49,18 +48,15 @@ def acquire_token(audience: str = AUDIENCE_URL) -> str:
     # Extract and return the token from the response.
     r.raise_for_status()
     return r.text
-
-
 # [END compute_vm_identity_acquire_token]
 
+
 # [START compute_vm_identity_verify_token]
-def verity_token(token: str, audience: str) -> dict:
+def verify_token(token: str, audience: str) -> dict:
     """Verify token signature and return the token payload"""
     request = google.auth.transport.requests.Request()
     payload = id_token.verify_token(token, request=request, audience=audience)
     return payload
-
-
 # [END compute_vm_identity_verify_token]
 
 
@@ -68,4 +64,4 @@ if __name__ == '__main__':
     token_ = acquire_token()
     print("Received token:", token_)
     print("Token verification:")
-    pprint.pprint(verity_token(acquire_token(AUDIENCE_URL), AUDIENCE_URL))
+    pprint.pprint(verify_token(acquire_token(AUDIENCE_URL), AUDIENCE_URL))

--- a/compute/metadata/vm_identity_test.py
+++ b/compute/metadata/vm_identity_test.py
@@ -32,7 +32,7 @@ def test_vm_identity():
 
     token = vm_identity.acquire_token(AUDIENCE)
     assert isinstance(token, str) and token
-    verification = vm_identity.verity_token(token, AUDIENCE)
+    verification = vm_identity.verify_token(token, AUDIENCE)
     assert isinstance(verification, dict) and verification
     assert verification['aud'] == AUDIENCE
     assert verification['email_verified']


### PR DESCRIPTION
+ Adding a docstring to the sample.

## Description
While updating the [public documentation](https://cloud.google.com/compute/docs/instances/verifying-instance-identity) page, I notices that I included unnecessary `import pprint` in one of the regions. So I want to fix this + add a docstring the the sample.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
