### PR TITLE
test(healthcare): include full operation in exception message

### DIFF
--- a/healthcare/api-client/v1/fhir/fhir_resources_test.py
+++ b/healthcare/api-client/v1/fhir/fhir_resources_test.py
@@ -62,18 +62,8 @@ def wait_for_operation(operation_name: str):
         .execute()
     )
 
-    try:
-        if not operation["done"]:
-            raise OperationNotComplete()
-    except KeyError:
-        # NOTE(busunkim): An operation should always have the 'done' field,
-        # but periodic logs indicate it is sometimes missing.
-        # This code prints out the full operation response for debugging purposes.
-        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
-        raise Exception(
-            "Operation missing key 'done':",
-            operation
-        )
+    if not operation.get("done", False):
+        raise OperationNotComplete(operation)
 
 
 @pytest.fixture(scope="module")

--- a/healthcare/api-client/v1/fhir/fhir_resources_test.py
+++ b/healthcare/api-client/v1/fhir/fhir_resources_test.py
@@ -61,8 +61,19 @@ def wait_for_operation(operation_name: str):
         .get(name=operation_name)
         .execute()
     )
-    if not operation["done"]:
-        raise OperationNotComplete()
+
+    try:
+        if not operation["done"]:
+            raise OperationNotComplete()
+    except KeyError:
+        # NOTE(busunkim): An operation should always have the 'done' field,
+        # but periodic logs indicate it is sometimes missing.
+        # This code prints out the full operation response for debugging purposes.
+        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
+        raise Exception(
+            "Operation missing key 'done':",
+            operation
+        )
 
 
 @pytest.fixture(scope="module")

--- a/healthcare/api-client/v1/fhir/fhir_stores_test.py
+++ b/healthcare/api-client/v1/fhir/fhir_stores_test.py
@@ -64,8 +64,19 @@ def wait_for_operation(operation_name: str):
         .get(name=operation_name)
         .execute()
     )
-    if not operation["done"]:
-        raise OperationNotComplete()
+
+    try:
+        if not operation["done"]:
+            raise OperationNotComplete()
+    except KeyError:
+        # NOTE(busunkim): An operation should always have the 'done' field,
+        # but periodic logs indicate it is sometimes missing.
+        # This code prints out the full operation response for debugging purposes.
+        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
+        raise Exception(
+            "Operation missing key 'done':",
+            operation
+        )
 
 
 @pytest.fixture(scope="module")

--- a/healthcare/api-client/v1/fhir/fhir_stores_test.py
+++ b/healthcare/api-client/v1/fhir/fhir_stores_test.py
@@ -65,18 +65,8 @@ def wait_for_operation(operation_name: str):
         .execute()
     )
 
-    try:
-        if not operation["done"]:
-            raise OperationNotComplete()
-    except KeyError:
-        # NOTE(busunkim): An operation should always have the 'done' field,
-        # but periodic logs indicate it is sometimes missing.
-        # This code prints out the full operation response for debugging purposes.
-        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
-        raise Exception(
-            "Operation missing key 'done':",
-            operation
-        )
+    if not operation.get("done", False):
+        raise OperationNotComplete(operation)
 
 
 @pytest.fixture(scope="module")

--- a/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
@@ -59,18 +59,9 @@ def wait_for_operation(operation_name: str):
         .execute()
     )
 
-    try:
-        if not operation["done"]:
-            raise OperationNotComplete()
-    except KeyError:
-        # NOTE(busunkim): An operation should always have the 'done' field,
-        # but periodic logs indicate it is sometimes missing.
-        # This code prints out the full operation response for debugging purposes.
-        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
-        raise Exception(
-            "Operation missing key 'done':",
-            operation
-        )
+    if not operation.get("done", False):
+        raise OperationNotComplete(operation)
+
 
 
 @pytest.fixture(scope="module")

--- a/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
@@ -63,7 +63,6 @@ def wait_for_operation(operation_name: str):
         raise OperationNotComplete(operation)
 
 
