### PR TITLE
remove numpy version for 3.6

### DIFF
--- a/people-and-planet-ai/geospatial-classification/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements.txt
@@ -1,5 +1,4 @@
 numpy==1.21.4; python_version > "3.6"
-numpy==1.19.5; python_version <= "3.6"
 tensorflow==2.7.0
 earthengine-api==0.1.292
 pytest==6.2.4


### PR DESCRIPTION
this sample omits 3.6 anyway, so we can remove this vulnerable version of numpy as a requirement
