### PR TITLE
ppai/geospatial: fix bucket name and region

### DIFF
--- a/people-and-planet-ai/geospatial-classification/README.ipynb
+++ b/people-and-planet-ai/geospatial-classification/README.ipynb
@@ -856,7 +856,7 @@
     "training_task = ee.batch.Export.table.toCloudStorage(\n",
     "    collection=ee.FeatureCollection(train_features),\n",
     "    description=\"Training image export\",\n",
-    "    bucket=bucket,\n",
+    "    bucket=cloud_storage_bucket,\n",
     "    fileNamePrefix=\"geospatial_training\",\n",
     "    selectors=BANDS + [LABEL],\n",
     "    fileFormat=\"TFRecord\",\n",
@@ -867,7 +867,7 @@
     "validation_task = ee.batch.Export.table.toCloudStorage(\n",
     "    collection=ee.FeatureCollection(validation_features),\n",
     "    description=\"Validation image export\",\n",
-    "    bucket=bucket,\n",
+    "    bucket=cloud_storage_bucket,\n",
     "    fileNamePrefix=\"geospatial_validation\",\n",
     "    selectors= BANDS + [LABEL],\n",
     "    fileFormat='TFRecord')\n",
@@ -1013,7 +1013,7 @@
     "  --source=serving_app \\\n",
     "  --command=\"gunicorn\" \\\n",
     "  --args=\"--threads=8,--timeout=0,main:app\" \\\n",
-    "  --region=\"us-central1\" \\\n",
+    "  --region=\"{region}\" \\\n",
     "  --memory=\"1G\" \\\n",
     "  --no-allow-unauthenticated \\"
    ]


### PR DESCRIPTION
## Description

Use the `cloud_storage_bucket` variable when exporting data, and use the `region` variable when deploying the web service.

Fixes #7605, #7606

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
