### PR TITLE
fix(storage): add time for bucket config changes to propagate

### DIFF
--- a/storage/cloud-client/bucket_lock_test.py
+++ b/storage/cloud-client/bucket_lock_test.py
@@ -123,6 +123,10 @@ def test_enable_disable_bucket_default_event_based_hold(bucket, capsys):
         "Default event-based hold is enabled for {}".format(bucket.name) in out
     )
 
+    # Changes to the bucket will be readable immediately after writing,
+    # but configuration changes may take time to propagate.
+    time.sleep(10)
+
     blob = bucket.blob(BLOB_NAME)
     blob.upload_from_string(BLOB_CONTENT)
     assert blob.event_based_hold is True


### PR DESCRIPTION
Although changes to the bucket (enabling `default_event_based_hold`) will be readable immediately after writing, configuration changes may take time to propagate. This adds time to allow the bucket configurations to propagate. 

Fixes #6733
