### PR TITLE
Using check_call to expose underlying error messages

### DIFF
--- a/memorystore/redis/cloud_run_deployment/e2e_test.py
+++ b/memorystore/redis/cloud_run_deployment/e2e_test.py
@@ -59,14 +59,15 @@ def redis_host():
 def container_image():
     # Build container image for Cloud Run deployment
     image_name = f"gcr.io/{PROJECT}/test-visit-count-{SUFFIX}"
-    subprocess.run(
+    subprocess.check_call(
         [
             "cp",
             "cloud_run_deployment/Dockerfile",
             ".",
-        ], check=True
+        ]
     )
-    subprocess.run(
+
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -75,14 +76,15 @@ def container_image():
             image_name,
             "--project",
             PROJECT,
-        ], check=True
+        ]
     )
+
     yield image_name
 
-    subprocess.run(["rm", "Dockerfile"], check=True)
+    subprocess.check_call(["rm", "Dockerfile"])
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -92,7 +94,7 @@ def container_image():
             "--quiet",
             "--project",
             PROJECT,
-        ], check=True
+        ]
     )
 
 
@@ -100,7 +102,7 @@ def container_image():
 def deployed_service(container_image, redis_host):
     # Deploy image to Cloud Run
     service_name = f"test-visit-count-{SUFFIX}"
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -117,12 +119,12 @@ def deployed_service(container_image, redis_host):
             f"REDISHOST={redis_host},REDISPORT=6379",
             "--project",
             PROJECT,
-        ], check=True
+        ]
     )
     yield service_name
 
     # Delete Cloud Run service
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -134,7 +136,7 @@ def deployed_service(container_image, redis_host):
             "--quiet",
             "--project",
             PROJECT,
-        ], check=True
+        ]
     )
 
 

--- a/run/django/test/e2e_test.py
+++ b/run/django/test/e2e_test.py
@@ -84,7 +84,7 @@ def deployed_service() -> str:
     if SAMPLE_VERSION:
         substitutions.append(f",_VERSION={SAMPLE_VERSION}")
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -95,8 +95,7 @@ def deployed_service() -> str:
             "./test/e2e_test_setup.yaml",
             "--substitutions",
         ]
-        + substitutions,
-        check=True,
+        + substitutions
     )
 
     yield SERVICE
@@ -117,7 +116,7 @@ def deployed_service() -> str:
     if SAMPLE_VERSION:
         substitutions.append(f"_SAMPLE_VERSION={SAMPLE_VERSION}")
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -128,8 +127,7 @@ def deployed_service() -> str:
             "./test/e2e_test_cleanup.yaml",
             "--substitutions",
         ]
-        + substitutions,
-        check=True,
+        + substitutions
     )
 
 

--- a/run/filesystem/e2e_test.py
+++ b/run/filesystem/e2e_test.py
@@ -36,7 +36,7 @@ def deployed_service():
     connector = os.environ['CONNECTOR']
     ip_address = os.environ['IP_ADDRESS']
 
-    subprocess.run(
+    subprocess.check_call(
         [
             'gcloud',
             'builds',
@@ -46,13 +46,12 @@ def deployed_service():
             '--project',
             PROJECT,
             f'--substitutions=_SERVICE_NAME={service_name},_FILESTORE_IP_ADDRESS={ip_address},_CONNECTOR={connector}'
-        ],
-        check=True,
+        ]
     )
 
     yield service_name
 
-    subprocess.run(
+    subprocess.check_call(
         [
             'gcloud',
             'run',
@@ -64,8 +63,7 @@ def deployed_service():
             '--quiet',
             '--project',
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 

--- a/run/hello-broken/e2e_test.py
+++ b/run/hello-broken/e2e_test.py
@@ -32,7 +32,7 @@ IMAGE_NAME = f"gcr.io/{PROJECT}/hello-{SUFFIX}"
 @pytest.fixture
 def container_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -42,14 +42,13 @@ def container_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
 
     yield IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -59,8 +58,7 @@ def container_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
@@ -68,7 +66,7 @@ def container_image():
 def deployed_service(container_image):
     # Deploy image to Cloud Run
     service_name = f"hello-{SUFFIX}"
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -81,13 +79,12 @@ def deployed_service(container_image):
             "--region=us-central1",
             "--platform=managed",
             "--no-allow-unauthenticated",
-        ],
-        check=True,
+        ]
     )
 
     yield service_name
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -99,8 +96,7 @@ def deployed_service(container_image):
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 

