### PR TITLE
fix: add retry for subnet not being ready

### DIFF
--- a/data-science-onramp/data-ingestion/ingestion_test.py
+++ b/data-science-onramp/data-ingestion/ingestion_test.py
@@ -16,11 +16,13 @@ The job uploads a subset of the data to BigQuery.
 Then, data is pulled from BigQuery and checks are made to see if the data is dirty.
 """
 
+
 import os
 import re
 import uuid
 
-from google.api_core.exceptions import NotFound
+import backoff
+from google.api_core.exceptions import InvalidArgument, NotFound
 from google.cloud import bigquery
 from google.cloud import dataproc_v1 as dataproc
 from google.cloud import storage
@@ -71,7 +73,11 @@ DATAPROC_JOB = {  # Dataproc job configuration
 }
 
 
+# backoff used to retry in the event of subnet not being ready
+# see https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-vm-creation#simultaneous_resource_mutation_or_creation_operations
+# for more info
 @pytest.fixture(autouse=True)
+@backoff.on_exception(backoff.expo, InvalidArgument, max_tries=3)
 def setup_and_teardown_cluster():
     try:
         # Create cluster using cluster client

--- a/data-science-onramp/data-ingestion/requirements-test.txt
+++ b/data-science-onramp/data-ingestion/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest==7.0.1
+backoff==1.11.1

--- a/data-science-onramp/data-processing/requirements-test.txt
+++ b/data-science-onramp/data-processing/requirements-test.txt
@@ -4,3 +4,4 @@ pandas==1.3.5; python_version > '3.6'
 pyarrow==6.0.1; python_version < '3.7'
 pyarrow==7.0.0; python_version > '3.6'
 google-cloud-bigquery==2.33.0
+backoff==1.11.1


### PR DESCRIPTION
Fixes: #7489
Fixes: #7493

## Description
When we see the "Subnet not ready" error, retry, as is suggested [in the documentation](https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-vm-creation#simultaneous_resource_mutation_or_creation_operations)

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
