### PR TITLE
doc: Update env variable mentioned in Authoring Guide

### DIFF
--- a/AUTHORING_GUIDE.md
+++ b/AUTHORING_GUIDE.md
@@ -640,7 +640,7 @@ We suggest that you copy this file as follows:
 
 ```sh
 $ cp testing/test-env.tmpl.sh testing/test-env.sh
-$ editor testing/test-env.sh  # change the value of `GCLOUD_PROJECT`.
+$ editor testing/test-env.sh  # change the value of `GOOGLE_CLOUD_PROJECT`.
 ```
 
 You can easily `source` this file for exporting the environment variables.


### PR DESCRIPTION
The correct value to be changed in `testing/test-env.sh` is `GOOGLE_CLOUD_PROJECT`
instead of `GCLOUD_PROJECT`.

Source:

https://github.com/GoogleCloudPlatform/python-docs-samples/blob/1d6736bd49778b2440e348890ec444d785c4fb60/testing/test-env.tmpl.sh#L16

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
