### PR TITLE
feat(iam): use Application Default Credentials (ADC) in IAM quickstart

### DIFF
--- a/iam/api-client/quickstart.py
+++ b/iam/api-client/quickstart.py
@@ -15,8 +15,6 @@
 # limitations under the License.
 
 # [START iam_quickstart]
-import os
-
 import google.auth
 import googleapiclient.discovery
 

--- a/iam/api-client/quickstart.py
+++ b/iam/api-client/quickstart.py
@@ -17,7 +17,7 @@
 # [START iam_quickstart]
 import os
 
-from google.oauth2 import service_account
+import google.auth
 import googleapiclient.discovery
 
 
@@ -39,7 +39,7 @@ def quickstart(project_id, member):
     print(f'Role: {(binding["role"])}')
     print("Members: ")
     for m in binding["members"]:
-        print(f'[{m}]')
+        print(f"[{m}]")
 
     # Removes the member from the 'Log Writer' role.
     modify_policy_remove_member(crm_service, project_id, role, member)
@@ -48,9 +48,8 @@ def quickstart(project_id, member):
 def initialize_service():
     """Initializes a Cloud Resource Manager service."""
 
-    credentials = service_account.Credentials.from_service_account_file(
-        filename=os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
-        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    credentials, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
     )
     crm_service = googleapiclient.discovery.build(
         "cloudresourcemanager", "v1", credentials=credentials
@@ -114,7 +113,7 @@ def set_policy(crm_service, project_id, policy):
     return policy
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # TODO: replace with your project ID
     project_id = "your-project-id"


### PR DESCRIPTION
ADC allows users to authenticate with methods other than a service account key—for example, with credentials for a Google Account created via `gcloud auth application-default login`.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
