### PR TITLE
Group people and planet dependency updates

### DIFF
--- a/people-and-planet-ai/image-classification/requirements.txt
+++ b/people-and-planet-ai/image-classification/requirements.txt
@@ -1,4 +1,4 @@
 Pillow==8.4.0
-apache-beam[gcp]==2.31.0
+apache-beam[gcp]==2.33.0
 google-cloud-aiplatform==1.1.1
-google-cloud-bigquery==2.29.0 # Indirect dependency, but there is a version conflict that causes pip to hang unless we constraint this.
+google-cloud-bigquery==2.30.0 # Indirect dependency, but there is a version conflict that causes pip to hang unless we constraint this.

--- a/people-and-planet-ai/timeseries-classification/constraints.txt
+++ b/people-and-planet-ai/timeseries-classification/constraints.txt
@@ -1,2 +1,2 @@
 # If we don't constraint this, the dependency resolver can take a really long time.
-google-cloud-bigquery==2.29.0
+google-cloud-bigquery==2.30.0

--- a/people-and-planet-ai/timeseries-classification/requirements.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.0.1
-apache-beam[gcp]==2.32.0
+apache-beam[gcp]==2.33.0
 google-cloud-aiplatform==1.4.2
 gunicorn==20.1.0
 pandas==1.3.4
-tensorflow==2.6.1
+tensorflow==2.6.2


### PR DESCRIPTION
Grouping people and planet dependency updates so I can remove them from PRs where people and planet is blocking other dependency updates