### PR TITLE
fix: Remove invalid --async flag from functions command

### DIFF
--- a/auth/service-to-service/auth_test.py
+++ b/auth/service-to-service/auth_test.py
@@ -97,7 +97,6 @@ def services():
         [
             "gcloud", "functions", "delete", f"helloworld-{suffix}",
             "--project", project,
-            "--async",
             "--region=us-central1",
             "--quiet",
          ],


### PR DESCRIPTION
Remove invalid --async flag from functions command.

## Description

Fixes #7111

I meant to add this flag to the Cloud Run commands to fix the flaky test, but accidentally also added it to a functions command.  