### PR TITLE
Add region tags for the Composer 2 Airflow REST API example

### DIFF
--- a/composer/rest/composer2/composer2_airflow_rest_api.py
+++ b/composer/rest/composer2/composer2_airflow_rest_api.py
@@ -18,6 +18,7 @@ Trigger a DAG in Cloud Composer 2 environment using the Airflow 2 stable REST AP
 """
 
 # [START composer_2_trigger_dag]
+# [START composer_2_trigger_dag_for_import]
 from typing import Any
 
 import google.auth
@@ -82,7 +83,7 @@ def trigger_dag(web_server_url: str, dag_id: str, data: dict) -> str:
         response.raise_for_status()
     else:
         return response.text
-
+# [END composer_2_trigger_dag_for_import]
 
 if __name__ == "__main__":
 

--- a/composer/rest/composer2/composer2_airflow_rest_api.py
+++ b/composer/rest/composer2/composer2_airflow_rest_api.py
@@ -85,6 +85,7 @@ def trigger_dag(web_server_url: str, dag_id: str, data: dict) -> str:
         return response.text
 # [END composer_2_trigger_dag_for_import]
 
+
 if __name__ == "__main__":
 
     # TODO(developer): replace with your values


### PR DESCRIPTION
## Description

Add region tags, so that this example can be used on a different documentation page.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [X] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
