### PR TITLE
dataflow: add custom container minimal sample

### DIFF
--- a/dataflow/custom-containers/README.md
+++ b/dataflow/custom-containers/README.md
@@ -1,0 +1,7 @@
+# Dataflow custom containers
+
+These samples show some common use cases when creating custom container images for the Dataflow workers.
+
+For more information, see [Using custom containers in Dataflow](https://cloud.google.com/dataflow/docs/guides/using-custom-containers) in the docs.
+
+For examples on creating custom containers with GPU support, look in the [`gpu-examples`](../gpu-examples) directory.

--- a/dataflow/custom-containers/minimal/Dockerfile
+++ b/dataflow/custom-containers/minimal/Dockerfile
@@ -14,13 +14,14 @@
 
 FROM python:3.8-slim
 
-COPY requirements.txt .
-COPY main.py ./
-
-# Install the requirements.
-RUN pip install --no-cache-dir -r requirements.txt \
-    && pip check
-
 # Set the entrypoint to Apache Beam SDK worker launcher.
 COPY --from=apache/beam_python3.8_sdk:2.35.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]
+
+# Install the requirements.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip check
+
+# Copy the pipeline source files.
+COPY main.py ./

--- a/dataflow/custom-containers/minimal/Dockerfile
+++ b/dataflow/custom-containers/minimal/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.8-slim
+
+COPY requirements.txt .
+COPY main.py ./
+
+# Install the requirements.
+RUN pip install --no-cache-dir -r requirements.txt \
+    && pip check
+
+# Set the entrypoint to Apache Beam SDK worker launcher.
+COPY --from=apache/beam_python3.8_sdk:2.35.0 /opt/apache/beam /opt/apache/beam
+ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/custom-containers/minimal/e2e_test.py
+++ b/dataflow/custom-containers/minimal/e2e_test.py
@@ -48,6 +48,6 @@ def test_tensorflow_minimal(
             f"--region={utils.region}",
             f"--temp_location=gs://{bucket_name}",
             f"--sdk_container_image={container_image}",
-            f"--experiment=use_runner_v2",
+            "--experiment=use_runner_v2",
         ]
     )

--- a/dataflow/custom-containers/minimal/e2e_test.py
+++ b/dataflow/custom-containers/minimal/e2e_test.py
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import subprocess
+
 try:
     # `conftest` cannot be imported when running in `nox`, but we still
     # try to import it for the autocomplete when writing the tests.
     from conftest import Utils
 except ModuleNotFoundError:
     Utils = None
-import subprocess
 import pytest
 
 NAME = "dataflow/custom-containers/minimal"

--- a/dataflow/custom-containers/minimal/e2e_test.py
+++ b/dataflow/custom-containers/minimal/e2e_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    # `conftest` cannot be imported when running in `nox`, but we still
+    # try to import it for the autocomplete when writing the tests.
+    from conftest import Utils
+except ModuleNotFoundError:
+    Utils = None
+import subprocess
+import pytest
+
+NAME = "dataflow/custom-containers/minimal"
+
+
+@pytest.fixture(scope="session")
+def bucket_name(utils: Utils) -> str:
+    yield from utils.storage_bucket(NAME)
+
+
+@pytest.fixture(scope="session")
+def container_image(utils: Utils) -> str:
+    yield from utils.cloud_build_submit(image_name=NAME)
+
+
+def test_tensorflow_minimal(
+    utils: Utils, bucket_name: str, container_image: str
+) -> None:
+    subprocess.check_call(
+        [
+            "python",
+            "main.py",
+            "--runner=DataflowRunner",
+            f"--project={utils.project}",
+            f"--region={utils.region}",
+            f"--temp_location=gs://{bucket_name}",
+            f"--sdk_container_image={container_image}",
+            f"--experiment=use_runner_v2",
+        ]
+    )

--- a/dataflow/custom-containers/minimal/main.py
+++ b/dataflow/custom-containers/minimal/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/dataflow/custom-containers/minimal/main.py
+++ b/dataflow/custom-containers/minimal/main.py
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import platform
+
+import apache_beam as beam
+
+
+def run():
+    with beam.Pipeline() as pipeline:
+        (
+            pipeline
+            | "Create data" >> beam.Create(["Hello", "World!", platform.platform()])
+            | "Print" >> beam.Map(logging.info)
+        )
+
+
+if __name__ == "__main__":
+    logging.getLogger().setLevel(logging.INFO)
+    run()

--- a/dataflow/custom-containers/minimal/main.py
+++ b/dataflow/custom-containers/minimal/main.py
@@ -20,7 +20,7 @@ import platform
 import apache_beam as beam
 
 
-def run():
+def run() -> None:
     with beam.Pipeline() as pipeline:
         (
             pipeline

--- a/dataflow/custom-containers/minimal/noxfile_config.py
+++ b/dataflow/custom-containers/minimal/noxfile_config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dataflow/custom-containers/minimal/noxfile_config.py
+++ b/dataflow/custom-containers/minimal/noxfile_config.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default TEST_CONFIG_OVERRIDE for python repos.
+
+# You can copy this file into your directory, then it will be imported from
+# the noxfile.py.
+
+# The source of truth:
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/noxfile_config.py
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    # > ℹ️ We're opting out of all Python versions except 3.8.
+    # > The Python version used is defined by the Dockerfile, so it's redundant
+    # > to run multiple tests since they would all be running the same Dockerfile.
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.10"],
+    # Old samples are opted out of enforcing Python type hints
+    # All new samples should feature them
+    "enforce_type_hints": True,
+    # An envvar key for determining the project id to use. Change it
+    # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
+    # build specific Cloud project. You can also use your own string
+    # to use your own Cloud project.
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    # If you need to use a specific version of pip,
+    # change pip_version_override to the string representation
+    # of the version number, for example, "20.2.4"
+    "pip_version_override": None,
+    # A dictionary you want to inject into your test. Don't put any
+    # secrets here. These values will override predefined values.
+    "envs": {},
+}

--- a/dataflow/custom-containers/minimal/requirements-test.txt
+++ b/dataflow/custom-containers/minimal/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest-xdist==2.5.0
+pytest==6.2.4

--- a/dataflow/custom-containers/minimal/requirements-test.txt
+++ b/dataflow/custom-containers/minimal/requirements-test.txt
@@ -1,2 +1,3 @@
+google-cloud-storage==1.43.0
 pytest-xdist==2.5.0
 pytest==6.2.4

--- a/dataflow/custom-containers/minimal/requirements.txt
+++ b/dataflow/custom-containers/minimal/requirements.txt
@@ -1,0 +1,1 @@
+apache-beam[gcp]==2.35.0


### PR DESCRIPTION
## Description

Add samples for Dataflow custom containers.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
