### PR TITLE
fix: fail nox session if python version is missing

### DIFF
--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -97,6 +97,9 @@ IGNORED_VERSIONS = TEST_CONFIG['ignored_versions']
 TESTED_VERSIONS = sorted([v for v in ALL_VERSIONS if v not in IGNORED_VERSIONS])
 
 INSTALL_LIBRARY_FROM_SOURCE = bool(os.environ.get("INSTALL_LIBRARY_FROM_SOURCE", False))
+
+# Error if a python version is missing
+nox.options.error_on_missing_interpreters = True
 #
 # Style Checks
 #

--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -100,6 +100,7 @@ INSTALL_LIBRARY_FROM_SOURCE = bool(os.environ.get("INSTALL_LIBRARY_FROM_SOURCE",
 
 # Error if a python version is missing
 nox.options.error_on_missing_interpreters = True
+
 #
 # Style Checks
 #


### PR DESCRIPTION
By default nox skips the session if the interpreter is missing.
This asks it to error instead.