### PR TITLE
fix: remove redundant Airflow variable

### DIFF
--- a/composer/airflow_1_samples/dataflowtemplateoperator_tutorial.py
+++ b/composer/airflow_1_samples/dataflowtemplateoperator_tutorial.py
@@ -23,7 +23,6 @@ https://airflow.apache.org/docs/apache-airflow/stable/concepts/variables.html
 * project_id - Google Cloud Project ID to use for the Cloud Dataflow cluster.
 * gce_zone - Google Compute Engine zone where Cloud Dataflow cluster should be
   created.
-* gce_region - Google Compute Engine region where Cloud Dataflow cluster should be
   created.
 Learn more about the difference between the two here:
 https://cloud.google.com/compute/docs/regions-zones
@@ -40,7 +39,6 @@ from airflow.utils.dates import days_ago
 bucket_path = models.Variable.get("bucket_path")
 project_id = models.Variable.get("project_id")
 gce_zone = models.Variable.get("gce_zone")
-gce_region = models.Variable.get("gce_region")
 
 
 default_args = {
@@ -48,8 +46,6 @@ default_args = {
     "start_date": days_ago(1),
     "dataflow_default_options": {
         "project": project_id,
-        # Set to your region
-        "region": gce_region,
         # Set to your zone
         "zone": gce_zone,
         # This is a subfolder for storing temporary files, like the staged pipeline job.

--- a/composer/airflow_1_samples/dataflowtemplateoperator_tutorial_test.py
+++ b/composer/airflow_1_samples/dataflowtemplateoperator_tutorial_test.py
@@ -23,12 +23,10 @@ def set_variables(airflow_database):
     models.Variable.set("bucket_path", "gs://example_bucket")
     models.Variable.set("project_id", "example-project")
     models.Variable.set("gce_zone", "us-central1-f")
-    models.Variable.set("gce_region", "us-central1-f")
     yield
     models.Variable.delete('bucket_path')
     models.Variable.delete('project_id')
     models.Variable.delete('gce_zone')
-    models.Variable.delete('gce_region')
 
 
 def test_dag_import():


### PR DESCRIPTION
## Description
Removes a redundant parameter to match with the [Airflow 2 sample](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/composer/workflows/dataflowtemplateoperator_tutorial.py)
Fixes b/209830375 along with https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/2531
Dataflow job success: [job](https://pantheon.corp.google.com/dataflow/jobs/us-central1/2022-02-08_11_45_36-18254988095377204925?project=leah-playground) [screenshot](https://screenshot.googleplex.com/4FYdXpwAnkFFBSB)
DAG run success: [screenshot](https://screenshot.googleplex.com/6dxJuW55ZvyoNv9)
Note: It's a good idea to open an issue first for discussion. [airflow logs](https://de34b6bb073e6fc6cp-tp.appspot.com/admin/airflow/log?task_id=dataflow_operator_transform_csv_to_bq&dag_id=composer_dataflow_dag&execution_date=2022-02-08T19%3A45%3A13.041329%2B00%3A00&format=json)

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
