### PR TITLE
chore: Update Airflow 2 GKE sample to use regional clusters

### DIFF
--- a/composer/workflows/gke_operator.py
+++ b/composer/workflows/gke_operator.py
@@ -40,7 +40,7 @@ with models.DAG(
     # [START composer_gkeoperator_fullconfig]
     # TODO(developer): update with your values
     PROJECT_ID = "my-project-id"
-    CLUSTER_ZONE = "us-west1-a"
+    CLUSTER_REGION = "us-west1"
     CLUSTER_NAME = "example-cluster"
     # [END composer_gkeoperator_minconfig]
     # [END composer_gkeoperator_templateconfig]
@@ -58,7 +58,7 @@ with models.DAG(
     create_cluster = GKECreateClusterOperator(
         task_id="create_cluster",
         project_id=PROJECT_ID,
-        location=CLUSTER_ZONE,
+        location=CLUSTER_REGION,
         body=CLUSTER,
     )
     # [END composer_gke_create_cluster]
@@ -70,7 +70,7 @@ with models.DAG(
         # Name of task you want to run, used to generate Pod ID.
         name="pod-ex-minimum",
         project_id=PROJECT_ID,
-        location=CLUSTER_ZONE,
+        location=CLUSTER_REGION,
         cluster_name=CLUSTER_NAME,
         # Entrypoint of the container, if not specified the Docker container's
         # entrypoint is used. The cmds parameter is templated.
@@ -93,7 +93,7 @@ with models.DAG(
         task_id="ex-kube-templates",
         name="ex-kube-templates",
         project_id=PROJECT_ID,
-        location=CLUSTER_ZONE,
+        location=CLUSTER_REGION,
         cluster_name=CLUSTER_NAME,
         namespace="default",
         image="bash",
@@ -120,7 +120,7 @@ with models.DAG(
     kubernetes_affinity_ex = GKEStartPodOperator(
         task_id="ex-pod-affinity",
         project_id=PROJECT_ID,
-        location=CLUSTER_ZONE,
+        location=CLUSTER_REGION,
         cluster_name=CLUSTER_NAME,
         name="ex-pod-affinity",
         namespace="default",
@@ -170,7 +170,7 @@ with models.DAG(
         task_id="ex-all-configs",
         name="full",
         project_id=PROJECT_ID,
-        location=CLUSTER_ZONE,
+        location=CLUSTER_REGION,
         cluster_name=CLUSTER_NAME,
         namespace="default",
         image="perl",
@@ -228,7 +228,7 @@ with models.DAG(
         task_id="delete_cluster",
         name=CLUSTER_NAME,
         project_id=PROJECT_ID,
-        location=CLUSTER_ZONE,
+        location=CLUSTER_REGION,
     )
     # [END composer_gkeoperator_delete_cluster]
 

--- a/composer/workflows/gke_operator.py
+++ b/composer/workflows/gke_operator.py
@@ -40,6 +40,8 @@ with models.DAG(
     # [START composer_gkeoperator_fullconfig]
     # TODO(developer): update with your values
     PROJECT_ID = "my-project-id"
+    # It is recommended to use regional clusters for increased reliability
+    # though passing a zone in the location parameter is also valid
     CLUSTER_REGION = "us-west1"
     CLUSTER_NAME = "example-cluster"
     # [END composer_gkeoperator_minconfig]


### PR DESCRIPTION
Companion to cl/439518578 - we recommend using regional clusters not zonal clusters
[Airflow success](https://screenshot.googleplex.com/BbGYiKnWMgzuweC)

Airflow 1 sample will not be updated to match due to the way the `location` functionality is implemented in Airflow 1. If customer want to use regional clusters, we recommend they upgrade to Airflow 2.