-
 @pytest.fixture(scope="module")
 def test_dataset():
     operation = fhir_stores.create_dataset(

--- a/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
@@ -72,6 +72,7 @@ def wait_for_operation(operation_name: str):
             operation
         )
 
+
 @pytest.fixture(scope="module")
 def test_dataset():
     operation = fhir_stores.create_dataset(

--- a/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_resources_test.py
@@ -58,9 +58,19 @@ def wait_for_operation(operation_name: str):
         .get(name=operation_name)
         .execute()
     )
-    if not operation["done"]:
-        raise OperationNotComplete()
 
+    try:
+        if not operation["done"]:
+            raise OperationNotComplete()
+    except KeyError:
+        # NOTE(busunkim): An operation should always have the 'done' field,
+        # but periodic logs indicate it is sometimes missing.
+        # This code prints out the full operation response for debugging purposes.
+        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
+        raise Exception(
+            "Operation missing key 'done':",
+            operation
+        )
 
 @pytest.fixture(scope="module")
 def test_dataset():

--- a/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
@@ -53,7 +53,6 @@ def wait_for_operation(operation_name: str):
         raise OperationNotComplete(operation)
 
 
-
 @pytest.fixture(scope="module")
 def test_dataset():
     operation = fhir_stores.create_dataset(

--- a/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
@@ -49,18 +49,9 @@ def wait_for_operation(operation_name: str):
         .execute()
     )
 
-    try:
-        if not operation["done"]:
-            raise OperationNotComplete()
-    except KeyError:
-        # NOTE(busunkim): An operation should always have the 'done' field,
-        # but periodic logs indicate it is sometimes missing.
-        # This code prints out the full operation response for debugging purposes.
-        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
-        raise Exception(
-            "Operation missing key 'done':",
-            operation
-        )
+    if not operation.get("done", False):
+        raise OperationNotComplete(operation)
+
 
 
 @pytest.fixture(scope="module")

--- a/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
@@ -62,6 +62,7 @@ def wait_for_operation(operation_name: str):
             operation
         )
 
+
 @pytest.fixture(scope="module")
 def test_dataset():
     operation = fhir_stores.create_dataset(

--- a/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
+++ b/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py
@@ -48,9 +48,19 @@ def wait_for_operation(operation_name: str):
         .get(name=operation_name)
         .execute()
     )
-    if not operation["done"]:
-        raise OperationNotComplete()
 
+    try:
+        if not operation["done"]:
+            raise OperationNotComplete()
+    except KeyError:
+        # NOTE(busunkim): An operation should always have the 'done' field,
+        # but periodic logs indicate it is sometimes missing.
+        # This code prints out the full operation response for debugging purposes.
+        # https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512
+        raise Exception(
+            "Operation missing key 'done':",
+            operation
+        )
 
 @pytest.fixture(scope="module")
 def test_dataset():


### PR DESCRIPTION
## Description

For #7433.

https://github.com/GoogleCloudPlatform/python-docs-samples/issues/7433#issuecomment-1053561512 These tests failed with a `KeyError` yesterday in the 3.7 periodic build last night:

```
Traceback (most recent call last):
  File "/workspace/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py", line 62, in test_dataset
    wait_for_operation(operation["name"])
  File "/workspace/healthcare/api-client/v1beta1/fhir/.nox/py-3-10/lib/python3.10/site-packages/google/api_core/retry.py", line 283, in retry_wrapped_func
    return retry_target(
  File "/workspace/healthcare/api-client/v1beta1/fhir/.nox/py-3-10/lib/python3.10/site-packages/google/api_core/retry.py", line 190, in retry_target
    return target()
  File "/workspace/healthcare/api-client/v1beta1/fhir/fhir_stores_test.py", line 51, in wait_for_operation
    if not operation["done"]:
KeyError: 'done'
```


I was unable to reproduce the error locally using the CI project, and I'm unsure what is causing the frequent failures on the periodic build. 

This PR prints out the full `operation` when the `done` key is missing. It will not resolve #7433, but should be helpful for determining the root case.



