### PR TITLE
docs: add Google Cloud Samples browser link to readme template

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python samples for [Google Cloud Platform products][cloud].
 
 ## Google Cloud Samples
 
-To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=python).
+To browse Google Cloud product specific code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=python).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Python samples for [Google Cloud Platform products][cloud].
 
 [![Build Status][py-2.7-shield]][py-2.7-link] [![Build Status][py-3.6-shield]][py-3.6-link] [![Build Status][py-3.7-shield]][py-3.7-link] [![Build Status][py-3.8-shield]][py-3.8-link] [![Build Status][py-3.9-shield]][py-3.9-link] [![Build Status][py-3.10-shield]][py-3.10-link]
 
+## Google Cloud Samples
+
+To browse ready to use code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=python).
+
 ## Setup
 
 1. Install [`pip` and `virtualenv`][cloud_python_setup] if you do not already have them.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python samples for [Google Cloud Platform products][cloud].
 
 ## Google Cloud Samples
 
-To browse Google Cloud product specific code samples check [Google Cloud Samples](https://cloud.google.com/docs/samples?l=python).
+Check out some of the samples found on this repository on the [Google Cloud Samples](https://cloud.google.com/docs/samples?l=python) page.
 
 ## Setup
 


### PR DESCRIPTION
Adding a generic Google Code Sample link to the readme template.

This is for the benefit of the users, in navigating available Google Cloud code samples.

## Description

Fixes #<ISSUE-NUMBER>

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
