### PR TITLE
fix: create separate bucket for iot gcs_file_to_device test

### DIFF
--- a/appengine/flexible/storage/main.py
+++ b/appengine/flexible/storage/main.py
@@ -15,8 +15,10 @@
 # [START gae_flex_storage_app]
 import logging
 import os
+from typing import Union
 
 from flask import Flask, request
+import flask.typing
 from google.cloud import storage
 
 app = Flask(__name__)
@@ -26,7 +28,7 @@ CLOUD_STORAGE_BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
 
 
 @app.route('/')
-def index():
+def index() -> str:
     return """
 <form method="POST" action="/upload" enctype="multipart/form-data">
     <input type="file" name="file">
@@ -36,7 +38,7 @@ def index():
 
 
 @app.route('/upload', methods=['POST'])
-def upload():
+def upload() -> str:
     """Process the uploaded file and upload it to Google Cloud Storage."""
     uploaded_file = request.files.get('file')
 
@@ -67,7 +69,7 @@ def upload():
 
 
 @app.errorhandler(500)
-def server_error(e):
+def server_error(e: Union[flask.typing.GenericException, int]) -> str:
     logging.exception('An error occurred during a request.')
     return """
     An internal error occurred: <pre>{}</pre>

--- a/appengine/flexible/storage/main.py
+++ b/appengine/flexible/storage/main.py
@@ -18,7 +18,6 @@ import os
 from typing import Union
 
 from flask import Flask, request
-import flask.typing
 from google.cloud import storage
 
 app = Flask(__name__)
@@ -69,7 +68,7 @@ def upload() -> str:
 
 
 @app.errorhandler(500)
