### PR TITLE
dataflow (fix): pin in to ubuntu:impish

### DIFF
--- a/dataflow/custom-containers/ubuntu/Dockerfile
+++ b/dataflow/custom-containers/ubuntu/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:latest
+FROM ubuntu:impish
 
 WORKDIR /pipeline
 


### PR DESCRIPTION
# Description

Fixes #7822

It looks like they upgraded the Python version to 3.10 on the newly released `ubuntu:jammy` changed. Recently `ubuntu:latest` now points to `ubuntu:jammy` ([Python per Ubuntu releases](https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=python3-dev&searchon=names)). Even though Apache Beam is available in Python 3.10 through `pip`, unfortunately there is no "official" support for it so there is no `apache/beam_python3.10_sdk` image (to pull the worker boot files from).

We're pinning to `ubuntu:impish` which is the latest ubuntu image with Python 3.9 support.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