--- a/run/helloworld/e2e_test.py
+++ b/run/helloworld/e2e_test.py
@@ -32,7 +32,7 @@ IMAGE_NAME = f"gcr.io/{PROJECT}/helloworld-{SUFFIX}"
 @pytest.fixture
 def container_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -42,14 +42,13 @@ def container_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
 
     yield IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -59,8 +58,7 @@ def container_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
@@ -68,7 +66,7 @@ def container_image():
 def deployed_service(container_image):
     # Deploy image to Cloud Run
     service_name = f"helloworld-{SUFFIX}"
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -82,13 +80,12 @@ def deployed_service(container_image):
             "--platform=managed",
             "--no-allow-unauthenticated",
             "--set-env-vars=NAME=Test",
-        ],
-        check=True,
+        ]
     )
 
     yield service_name
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -100,8 +97,7 @@ def deployed_service(container_image):
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 

--- a/run/idp-sql/test/e2e_test.py
+++ b/run/idp-sql/test/e2e_test.py
@@ -106,7 +106,7 @@ def deployed_service() -> str:
     if SAMPLE_VERSION:
         substitutions.append(f"_SAMPLE_VERSION={SAMPLE_VERSION}")
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -117,8 +117,7 @@ def deployed_service() -> str:
             "./test/e2e_test_setup.yaml",
             "--substitutions",
         ]
-        + substitutions,
-        check=True,
+        + substitutions
     )
 
     service_url = (
@@ -159,7 +158,7 @@ def deployed_service() -> str:
     if SAMPLE_VERSION:
         substitutions.append(f"_SAMPLE_VERSION={SAMPLE_VERSION}")
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -170,8 +169,7 @@ def deployed_service() -> str:
             "./test/e2e_test_cleanup.yaml",
             "--substitutions",
         ]
-        + substitutions,
-        check=True,
+        + substitutions
     )
 
 

--- a/run/image-processing/e2e_test.py
+++ b/run/image-processing/e2e_test.py
@@ -39,7 +39,7 @@ TOPIC = f"image_proc_{SUFFIX}"
 @pytest.fixture
 def container_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -49,13 +49,12 @@ def container_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
     yield IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -65,8 +64,7 @@ def container_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
@@ -74,7 +72,7 @@ def container_image():
 def deployed_service(container_image, output_bucket):
     # Deploy image to Cloud Run
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -89,13 +87,12 @@ def deployed_service(container_image, output_bucket):
             "--set-env-vars",
             f"BLURRED_BUCKET_NAME={output_bucket.name}",
             "--no-allow-unauthenticated",
-        ],
-        check=True,
+        ]
     )
 
     yield CLOUD_RUN_SERVICE
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -107,8 +104,7 @@ def deployed_service(container_image, output_bucket):
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 

--- a/run/logging-manual/e2e_test.py
+++ b/run/logging-manual/e2e_test.py
@@ -39,7 +39,7 @@ IMAGE_NAME = f"gcr.io/{PROJECT}/logging-{SUFFIX}"
 @pytest.fixture
 def container_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -49,13 +49,12 @@ def container_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
     yield IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -65,8 +64,7 @@ def container_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
@@ -74,7 +72,7 @@ def container_image():
 def deployed_service(container_image):
     # Deploy image to Cloud Run
     service_name = f"logging-{SUFFIX}"
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -88,13 +86,12 @@ def deployed_service(container_image):
             "--platform=managed",
             "--set-env-vars",
             f"GOOGLE_CLOUD_PROJECT={PROJECT}" "--no-allow-unauthenticated",
