### PR TITLE
docs: Change Python client examples from sample_task to sampleTask

### DIFF
--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -150,7 +150,7 @@ def incomplete_key(client):
 
 def named_key(client):
     # [START datastore_named_key]
-    key = client.key("Task", "sample_task")
+    key = client.key("Task", "sampleTask")
     # [END datastore_named_key]
 
     return key
@@ -158,10 +158,10 @@ def named_key(client):
 
 def key_with_parent(client):
     # [START datastore_key_with_parent]
-    key = client.key("TaskList", "default", "Task", "sample_task")
+    key = client.key("TaskList", "default", "Task", "sampleTask")
     # Alternatively
     parent_key = client.key("TaskList", "default")
-    key = client.key("Task", "sample_task", parent=parent_key)
+    key = client.key("Task", "sampleTask", parent=parent_key)
     # [END datastore_key_with_parent]
 
     return key
@@ -169,7 +169,7 @@ def key_with_parent(client):
 
 def key_with_multilevel_parent(client):
     # [START datastore_key_with_multilevel_parent]
-    key = client.key("User", "alice", "TaskList", "default", "Task", "sample_task")
+    key = client.key("User", "alice", "TaskList", "default", "Task", "sampleTask")
     # [END datastore_key_with_multilevel_parent]
 
     return key
@@ -193,7 +193,7 @@ def basic_entity(client):
 
 def entity_with_parent(client):
     # [START datastore_entity_with_parent]
-    key_with_parent = client.key("TaskList", "default", "Task", "sample_task")
+    key_with_parent = client.key("TaskList", "default", "Task", "sampleTask")
 
     task = datastore.Entity(key=key_with_parent)
 
@@ -241,7 +241,7 @@ def array_value(client):
 
 def upsert(client):
     # [START datastore_upsert]
-    complete_key = client.key("Task", "sample_task")
+    complete_key = client.key("Task", "sampleTask")
 
     task = datastore.Entity(key=complete_key)
 

--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -288,7 +288,7 @@ def update(client):
 
     # [START datastore_update]
     with client.transaction():
-        key = client.key("Task", "sample_task")
+        key = client.key("Task", "sampleTask")
         task = client.get(key)
 
         task["done"] = True
@@ -304,7 +304,7 @@ def lookup(client):
     upsert(client)
 
     # [START datastore_lookup]
-    key = client.key("Task", "sample_task")
+    key = client.key("Task", "sampleTask")
     task = client.get(key)
     # [END datastore_lookup]
 
@@ -316,7 +316,7 @@ def delete(client):
     upsert(client)
 
     # [START datastore_delete]
-    key = client.key("Task", "sample_task")
+    key = client.key("Task", "sampleTask")
     client.delete(key)
     # [END datastore_delete]
 

--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -767,7 +767,9 @@ def transactional_update(client):
 def transactional_get_or_create(client):
     # [START datastore_transactional_get_or_create]
     with client.transaction():
-        key = client.key("Task", datetime.datetime.now(tz=datetime.timezone.utc).isoformat())
+        key = client.key(
+            "Task", datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+        )
 
         task = client.get(key)
 

--- a/datastore/cloud-client/snippets_test.py
+++ b/datastore/cloud-client/snippets_test.py
@@ -97,7 +97,6 @@ class TestDatastoreSnippets:
         task = snippets.insert(client)
         client.entities_to_delete.append(task)
         assert task
-        assert task.key.name == "sampleTask"
 
     def test_lookup(self, client):
         task = snippets.lookup(client)

--- a/datastore/cloud-client/snippets_test.py
+++ b/datastore/cloud-client/snippets_test.py
@@ -50,18 +50,30 @@ class TestDatastoreSnippets:
         assert snippets.incomplete_key(client)
 
     def test_named_key(self, client):
-        assert snippets.named_key(client)
+        key = snippets.named_key(client)
+        assert key
+        assert key.name == "sampleTask"
 
     def test_key_with_parent(self, client):
-        assert snippets.key_with_parent(client)
+        key = snippets.key_with_parent(client)
+        assert key
+        assert key.name == "sampleTask"
+        assert key.parent.name == "default"
 
     def test_key_with_multilevel_parent(self, client):
-        assert snippets.key_with_multilevel_parent(client)
+        key = snippets.key_with_multilevel_parent(client)
+        assert key
+        assert key.name == "sampleTask"
+        assert key.parent.name == "default"
+        assert key.parent.parent.name == "alice"
 
     def test_basic_entity(self, client):
         assert snippets.basic_entity(client)
 
     def test_entity_with_parent(self, client):
+        task = snippets.entity_with_parent(client)
+        assert task
+        assert task.key.name == "sampleTask"
         assert snippets.entity_with_parent(client)
 
     def test_properties(self, client):
@@ -74,6 +86,7 @@ class TestDatastoreSnippets:
         task = snippets.upsert(client)
         client.entities_to_delete.append(task)
         assert task
+        assert task.key.name == "sampleTask"
 
     def test_insert(self, client):
         task = snippets.insert(client)
@@ -84,11 +97,13 @@ class TestDatastoreSnippets:
         task = snippets.insert(client)
         client.entities_to_delete.append(task)
         assert task
+        assert task.key.name == "sampleTask"
 
     def test_lookup(self, client):
         task = snippets.lookup(client)
         client.entities_to_delete.append(task)
         assert task
+        assert task.key.name == "sampleTask"
 
     def test_delete(self, client):
         snippets.delete(client)


### PR DESCRIPTION

## Description

The examples in other client libraries are all using `sampleTask`.

Additionally, the doc says: 
> The following example creates a key with kind Task using a key name, "sampleTask", as the identifier:

Closes internal bug 210583283

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
