### PR TITLE
chore(deps): update pytest to 6.2.5 and add note for Python2 pins

### DIFF
--- a/appengine/standard/analytics/requirements-test.txt
+++ b/appengine/standard/analytics/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 responses==0.17.0

--- a/appengine/standard/blobstore/blobreader/requirements-test.txt
+++ b/appengine/standard/blobstore/blobreader/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/blobstore/gcs/requirements-test.txt
+++ b/appengine/standard/blobstore/gcs/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/django/requirements-test.txt
+++ b/appengine/standard/django/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 pytest-django==3.10.0; python_version < '3.0'

--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements-test.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/endpoints-frameworks-v2/iata/requirements-test.txt
+++ b/appengine/standard/endpoints-frameworks-v2/iata/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/endpoints-frameworks-v2/quickstart/requirements-test.txt
+++ b/appengine/standard/endpoints-frameworks-v2/quickstart/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/firebase/firenotes/backend/requirements-test.txt
+++ b/appengine/standard/firebase/firenotes/backend/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/firebase/firetactoe/requirements-test.txt
+++ b/appengine/standard/firebase/firetactoe/requirements-test.txt
@@ -1,3 +1,4 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'
 mock==3.0.5; python_version < "3"

--- a/appengine/standard/flask/tutorial/requirements-test.txt
+++ b/appengine/standard/flask/tutorial/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/iap/requirements-test.txt
+++ b/appengine/standard/iap/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/mailgun/requirements-test.txt
+++ b/appengine/standard/mailgun/requirements-test.txt
@@ -1,3 +1,4 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 google-api-python-client==1.12.8; python_version < '3.0'
 mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/mailjet/requirements-test.txt
+++ b/appengine/standard/mailjet/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 responses==0.17.0

--- a/appengine/standard/migration/incoming/requirements-test.txt
+++ b/appengine/standard/migration/incoming/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/migration/memorystore/requirements-test.txt
+++ b/appengine/standard/migration/memorystore/requirements-test.txt
@@ -1,3 +1,4 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 mock==4.0.3; python_version > '3.0'
 mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/migration/ndb/overview/requirements-test.txt
+++ b/appengine/standard/migration/ndb/overview/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/migration/ndb/redis_cache/requirements-test.txt
+++ b/appengine/standard/migration/ndb/redis_cache/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/migration/storage/requirements-test.txt
+++ b/appengine/standard/migration/storage/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/migration/taskqueue/counter/requirements-test.txt
+++ b/appengine/standard/migration/taskqueue/counter/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==6.1.1 ; python_version >= "3.0"
+pytest==6.2.5 ; python_version >= "3.0"
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11 ; python_version < "3.0"

--- a/appengine/standard/migration/taskqueue/pull-counter/requirements-test.txt
+++ b/appengine/standard/migration/taskqueue/pull-counter/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==6.1.1 ; python_version >= "3.0"
+pytest==6.2.5 ; python_version >= "3.0"
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11 ; python_version < "3.0"

--- a/appengine/standard/migration/urlfetch/async/requirements-test.txt
+++ b/appengine/standard/migration/urlfetch/async/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/migration/urlfetch/requests/requirements-test.txt
+++ b/appengine/standard/migration/urlfetch/requests/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/ndb/transactions/requirements-test.txt
+++ b/appengine/standard/ndb/transactions/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/pubsub/requirements-test.txt
+++ b/appengine/standard/pubsub/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/appengine/standard/sendgrid/requirements-test.txt
+++ b/appengine/standard/sendgrid/requirements-test.txt
@@ -1,3 +1,4 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 mock==3.0.5; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/storage/api-client/requirements-test.txt
+++ b/appengine/standard/storage/api-client/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/storage/appengine-client/requirements-test.txt
+++ b/appengine/standard/storage/appengine-client/requirements-test.txt
@@ -1,2 +1,3 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/urlfetch/requests/requirements-test.txt
+++ b/appengine/standard/urlfetch/requests/requirements-test.txt
@@ -1,1 +1,2 @@
+# pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'

--- a/functions/imagemagick/requirements-dev.txt
+++ b/functions/imagemagick/requirements-dev.txt
@@ -2,4 +2,5 @@ mock==3.0.5
 six==1.12.0
 uuid==1.30
 pytest==5.3.0; python_version > "3.0"
+# pin pytest to 4.6.11 or lower for Python2.
 pytest==4.6.6; python_version < "3.0"

--- a/run/hello-broken/requirements.txt
+++ b/run/hello-broken/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.0.2
-pytest==5.3.0; python_version > "3.0"
-pytest==4.6.6; python_version < "3.0"
+pytest==6.2.5; python_version > "3.0"
+# pin pytest to 4.6.11 for Python2.
+pytest==4.6.11; python_version < "3.0"
 gunicorn==20.1.0

--- a/run/image-processing/requirements.txt
+++ b/run/image-processing/requirements.txt
@@ -1,6 +1,7 @@
 Flask==2.0.2
-pytest==5.3.0; python_version > "3.0"
-pytest==4.6.6; python_version < "3.0"
+pytest==6.2.5; python_version > "3.0"
+# pin pytest to 4.6.11 for Python2.
+pytest==4.6.11; python_version < "3.0"
 gunicorn==20.1.0
 google-cloud-vision==2.6.3
 google-cloud-storage==1.43.0

--- a/run/logging-manual/requirements.txt
+++ b/run/logging-manual/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.0.2
-pytest==5.3.2; python_version > "3.0"
-pytest==5.3.2; python_version < "3.0"
+pytest==6.2.5; python_version > "3.0"
+# pin pytest to 4.6.11 for Python2.
+pytest==4.6.11; python_version < "3.0"
 gunicorn==20.1.0

--- a/run/pubsub/requirements.txt
+++ b/run/pubsub/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.0.2
-pytest==5.3.2; python_version > "3.0"
-pytest==5.3.2; python_version < "3.0"
+pytest==6.2.5; python_version > "3.0"
+# pin pytest to 4.6.11 for Python2.
+pytest==4.6.11; python_version < "3.0"
 gunicorn==20.1.0


### PR DESCRIPTION
## Description

I closed #7333 where it tried to update pytest for Python 2 versions. The latest supported version is 4.6.11. Pinned this information for Python2 pins, and updating other ones that Renovate tried to update to 6.2.5 version.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved.
