### PR TITLE
Cleanup cluster if error during creation

### DIFF
--- a/data-science-onramp/data-ingestion/ingestion.py
+++ b/data-science-onramp/data-ingestion/ingestion.py
@@ -218,6 +218,8 @@ def main():
 
     print("Uploading citibike dataset...")
     write_to_bigquery(df, CITIBIKE_TABLE_NAME, DATASET_NAME)
+
+
 # [END datascienceonramp_data_ingestion]
 
 

--- a/data-science-onramp/data-ingestion/ingestion_test.py
+++ b/data-science-onramp/data-ingestion/ingestion_test.py
@@ -20,6 +20,7 @@ import os
 import re
 import uuid
 
+from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from google.cloud import dataproc_v1 as dataproc
@@ -73,25 +74,37 @@ DATAPROC_JOB = {  # Dataproc job configuration
 
 @pytest.fixture(autouse=True)
 def setup_and_teardown_cluster():
-    # Create cluster using cluster client
-    cluster_client = dataproc.ClusterControllerClient(
-        client_options={"api_endpoint": f"{CLUSTER_REGION}-dataproc.googleapis.com:443"}
-    )
+    try:
+        # Create cluster using cluster client
+        cluster_client = dataproc.ClusterControllerClient(
+            client_options={"api_endpoint": f"{CLUSTER_REGION}-dataproc.googleapis.com:443"}
+        )
 
-    operation = cluster_client.create_cluster(
-        project_id=PROJECT_ID, region=CLUSTER_REGION, cluster=CLUSTER_CONFIG
-    )
+        operation = cluster_client.create_cluster(
+            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster=CLUSTER_CONFIG
+        )
 
-    # Wait for cluster to provision
-    operation.result()
+        # Wait for cluster to provision
+        operation.result()
+    except InternalServerError as e:
+        # Clean up leftovers if there is an error creating the fixture
+        operation = cluster_client.delete_cluster(
+            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
+        )
+        operation.result()
+        raise e
+
 
     yield
 
-    # Delete cluster
-    operation = cluster_client.delete_cluster(
-        project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
-    )
-    operation.result()
+    try:
+        # Delete cluster
+        operation = cluster_client.delete_cluster(
+            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
+        )
+        operation.result()
+    except NotFound:
+        print("Cluster already deleted")
 
 
 @pytest.fixture(autouse=True)

--- a/data-science-onramp/data-ingestion/ingestion_test.py
+++ b/data-science-onramp/data-ingestion/ingestion_test.py
@@ -77,7 +77,9 @@ def setup_and_teardown_cluster():
     try:
         # Create cluster using cluster client
         cluster_client = dataproc.ClusterControllerClient(
-            client_options={"api_endpoint": f"{CLUSTER_REGION}-dataproc.googleapis.com:443"}
+            client_options={
+                "api_endpoint": f"{CLUSTER_REGION}-dataproc.googleapis.com:443"
+            }
         )
 
         operation = cluster_client.create_cluster(
@@ -93,7 +95,6 @@ def setup_and_teardown_cluster():
         )
         operation.result()
         raise e
-
 
     yield
 

--- a/data-science-onramp/data-ingestion/ingestion_test.py
+++ b/data-science-onramp/data-ingestion/ingestion_test.py
@@ -20,7 +20,6 @@ import os
 import re
 import uuid
 
-from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from google.cloud import dataproc_v1 as dataproc
@@ -88,24 +87,17 @@ def setup_and_teardown_cluster():
 
         # Wait for cluster to provision
         operation.result()
-    except InternalServerError as e:
-        # Clean up leftovers if there is an error creating the fixture
-        operation = cluster_client.delete_cluster(
-            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
-        )
-        operation.result()
-        raise e
 
-    yield
-
-    try:
-        # Delete cluster
-        operation = cluster_client.delete_cluster(
-            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
-        )
-        operation.result()
-    except NotFound:
-        print("Cluster already deleted")
+        yield
+    finally:
+        try:
+            # Delete cluster
+            operation = cluster_client.delete_cluster(
+                project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
+            )
+            operation.result()
+        except NotFound:
+            print("Cluster already deleted")
 
 
 @pytest.fixture(autouse=True)

--- a/data-science-onramp/data-processing/process.py
+++ b/data-science-onramp/data-processing/process.py
@@ -168,14 +168,14 @@ if __name__ == "__main__":
     except Py4JJavaError as e:
         raise Exception(f"Error reading {TABLE}") from e
 
-# [END datascienceonramp_sparksession]
+    # [END datascienceonramp_sparksession]
 
-# [START datascienceonramp_removecolumn]
+    # [START datascienceonramp_removecolumn]
     # remove unused column
     df = df.drop("gender")
-# [END datascienceonramp_removecolumn]
+    # [END datascienceonramp_removecolumn]
 
-# [START datascienceonramp_sparksingleudfs]
+    # [START datascienceonramp_sparksingleudfs]
     # Single-parameter udfs
     udfs = {
         "start_station_name": UserDefinedFunction(station_name_udf, StringType()),

--- a/data-science-onramp/data-processing/process_test.py
+++ b/data-science-onramp/data-processing/process_test.py
@@ -17,7 +17,6 @@ import os
 import re
 import uuid
 
-from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
 from google.cloud import dataproc_v1 as dataproc
@@ -119,24 +118,16 @@ def setup_and_teardown_cluster():
 
         # Wait for cluster to provision
         operation.result()
-    except InternalServerError as e:
-        # Clean up leftovers if there is an error creating the fixture
-        operation = cluster_client.delete_cluster(
-            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
-        )
-        operation.result()
-        raise e
-
-    yield
-
-    try:
-        # Delete cluster
-        operation = cluster_client.delete_cluster(
-            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
-        )
-        operation.result()
-    except NotFound:
-        print("Cluster already deleted")
+        yield
+    finally:
+        try:
+            # Delete cluster
+            operation = cluster_client.delete_cluster(
+                project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
+            )
+            operation.result()
+        except NotFound:
+            print("Cluster already deleted")
 
 
 @pytest.fixture(autouse=True)

--- a/data-science-onramp/data-processing/process_test.py
+++ b/data-science-onramp/data-processing/process_test.py
@@ -109,7 +109,9 @@ def setup_and_teardown_cluster():
     try:
         # Create Dataproc cluster using cluster client
         cluster_client = dataproc.ClusterControllerClient(
-            client_options={"api_endpoint": f"{CLUSTER_REGION}-dataproc.googleapis.com:443"}
+            client_options={
+                "api_endpoint": f"{CLUSTER_REGION}-dataproc.googleapis.com:443"
+            }
         )
         operation = cluster_client.create_cluster(
             project_id=PROJECT_ID, region=CLUSTER_REGION, cluster=CLUSTER_CONFIG
@@ -130,9 +132,7 @@ def setup_and_teardown_cluster():
     try:
         # Delete cluster
         operation = cluster_client.delete_cluster(
-            project_id=PROJECT_ID,
-            region=CLUSTER_REGION,
-            cluster_name=DATAPROC_CLUSTER
+            project_id=PROJECT_ID, region=CLUSTER_REGION, cluster_name=DATAPROC_CLUSTER
         )
         operation.result()
     except NotFound:


### PR DESCRIPTION
## Description

We currently are having problems with dataproc clusters in our test environment (see b/211687420 if you're internal) and I figured out that these tests had leftovers if the dataproc fixtures failed which meant we were hitting quotas. This cleans up the leftovers if theres an error creating the cluster and still raises the error.

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
