### PR TITLE
Upgrade pandas in BQ samples lagging in python 3.10

### DIFF
--- a/bigquery/bqml/requirements.txt
+++ b/bigquery/bqml/requirements.txt
@@ -1,7 +1,7 @@
 google-cloud-bigquery[pandas,bqstorage]==2.30.1
 google-cloud-bigquery-storage==2.10.1
 pandas==1.1.5; python_version < '3.7'
-pandas==1.2.0; python_version > '3.6'
+pandas==1.3.4; python_version > '3.6'
 pyarrow==6.0.1
 flaky==3.7.0
 mock==4.0.3

--- a/bigquery/pandas-gbq-migration/requirements.txt
+++ b/bigquery/pandas-gbq-migration/requirements.txt
@@ -1,7 +1,7 @@
 google-cloud-bigquery==2.30.1
 google-cloud-bigquery-storage==2.10.1
 pandas==1.1.5; python_version < '3.7'
-pandas==1.2.4; python_version > '3.6'
+pandas==1.3.4; python_version > '3.6'
 pandas-gbq==0.15.0; python_version > '3.6'
 pandas-gbq==0.14.1; python_version < '3.7'
 pyarrow==6.0.1


### PR DESCRIPTION
## Description

Fixes #7037 

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
