### PR TITLE
chore(compute): Changing the default zone for compute api tests

### DIFF
--- a/compute/api/create_instance.py
+++ b/compute/api/create_instance.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
         'bucket_name', help='Your Google Cloud Storage bucket name.')
     parser.add_argument(
         '--zone',
-        default='europe-north1-b',
+        default='us-central1-f',
         help='Compute Engine zone to deploy to.')
     parser.add_argument(
         '--name', default='demo-instance', help='New instance name.')

--- a/compute/api/create_instance.py
+++ b/compute/api/create_instance.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
         'bucket_name', help='Your Google Cloud Storage bucket name.')
     parser.add_argument(
         '--zone',
-        default='us-central1-f',
+        default='europe-north1-b',
         help='Compute Engine zone to deploy to.')
     parser.add_argument(
         '--name', default='demo-instance', help='New instance name.')

--- a/compute/api/create_instance_test.py
+++ b/compute/api/create_instance_test.py
@@ -28,13 +28,13 @@ def test_main(capsys):
     main(
         PROJECT,
         BUCKET,
-        'us-central1-f',
+        'europe-north1-b',
         instance_name,
         wait=False)
 
     out, _ = capsys.readouterr()
 
     assert "Instances in project" in out
-    assert "zone us-central1-f" in out
+    assert "zone europe-north1-b" in out
     assert instance_name in out
     assert "Deleting instance" in out

--- a/compute/api/create_instance_test.py
+++ b/compute/api/create_instance_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google, Inc.
+# Copyright 2015 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
## Description

Fixes #7461 

I figure the `us-central1` is a bit overused, so there might be more race conditions when tests are running. Going away to Europe should reduce the risk of the race conditions/resource exhaustion.

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
