### PR TITLE
chore(deps): pin markupsafe version

### DIFF
--- a/composer/airflow_1_samples/requirements.txt
+++ b/composer/airflow_1_samples/requirements.txt
@@ -8,3 +8,4 @@ scipy==1.4.1; python_version > '3.0'
 scipy==1.2.3; python_version < '3.0'
 numpy==1.19.5; python_version > '3.0'
 numpy==1.16.6; python_version < '3.0'
+markupsafe==2.0.1

--- a/trace/cloud-trace-demo-app-opentelemetry/app/requirements.txt
+++ b/trace/cloud-trace-demo-app-opentelemetry/app/requirements.txt
@@ -1,5 +1,6 @@
 # Don't upgrade to 2.0.0 until opentelemtry-instrumentation-flask is okay with it
 Flask==1.1.4
+markupsafe==2.0.1
 opentelemetry-exporter-gcp-trace==1.0.0
 opentelemetry-propagator-gcp==1.1.0
 opentelemetry-instrumentation-flask==0.20b0

--- a/trace/cloud-trace-demo-app/app/requirements.txt
+++ b/trace/cloud-trace-demo-app/app/requirements.txt
@@ -3,6 +3,7 @@ google-cloud-trace==0.24.0
 opencensus==0.8.0
 # Don't upgrade to 2.0.0 yet until opencensus-ext-flask is okay with it
 Flask==1.1.4
+markupsafe==2.0.1
 opencensus-ext-stackdriver==0.8.0
 opencensus-ext-flask==0.7.6 # requires flask!=1.1.3, <2.0.0 and >=0.12.3
 opencensus-context==0.1.2


### PR DESCRIPTION
## Description

Pinning markupsafe version to prevent imports failing.

Fixes #7479.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved.
