### PR TITLE
Exempt dataflow from 3.10

### DIFF
--- a/dataflow/flex-templates/streaming_beam/noxfile_config.py
+++ b/dataflow/flex-templates/streaming_beam/noxfile_config.py
@@ -25,7 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.8.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.9"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.10"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/pytorch-minimal/noxfile_config.py
+++ b/dataflow/gpu-examples/pytorch-minimal/noxfile_config.py
@@ -25,7 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.8.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.9"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.10"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-landsat/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-landsat/noxfile_config.py
@@ -25,7 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.8.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.9"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.10"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-minimal/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-minimal/noxfile_config.py
@@ -25,7 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.8.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.9"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.10"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,


### PR DESCRIPTION
@davidcavazos this was an educated guess based on which examples skip 3.9. Please edit or close as needed