-def server_error(e: Union[flask.typing.GenericException, int]) -> str:
+def server_error(e: Union[Exception, int]) -> str:
     logging.exception('An error occurred during a request.')
     return """
     An internal error occurred: <pre>{}</pre>

--- a/appengine/flexible/storage/main.py
+++ b/appengine/flexible/storage/main.py
@@ -57,6 +57,11 @@ def upload():
         content_type=uploaded_file.content_type
     )
 
+    # Make the blob public. This is not necessary if the
+    # entire bucket is public.
+    # See https://cloud.google.com/storage/docs/access-control/making-data-public.
+    blob.make_public()
+
     # The public URL can be used to directly access the uploaded file via HTTP.
     return blob.public_url
 

--- a/appengine/flexible/storage/main_test.py
+++ b/appengine/flexible/storage/main_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import flask
+import flask.testing
 import pytest
 import requests
 from six import BytesIO

--- a/appengine/flexible/storage/main_test.py
+++ b/appengine/flexible/storage/main_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import flask
 import pytest
 import requests
 from six import BytesIO
@@ -20,17 +21,17 @@ import main
 
 
 @pytest.fixture
-def client():
+def client() -> flask.testing.FlaskClient:
     main.app.testing = True
     return main.app.test_client()
 
 
-def test_index(client):
+def test_index(client: flask.testing.FlaskClient) -> None:
     r = client.get('/')
     assert r.status_code == 200
 
 
-def test_upload(client):
+def test_upload(client: flask.testing.FlaskClient) -> None:
     # Upload a simple file
     file_content = b"This is some test content."
 

--- a/appengine/flexible/storage/main_test.py
+++ b/appengine/flexible/storage/main_test.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import uuid
+
 import flask
 import flask.testing
+from google.cloud import storage
 import pytest
 import requests
 from six import BytesIO
@@ -32,14 +36,24 @@ def test_index(client: flask.testing.FlaskClient) -> None:
     assert r.status_code == 200
 
 
-def test_upload(client: flask.testing.FlaskClient) -> None:
+@pytest.fixture(scope="module")
+def blob_name() -> str:
+    name = f"gae-flex-storage-{uuid.uuid4()}"
+    yield name
+
+    bucket = storage.Client().bucket(os.environ["CLOUD_STORAGE_BUCKET"])
+    blob = bucket.blob(name)
+    blob.delete()
+
+
+def test_upload(client: flask.testing.FlaskClient, blob_name: str) -> None:
     # Upload a simple file
     file_content = b"This is some test content."
 
     r = client.post(
         '/upload',
         data={
-            'file': (BytesIO(file_content), 'example.txt')
+            'file': (BytesIO(file_content), blob_name)
         }
     )
 

--- a/appengine/flexible/storage/noxfile_config.py
+++ b/appengine/flexible/storage/noxfile_config.py
@@ -1,0 +1,44 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default TEST_CONFIG_OVERRIDE for python repos.
+
+# You can copy this file into your directory, then it will be imported from
+# the noxfile.py.
+
+# The source of truth:
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/noxfile_config.py
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    "ignored_versions": ["2.7"],
+    # Old samples are opted out of enforcing Python type hints
+    # All new samples should feature them
+    "enforce_type_hints": True,
+    # An envvar key for determining the project id to use. Change it
+    # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
+    # build specific Cloud project. You can also use your own string
+    # to use your own Cloud project.
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    # If you need to use a specific version of pip,
+    # change pip_version_override to the string representation
+    # of the version number, for example, "20.2.4"
+    "pip_version_override": None,
+    # A dictionary you want to inject into your test. Don't put any
+    # secrets here. These values will override predefined values.
+    "envs": {
+        "CLOUD_STORAGE_BUCKET": "python-docs-samples-tests-public"
+    },
+}

--- a/appengine/flexible/storage/requirements-test.txt
+++ b/appengine/flexible/storage/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest==6.2.4
+google-cloud-storage==1.42.2

--- a/iot/api-client/gcs_file_to_device/gcs_send_to_device_test.py
+++ b/iot/api-client/gcs_file_to_device/gcs_send_to_device_test.py
@@ -30,8 +30,6 @@ import gcs_send_to_device as gcs_to_device
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "manager"))  # noqa
 import manager  # noqa
 
-
-gcs_bucket = os.environ["CLOUD_STORAGE_BUCKET"]
 project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
 service_account_json = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
 
@@ -46,9 +44,38 @@ gcs_file_name = "my-config"
 
 
 @pytest.fixture(scope="module")
-def test_blob():
+def test_bucket_name():
+    bucket_name = "python-docs-samples-iot-api-client-{}".format(uuid.uuid4())
+
+    yield bucket_name 
+
+    bucket = storage.Client().bucket(bucket_name)
+    bucket.delete(force=True)
+
+
+@pytest.fixture(scope="module")
+def test_bucket(test_bucket_name):
+    """Yields a bucket that is deleted after the test completes."""
+    bucket = None
+    while bucket is None or bucket.exists():
+        bucket = storage.Client().bucket(test_bucket_name)
+    bucket.create()
+
+    # Bucket must be public for `test_make_file_public`
+    policy = bucket.get_iam_policy(requested_policy_version=3)
+    policy.bindings.append(
+        {"role": "roles/storage.objectViewer", "members": {"allUsers"}}
+    )
+
+    bucket.set_iam_policy(policy)
+
+    yield bucket
+
+
+@pytest.fixture(scope="module")
+def test_blob(test_bucket):
     """Provides a pre-existing blob in the test bucket."""
-    bucket = storage.Client().bucket(gcs_bucket)
+    bucket = storage.Client().bucket(test_bucket)
     # Name of the blob
     blob = bucket.blob("iot_core_store_file_gcs")
     # Text in the blob
@@ -64,14 +91,11 @@ def test_blob():
 
 
 @mock.patch("google.cloud.storage.client.Client.create_bucket")
-def test_create_bucket(create_bucket_mock, capsys):
-    # Unlike other tests for sending a config, this one mocks out the creation
-    # because buckets are expensive, globally-namespaced objects.
-    create_bucket_mock.return_value = mock.sentinel.bucket
+def test_create_bucket(test_bucket_name, capsys):
+    gcs_to_device.create_bucket(test_bucket_name)
 
-    gcs_to_device.create_bucket(gcs_bucket)
-
-    create_bucket_mock.assert_called_with(gcs_bucket)
+    out, _ = capsys.readouterr()
+    assert f"Bucket {test_bucket_name} created" in out
 
 
 def test_upload_local_file(capsys):
@@ -80,14 +104,14 @@ def test_upload_local_file(capsys):
     with tempfile.NamedTemporaryFile() as source_file:
         source_file.write(b"This is a source file.")
 
-        gcs_to_device.upload_local_file(gcs_bucket, gcs_file_name, source_file.name)
+        gcs_to_device.upload_local_file(test_bucket, gcs_file_name, source_file.name)
 
     out, _ = capsys.readouterr()
     assert "File {} uploaded as {}.".format(source_file.name, gcs_file_name) in out
 
 
 def test_make_file_public(test_blob):
-    gcs_to_device.make_file_public(gcs_bucket, test_blob.name)
+    gcs_to_device.make_file_public(test_bucket, test_blob.name)
 
     r = requests.get(test_blob.public_url)
     # Test for the content of the file to verify that
@@ -106,7 +130,7 @@ def test_send_to_device(capsys):
     )
 
     gcs_to_device.send_to_device(
-        gcs_bucket,
+        test_bucket,
         gcs_file_name,
         destination_file_name,
         project_id,


### PR DESCRIPTION
## Description

Fixes #6725, #6724

I disabled public access on the `python-docs-samples-tests` bucket and these were the two tests that failed. 

For the AppEngine sample it felt a bit awkward to create the bucket _before_ the app is imported (`main.py` references the bucket through an env var) so I stood up a new, separate bucket with public access enabled.

For IoT, I modified the test to create its own bucket.