### PR TITLE
feat(storage): add retry configurations sample and test

### DIFF
--- a/storage/cloud-client/snippets_test.py
+++ b/storage/cloud-client/snippets_test.py
@@ -508,4 +508,4 @@ def test_storage_configure_retries(test_blob, capsys):
     out, _ = capsys.readouterr()
     assert "The following library method is customized to be retried" in out
     assert "_should_retry" in out
-    assert "initial=1.0, maximum=60.0, multiplier=3.0, deadline=500.0" in out
+    assert "initial=1.5, maximum=45.0, multiplier=1.2, deadline=500.0" in out

--- a/storage/cloud-client/storage_configure_retries.py
+++ b/storage/cloud-client/storage_configure_retries.py
@@ -40,8 +40,10 @@ def configure_retries(bucket_name, blob_name):
 
     # Customize retry with a deadline of 500 seconds (default=120 seconds).
     modified_retry = DEFAULT_RETRY.with_deadline(500.0)
-    # Customize retry with a wait time multiplier per iteration of 3.0 (default=2.0).
-    modified_retry = modified_retry.with_delay(multiplier=3.0)
+    # Customize retry with an initial wait time of 1.5 (default=1.0).
+    # Customize retry with a wait time multiplier per iteration of 1.2 (default=2.0).
+    # Customize retry with a maximum wait time of 45.0 (default=60.0).
+    modified_retry = modified_retry.with_delay(initial=1.5, multiplier=1.2, maximum=45.0)
 
     # blob.delete() uses DEFAULT_RETRY_IF_GENERATION_SPECIFIED by default.
     # Override with modified_retry so the function retries even if the generation


### PR DESCRIPTION
## Description

This adds a storage sample for configuring retries. This sample is planned to be used on https://cloud.google.com/storage/docs/retry-strategy. The region tag `storage_configure_retries` already exists, and the  sample in node.js is published.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))

