### PR TITLE
Noxfile check for tests

### DIFF
--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -39,17 +39,15 @@ import nox
 
 TEST_CONFIG = {
     # You can opt out from the test for specific Python versions.
-    'ignored_versions': ["2.7"],
-
+    "ignored_versions": ["2.7"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
-    'enforce_type_hints': False,
-
+    "enforce_type_hints": False,
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
     # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
@@ -57,13 +55,13 @@ TEST_CONFIG = {
     "pip_version_override": None,
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
-    'envs': {},
+    "envs": {},
 }
 
 
 try:
     # Ensure we can import noxfile_config in the project's directory.
-    sys.path.append('.')
+    sys.path.append(".")
     from noxfile_config import TEST_CONFIG_OVERRIDE
 except ImportError as e:
     print("No user noxfile_config found: detail: {}".format(e))
@@ -78,13 +76,13 @@ def get_pytest_env_vars() -> Dict[str, str]:
     ret = {}
 
     # Override the GCLOUD_PROJECT and the alias.
-    env_key = TEST_CONFIG['gcloud_project_env']
+    env_key = TEST_CONFIG["gcloud_project_env"]
     # This should error out if not set.
-    ret['GOOGLE_CLOUD_PROJECT'] = os.environ[env_key]
-    ret['GCLOUD_PROJECT'] = os.environ[env_key]  # deprecated
+    ret["GOOGLE_CLOUD_PROJECT"] = os.environ[env_key]
+    ret["GCLOUD_PROJECT"] = os.environ[env_key]  # deprecated
 
     # Apply user supplied envs.
-    ret.update(TEST_CONFIG['envs'])
+    ret.update(TEST_CONFIG["envs"])
     return ret
 
 
@@ -93,7 +91,7 @@ def get_pytest_env_vars() -> Dict[str, str]:
 ALL_VERSIONS = ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
 # Any default versions that should be ignored.
-IGNORED_VERSIONS = TEST_CONFIG['ignored_versions']
+IGNORED_VERSIONS = TEST_CONFIG["ignored_versions"]
 
 TESTED_VERSIONS = sorted([v for v in ALL_VERSIONS if v not in IGNORED_VERSIONS])
 
@@ -146,7 +144,7 @@ FLAKE8_COMMON_ARGS = [
 
 @nox.session
 def lint(session: nox.sessions.Session) -> None:
-    if not TEST_CONFIG['enforce_type_hints']:
+    if not TEST_CONFIG["enforce_type_hints"]:
         session.install("flake8", "flake8-import-order")
     else:
         session.install("flake8", "flake8-import-order", "flake8-annotations")
@@ -155,7 +153,7 @@ def lint(session: nox.sessions.Session) -> None:
     args = FLAKE8_COMMON_ARGS + [
         "--application-import-names",
         ",".join(local_names),
-        "."
+        ".",
     ]
     session.run("flake8", *args)
 
@@ -163,6 +161,7 @@ def lint(session: nox.sessions.Session) -> None:
 #
 # Black
 #
+
 
 @nox.session
 def blacken(session: nox.sessions.Session) -> None:
@@ -180,7 +179,9 @@ def blacken(session: nox.sessions.Session) -> None:
 PYTEST_COMMON_ARGS = ["--junitxml=sponge_log.xml"]
 
 
-def _session_tests(session: nox.sessions.Session, post_install: Callable = None) -> None:
+def _session_tests(
+    session: nox.sessions.Session, post_install: Callable = None
+) -> None:
     # check for presence of tests
     test_list = glob.glob("*_test.py")
     if len(test_list) == 0:
@@ -198,7 +199,9 @@ def _session_tests(session: nox.sessions.Session, post_install: Callable = None)
 
         if os.path.exists("requirements-test.txt"):
             if os.path.exists("constraints-test.txt"):
-                session.install("-r", "requirements-test.txt", "-c", "constraints-test.txt")
+                session.install(
+                    "-r", "requirements-test.txt", "-c", "constraints-test.txt"
+                )
             else:
                 session.install("-r", "requirements-test.txt")
 
@@ -215,7 +218,7 @@ def _session_tests(session: nox.sessions.Session, post_install: Callable = None)
             # on travis where slow and flaky tests are excluded.
             # See http://doc.pytest.org/en/latest/_modules/_pytest/main.html
             success_codes=[0, 5],
-            env=get_pytest_env_vars()
+            env=get_pytest_env_vars(),
         )
 
 
@@ -225,9 +228,9 @@ def py(session: nox.sessions.Session) -> None:
     if session.python in TESTED_VERSIONS:
         _session_tests(session)
     else:
-        session.skip("SKIPPED: {} tests are disabled for this sample.".format(
-            session.python
-        ))
+        session.skip(
+            "SKIPPED: {} tests are disabled for this sample.".format(session.python)
+        )
 
 
 #
@@ -236,7 +239,7 @@ def py(session: nox.sessions.Session) -> None:
 
 
 def _get_repo_root() -> Optional[str]:
-    """ Returns the root folder of the project. """
+    """Returns the root folder of the project."""
     # Get root of this repository.
     # Assume we don't have directories nested deeper than 10 items.
     p = Path(os.getcwd())

--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -183,7 +183,7 @@ def _session_tests(
     session: nox.sessions.Session, post_install: Callable = None
 ) -> None:
     # check for presence of tests
-    test_list = glob.glob("*_test.py")
+    test_list = glob.glob("*_test.py") + glob.glob("test_*.py")
     if len(test_list) == 0:
         print("No tests found, skipping directory.")
     else:

--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import glob
 import os
 from pathlib import Path
 import sys
@@ -180,37 +181,42 @@ PYTEST_COMMON_ARGS = ["--junitxml=sponge_log.xml"]
 
 
 def _session_tests(session: nox.sessions.Session, post_install: Callable = None) -> None:
-    if TEST_CONFIG["pip_version_override"]:
-        pip_version = TEST_CONFIG["pip_version_override"]
-        session.install(f"pip=={pip_version}")
-    """Runs py.test for a particular project."""
-    if os.path.exists("requirements.txt"):
-        if os.path.exists("constraints.txt"):
-            session.install("-r", "requirements.txt", "-c", "constraints.txt")
-        else:
-            session.install("-r", "requirements.txt")
+    # check for presence of tests
+    test_list = glob.glob("_test.py")
+    if len(test_list) == 0:
+        print("No tests found, skipping directory.")
+    else:
+        if TEST_CONFIG["pip_version_override"]:
+            pip_version = TEST_CONFIG["pip_version_override"]
+            session.install(f"pip=={pip_version}")
+        """Runs py.test for a particular project."""
+        if os.path.exists("requirements.txt"):
+            if os.path.exists("constraints.txt"):
+                session.install("-r", "requirements.txt", "-c", "constraints.txt")
+            else:
+                session.install("-r", "requirements.txt")
 
-    if os.path.exists("requirements-test.txt"):
-        if os.path.exists("constraints-test.txt"):
-            session.install("-r", "requirements-test.txt", "-c", "constraints-test.txt")
-        else:
-            session.install("-r", "requirements-test.txt")
+        if os.path.exists("requirements-test.txt"):
+            if os.path.exists("constraints-test.txt"):
+                session.install("-r", "requirements-test.txt", "-c", "constraints-test.txt")
+            else:
+                session.install("-r", "requirements-test.txt")
 
-    if INSTALL_LIBRARY_FROM_SOURCE:
-        session.install("-e", _get_repo_root())
+        if INSTALL_LIBRARY_FROM_SOURCE:
+            session.install("-e", _get_repo_root())
 
-    if post_install:
-        post_install(session)
+        if post_install:
+            post_install(session)
 
-    session.run(
-        "pytest",
-        *(PYTEST_COMMON_ARGS + session.posargs),
-        # Pytest will return 5 when no tests are collected. This can happen
-        # on travis where slow and flaky tests are excluded.
-        # See http://doc.pytest.org/en/latest/_modules/_pytest/main.html
-        success_codes=[0, 5],
-        env=get_pytest_env_vars()
-    )
+        session.run(
+            "pytest",
+            *(PYTEST_COMMON_ARGS + session.posargs),
+            # Pytest will return 5 when no tests are collected. This can happen
+            # on travis where slow and flaky tests are excluded.
+            # See http://doc.pytest.org/en/latest/_modules/_pytest/main.html
+            success_codes=[0, 5],
+            env=get_pytest_env_vars()
+        )
 
 
 @nox.session(python=ALL_VERSIONS)

--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -182,7 +182,7 @@ PYTEST_COMMON_ARGS = ["--junitxml=sponge_log.xml"]
 
 def _session_tests(session: nox.sessions.Session, post_install: Callable = None) -> None:
     # check for presence of tests
-    test_list = glob.glob("_test.py")
+    test_list = glob.glob("*_test.py")
     if len(test_list) == 0:
         print("No tests found, skipping directory.")
     else:


### PR DESCRIPTION
This adds a check to the noxfile to see if there are tests in the directory. To test, use the noxfile-template in any directory with tests. Then try it on a directory like [this one](https://github.com/nikitamaia/python-docs-samples/tree/geospatial-sandbox/people-and-planet-ai/geospatial-classification/serving_app) which is found in PR #7291. This does assume that all tests are of the format `*_test.py` - if we want, I can also include a check for `test_*.py`, because I know that's a common Python pattern even though it's not the one we use. 

Corresponding PR in synthtool https://github.com/googleapis/synthtool/pull/1321


cc @davidcavazos - this will hopefully remove the need for your workaround