### PR TITLE
fix(storage): skip test temporarily before pap changes release

### DIFF
--- a/storage/cloud-client/public_access_prevention_test.py
+++ b/storage/cloud-client/public_access_prevention_test.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 import storage_get_public_access_prevention
 import storage_set_public_access_prevention_enforced
 import storage_set_public_access_prevention_unspecified
 
 
+@pytest.mark.skip(reason="Unspecified PAP is changing to inherited")
 def test_get_public_access_prevention(bucket, capsys):
     short_name = storage_get_public_access_prevention
     short_name.get_public_access_prevention(


### PR DESCRIPTION
This temporary skips failing test until we get the PAP changes for #6751  fully merged in.

GCS is changing the `unspecified` public access prevention value to `inherited`

Please see nodejs example here: https://github.com/googleapis/nodejs-storage/pull/1614/files

