### PR TITLE
Added timestamp and flushed STDOUT for logging.

### DIFF
--- a/compute/metadata/main.py
+++ b/compute/metadata/main.py
@@ -21,6 +21,8 @@ For more information, see the README.md under /compute.
 
 # [START all]
 
+import datetime
+import sys
 import time
 
 import requests
@@ -63,10 +65,11 @@ def wait_for_maintenance(callback):
 
 
 def maintenance_callback(event):
+    now = datetime.datetime.now().time().strftime('%H:%M:%S.%f')
     if event:
-        print('Undergoing host maintenance: {}'.format(event))
+        print(now + ' Undergoing host maintenance: {}'.format(event), flush=True)
     else:
-        print('Finished host maintenance')
+        print(now + ' Finished host maintenance', flush=True)
 
 
 def main():
@@ -74,5 +77,10 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    try: 
+        main()
+    except KeyboardInterrupt:
+        print('Stopped')
+        sys.exit(0)
+
 # [END all]


### PR DESCRIPTION
Also caught KeyboardInterrupt for cleaner exit on ^C

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
