### PR TITLE
fix: Encryption samples no logner break with new requests library version

### DIFF
--- a/compute/encryption/generate_wrapped_rsa_key.py
+++ b/compute/encryption/generate_wrapped_rsa_key.py
@@ -42,7 +42,7 @@ def get_google_public_cert_key():
 
     # Load the certificate.
     certificate = x509.load_pem_x509_certificate(
-        r.text.encode('utf-8'), default_backend())
+        r.content, default_backend())
 
     # Get the certicate's public key.
     public_key = certificate.public_key()

--- a/compute/encryption/requirements.txt
+++ b/compute/encryption/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==3.4.7
-requests==2.25.1
+requests==2.26.0
 google-api-python-client==2.12.0
 google-auth==1.31.0
 google-auth-httplib2==0.1.0


### PR DESCRIPTION
## Description

Fixes the code that was failing with new version of requests library, as evident in https://github.com/GoogleCloudPlatform/python-docs-samples/pull/6422

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