-        ],
-        check=True,
+        ]
     )
 
     yield service_name
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -106,8 +103,7 @@ def deployed_service(container_image):
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 

--- a/run/markdown-preview/e2e_test.py
+++ b/run/markdown-preview/e2e_test.py
@@ -34,7 +34,7 @@ RENDERER_IMAGE_NAME = f"gcr.io/{PROJECT}/renderer-{SUFFIX}"
 @pytest.fixture()
 def renderer_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -45,13 +45,12 @@ def renderer_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
     yield RENDERER_IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -61,15 +60,14 @@ def renderer_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
 @pytest.fixture()
 def editor_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -80,13 +78,12 @@ def editor_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
     yield EDITOR_IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -96,8 +93,7 @@ def editor_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
@@ -105,7 +101,7 @@ def editor_image():
 def renderer_deployed_service(renderer_image):
     # Deploy image to Cloud Run
     renderer_service_name = f"renderer-{SUFFIX}"
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -118,13 +114,12 @@ def renderer_deployed_service(renderer_image):
             "--region=us-central1",
             "--platform=managed",
             "--no-allow-unauthenticated",
-        ],
-        check=True,
+        ]
     )
 
     yield renderer_service_name
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -136,8 +131,7 @@ def renderer_deployed_service(renderer_image):
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 

--- a/run/pubsub/e2e_test.py
+++ b/run/pubsub/e2e_test.py
@@ -38,7 +38,7 @@ IMAGE_NAME = f"gcr.io/{PROJECT}/pubsub-test-{SUFFIX}"
 @pytest.fixture
 def container_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -48,13 +48,12 @@ def container_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
     yield IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -64,8 +63,7 @@ def container_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
@@ -73,7 +71,7 @@ def container_image():
 def deployed_service(container_image):
     # Deploy image to Cloud Run
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -86,13 +84,12 @@ def deployed_service(container_image):
             PROJECT,
             "--platform=managed",
             "--no-allow-unauthenticated",
-        ],
-        check=True,
+        ]
     )
 
     yield CLOUD_RUN_SERVICE
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -104,8 +101,7 @@ def deployed_service(container_image):
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -36,7 +36,7 @@ IMAGE_NAME = f"gcr.io/{PROJECT}/sys-package-{SUFFIX}"
 @pytest.fixture
 def container_image():
     # Build container image for Cloud Run deployment
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "builds",
@@ -46,13 +46,12 @@ def container_image():
             "--project",
             PROJECT,
             "--quiet",
-        ],
-        check=True,
+        ]
     )
     yield IMAGE_NAME
 
     # Delete container image
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "container",
@@ -62,8 +61,7 @@ def container_image():
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 
@@ -71,7 +69,7 @@ def container_image():
 def deployed_service(container_image):
     # Deploy image to Cloud Run
     service_name = f"sys-package-{SUFFIX}"
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -84,13 +82,12 @@ def deployed_service(container_image):
             "--region=us-central1",
             "--platform=managed",
             "--no-allow-unauthenticated",
-        ],
-        check=True,
+        ]
     )
 
     yield service_name
 
-    subprocess.run(
+    subprocess.check_call(
         [
             "gcloud",
             "run",
@@ -102,8 +99,7 @@ def deployed_service(container_image):
             "--quiet",
             "--project",
             PROJECT,
-        ],
-        check=True,
+        ]
     )
 
 


### PR DESCRIPTION
Changed `subprocess.run` to `subprocess.check_call` whenever we're running a command and not saving the stdout.  This bubbles up the error message.  

We had some flaky tests failing on subprocess.run (eg [hello-broken](https://source.cloud.google.com/results/invocations/31e5fdd2-bcc3-4012-a153-1fd81271dba6/targets/github%2Fpython-docs-samples%2Frun%2Fhello-broken/tests)), so this should help us debug it in the future.