### PR TITLE
chore: Use latest google-auth to avoid a utility function deprecation

### DIFF
--- a/iap/requirements.txt
+++ b/iap/requirements.txt
@@ -1,6 +1,6 @@
 cryptography==3.4.8
 Flask==2.0.1
-google-auth==2.0.0
+google-auth==2.0.2
 gunicorn==20.1.0
 requests==2.26.0
 requests_toolbelt==0.9.1


### PR DESCRIPTION
## Description

Fixes #6605 


