### PR TITLE
Two character update to Airflow DAG

### DIFF
--- a/composer/airflow_1_samples/kubernetes_pod_operator.py
+++ b/composer/airflow_1_samples/kubernetes_pod_operator.py
@@ -131,7 +131,8 @@ with models.DAG(
         # env_vars allows you to specify environment variables for your
         # container to use. env_vars is templated.
         env_vars={
-            'EXAMPLE_VAR': '/example/value'})
+            'EXAMPLE_VAR': '/example/value',
+            'GOOGLE_APPLICATION_CREDENTIALS': '/var/secrets/google/service-account.json '})
     # [END composer_kubernetespodoperator_secretconfig_airflow_1]
     # [START composer_kubernetespodaffinity_airflow_1]
     kubernetes_affinity_ex = kubernetes_pod_operator.KubernetesPodOperator(

--- a/composer/airflow_1_samples/kubernetes_pod_operator.py
+++ b/composer/airflow_1_samples/kubernetes_pod_operator.py
@@ -131,8 +131,7 @@ with models.DAG(
         # env_vars allows you to specify environment variables for your
         # container to use. env_vars is templated.
         env_vars={
-            'EXAMPLE_VAR': '/example/value',
-            'GOOGLE_APPLICATION_CREDENTIALS': '/var/secrets/google/service-account.json'})
+            'EXAMPLE_VAR': '/example/value'})
     # [END composer_kubernetespodoperator_secretconfig_airflow_1]
     # [START composer_kubernetespodaffinity_airflow_1]
     kubernetes_affinity_ex = kubernetes_pod_operator.KubernetesPodOperator(

--- a/composer/workflows/kubernetes_pod_operator.py
+++ b/composer/workflows/kubernetes_pod_operator.py
@@ -131,8 +131,7 @@ with models.DAG(
         # env_vars allows you to specify environment variables for your
         # container to use. env_vars is templated.
         env_vars={
-            'EXAMPLE_VAR': '/example/value',
-            'GOOGLE_APPLICATION_CREDENTIALS': '/var/secrets/google/service-account.json'})
+            'EXAMPLE_VAR': '/example/value'})
     # [END composer_kubernetespodoperator_secretconfig]
     # [START composer_kubernetespodaffinity]
     kubernetes_affinity_ex = KubernetesPodOperator(

--- a/composer/workflows/kubernetes_pod_operator.py
+++ b/composer/workflows/kubernetes_pod_operator.py
@@ -131,7 +131,8 @@ with models.DAG(
         # env_vars allows you to specify environment variables for your
         # container to use. env_vars is templated.
         env_vars={
-            'EXAMPLE_VAR': '/example/value'})
+            'EXAMPLE_VAR': '/example/value',
+            'GOOGLE_APPLICATION_CREDENTIALS': '/var/secrets/google/service-account.json '})
     # [END composer_kubernetespodoperator_secretconfig]
     # [START composer_kubernetespodaffinity]
     kubernetes_affinity_ex = KubernetesPodOperator(


### PR DESCRIPTION
I was going through [this tutorial](https://cloud.google.com/composer/docs/how-to/using/using-kubernetes-pod-operator#secret-config) earlier and found that the environment variable set here throws TemplateNotFound errors. It's because of a stupid quirk of Airflow and adding a space after the filename fixes it. 🙄 (found in [common pitfalls](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=62694614))