### PR TITLE
Add glasnt as */django/* codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,8 @@
 *                               @GoogleCloudPlatform/python-samples-owners
 
 /appengine/**/*.py                     @engelke @GoogleCloudPlatform/python-samples-owners
+/appengine/standard/django/**/*.py     @glasnt @GoogleCloudPlatform/python-samples-owners
+/appengine/flexible/django_cloudsql/**/*.py  @glasnt @GoogleCloudPlatform/python-samples-owners
 /auth/**/*.py                          @busunkim96 @GoogleCloudPlatform/python-samples-owners
 /automl/**/*.py                        @telpirion @sirtorry @GoogleCloudPlatform/python-samples-owners
 /billing/**/*.py                       @GoogleCloudPlatform/billing-samples-maintainers @GoogleCloudPlatform/python-samples-owners


### PR DESCRIPTION
## Description

Adds @glasnt as a codeowner for the django samples


## Checklist
- [x] Yes, I would like to ensure continued maintenance for these samples, so I am offering to be a CODEOWNER.
