### PR TITLE
refactor: Update deployment preview to support built-in secrets, discovery API

### DIFF
--- a/run/deployment-previews/Dockerfile
+++ b/run/deployment-previews/Dockerfile
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 # [START cloudrun_deployment_preview_dockerfile]
-# Use the Cloud SDK docker container, which includes Python 3.7
-# https://github.com/GoogleCloudPlatform/cloud-sdk-docker
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+# Start from a Python base container
+FROM python:3.9-slim
 
 # Copy local code into the container image
 ENV APP_HOME /app

--- a/run/deployment-previews/check_status.py
+++ b/run/deployment-previews/check_status.py
@@ -24,7 +24,6 @@ import click
 import github
 from github.GithubException import GithubException
 from google.api_core.exceptions import NotFound
-from google.cloud import secretmanager
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 

--- a/run/deployment-previews/check_status.py
+++ b/run/deployment-previews/check_status.py
@@ -25,7 +25,6 @@ from github.GithubException import GithubException
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 
-api = discovery.build("run", "v1")
 
 # cloud run tags much be lowercase
 TAG_PREFIX = "pr-"
@@ -80,6 +79,7 @@ def error(msg: str, context: str = None) -> None:
 
 def get_service(project_id: str, region: str, service_name: str) -> dict:
     """Get the Cloud Run service object"""
+    api = discovery.build("run", "v1")
     fqname = f"projects/{project_id}/locations/{region}/services/{service_name}"
     try:
         service = api.projects().locations().services().get(name=fqname).execute()
@@ -90,6 +90,7 @@ def get_service(project_id: str, region: str, service_name: str) -> dict:
 
 def update_service(project_id: str, region: str, service_name: str, body: dict) -> dict:
     """Update the Cloud Run service."""
