### PR TITLE
pubsublite: lifecycle config during cluster creation

### DIFF
--- a/pubsublite/spark-connector/spark_streaming_test.py
+++ b/pubsublite/spark-connector/spark_streaming_test.py
@@ -136,7 +136,7 @@ def dataproc_cluster() -> Generator[dataproc_v1.Cluster, None, None]:
             },
             "lifecycle_config": {
                 # Schedule cluster deletion after 2 hours of inactivity.
-                "idle_delete_ttl": "3600s",
+                "idle_delete_ttl": {"seconds": 3600},
             },
         },
     }

--- a/pubsublite/spark-connector/spark_streaming_test.py
+++ b/pubsublite/spark-connector/spark_streaming_test.py
@@ -136,7 +136,7 @@ def dataproc_cluster() -> Generator[dataproc_v1.Cluster, None, None]:
             },
             "lifecycle_config": {
                 # Schedule cluster deletion after 2 hours of inactivity.
-                "idleDeleteTtl": "3600s",
+                "idle_delete_ttl": "3600s",
             },
         },
     }

--- a/pubsublite/spark-connector/spark_streaming_test.py
+++ b/pubsublite/spark-connector/spark_streaming_test.py
@@ -134,6 +134,10 @@ def dataproc_cluster() -> Generator[dataproc_v1.Cluster, None, None]:
                     "https://www.googleapis.com/auth/cloud-platform",
                 ],
             },
+            "lifecycle_config": {
+                # Schedule cluster deletion after 2 hours of inactivity.
+                "idleDeleteTtl": "3600s",
+            },
         },
     }
 


### PR DESCRIPTION
Schedule Dataproc clusters for deletion during cluster creation time. Clusters will get deleted even if tests fail, freeing up resources.

Tests are no longer flaky:

fixes #7928 
fixes #7927 