+    api = discovery.build("run", "v1")
     fqname = f"projects/{project_id}/locations/{region}/services/{service_name}"
     try:
         result = (

--- a/run/deployment-previews/check_status.py
+++ b/run/deployment-previews/check_status.py
@@ -25,7 +25,6 @@ from github.GithubException import GithubException
 from googleapiclient import discovery
 from googleapiclient.errors import HttpError
 
-
 api = discovery.build("run", "v1")
 
 # cloud run tags much be lowercase

--- a/run/deployment-previews/cloudbuild-configurations/cloudbuild-cleanup.yaml
+++ b/run/deployment-previews/cloudbuild-configurations/cloudbuild-cleanup.yaml
@@ -59,6 +59,7 @@ steps:
   # Cleanup tags against closed pull requests
   - id: "clean up old tag"
     name: "gcr.io/${PROJECT_ID}/deployment-previews" # our custom builder
+    secretEnv: ["GITHUB_TOKEN"]
     args:
       [
         "cleanup",
@@ -76,4 +77,12 @@ substitutions:
   _SERVICE_NAME: myservice
   _REGION: us-central1
   _GITHUB_OWNER: $(push.repository.owner.name)
+
+options:
+  dynamicSubstitutions: true
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/github_token/versions/latest
+      env: "GITHUB_TOKEN"
 # [END cloudrun_deployment_preview_cleanup]

--- a/run/deployment-previews/cloudbuild-configurations/cloudbuild-preview.yaml
+++ b/run/deployment-previews/cloudbuild-configurations/cloudbuild-preview.yaml
@@ -37,7 +37,6 @@ steps:
     entrypoint: "gcloud"
     args:
       [
-        "beta",
         "run",
         "deploy",
         "${_SERVICE_NAME}",

--- a/run/deployment-previews/cloudbuild-configurations/cloudbuild-preview.yaml
+++ b/run/deployment-previews/cloudbuild-configurations/cloudbuild-preview.yaml
@@ -54,6 +54,7 @@ steps:
 
   - id: "link revision on pull request"
     name: "gcr.io/${PROJECT_ID}/deployment-previews" # our custom builder
+    secretEnv: ["GITHUB_TOKEN"]
     args:
       [
         "set",
@@ -75,4 +76,12 @@ substitutions:
   _SERVICE_NAME: myservice
   _REGION: us-central1
   _GITHUB_REPO: $(pull_request.pull_request.head.repo.full_name)
+
+options:
+  dynamicSubsitutions: true
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/$PROJECT_ID/secrets/github_token/versions/latest
+      env: "GITHUB_TOKEN"
 # [END cloudrun_deployment_preview_preview]

--- a/run/deployment-previews/requirements.txt
+++ b/run/deployment-previews/requirements.txt
@@ -1,4 +1,3 @@
 pygithub==1.55
 click==8.0.3
-google-cloud-secret-manager==2.8.0
 google-api-python-client==2.31.0

--- a/run/deployment-previews/test_app.py
+++ b/run/deployment-previews/test_app.py
@@ -141,6 +141,7 @@ def test_set_check_calls(github_mock: Any, discovery_mock: Any) -> NoReturn:
             "--dry-run",
         ],
     )
+    print(response.output)
     assert response.exit_code == 0
     assert "Dry-run" in response.output
 

--- a/run/deployment-previews/test_app.py
+++ b/run/deployment-previews/test_app.py
@@ -15,9 +15,9 @@
 import os
 from typing import Any, List, NoReturn
 
-import pytest
 from click.testing import CliRunner
 from mock import MagicMock, patch
+import pytest
 
 from check_status import cli
 
@@ -33,7 +33,7 @@ runner = CliRunner()
 
 
 @pytest.fixture(autouse=True)
-def mock_settings_env_vars():
+def mock_settings_env_vars() -> NoReturn:
     with patch.dict(os.environ, {"GITHUB_TOKEN": MOCK_GH_TOKEN}):
         yield
 

--- a/run/deployment-previews/test_app.py
+++ b/run/deployment-previews/test_app.py
@@ -14,10 +14,10 @@
 
 from typing import Any, List, NoReturn
 
-from check_status import cli
 from click.testing import CliRunner
 from mock import MagicMock, patch
 
+from check_status import cli
 
 MOCK_SERVICE_NAME = "myservice"
 MOCK_GH_TOKEN = "aaaaa"
@@ -80,7 +80,7 @@ def test_set_wrongtag(discovery_mock: Any) -> NoReturn:
         [
             "set",
             "--project-id",
-            "foo",
+            MOCK_PROJECT_ID,
             "--region",
             "us-central1",
             "--service",

--- a/run/deployment-previews/test_app.py
+++ b/run/deployment-previews/test_app.py
@@ -14,10 +14,9 @@
 
 from typing import Any, List, NoReturn
 
-from click.testing import CliRunner
-from mock import MagicMock, patch, PropertyMock
-
 from check_status import cli
+from click.testing import CliRunner
+from mock import MagicMock, patch
 
 
 MOCK_SERVICE_NAME = "myservice"
@@ -44,7 +43,12 @@ def test_set_no_project() -> NoReturn:
 
 
 def service_data(name: str, tags: List[str]) -> dict:
-    traffic = [{"revisionName": f"{name}-00001-aaa", "percent": 100, }]
+    traffic = [
+        {
+            "revisionName": f"{name}-00001-aaa",
+            "percent": 100,
+        }
+    ]
     for t in tags:
         tag = f"pr-{t}"
         traffic.append(

--- a/run/deployment-previews/test_app.py
+++ b/run/deployment-previews/test_app.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from typing import Any, List, NoReturn
 
+import pytest
 from click.testing import CliRunner
 from mock import MagicMock, patch
 
@@ -28,6 +30,12 @@ MOCK_PROJECT_ID = "foocorp"
 
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def mock_settings_env_vars():
+    with patch.dict(os.environ, {"GITHUB_TOKEN": MOCK_GH_TOKEN}):
+        yield
 
 
 def test_help() -> NoReturn:
@@ -141,7 +149,6 @@ def test_set_check_calls(github_mock: Any, discovery_mock: Any) -> NoReturn:
             "--dry-run",
         ],
     )
-    print(response.output)
     assert response.exit_code == 0
     assert "Dry-run" in response.output
 

--- a/run/deployment-previews/test_app.py
+++ b/run/deployment-previews/test_app.py
@@ -97,9 +97,8 @@ def test_set_wrongtag(discovery_mock: Any) -> NoReturn:
 
 
 @patch("check_status.discovery")
-@patch("check_status.secretmanager")
 @patch("check_status.github")
-def test_set_check_calls(github_mock: Any, sm_mock: Any, discovery_mock: Any) -> NoReturn:
+def test_set_check_calls(github_mock: Any, discovery_mock: Any) -> NoReturn:
     service_mock = MagicMock()
     service_mock.projects = MagicMock(return_value=service_mock)
     service_mock.locations = MagicMock(return_value=service_mock)
@@ -109,12 +108,6 @@ def test_set_check_calls(github_mock: Any, sm_mock: Any, discovery_mock: Any) ->
         return_value=service_data(MOCK_SERVICE_NAME, [MOCK_PR_NUMBER])
     )
     discovery_mock.build = MagicMock(return_value=service_mock)
-
-    sm_mock = MagicMock()
-    sm_mock.SecretManagerServiceClient = MagicMock(return_value=sm_mock)
-    sm_mock.access_secret_version = MagicMock(return_value=sm_mock)
-    sm_mock.payload = PropertyMock(return_value="TEST")
-    sm_mock.decode = PropertyMock(return_value=b"foobar")
 
     gh_mock = MagicMock()
     gh_mock.get_repo = MagicMock(return_value=gh_mock)


### PR DESCRIPTION
## Description

Fixes #5009

* Migrates from secret manager API to built-in secrets for Cloud Build 
* Removes `gcloud` dependency and uses discovery API for service updating/tag removing. 

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/.github/CODEOWNERS) with the codeowners for this sample
