### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "requirements-composer.txt", "constraints.txt", "constraints-test.txt"]
   },
-  "ignorePaths" : ["composer/workflows/constraints.txt", "composer/blog/gcp-tech-blog/data-orchestration-with-composer/constraints.txt", "composer/airflow_1_samples/requirements.txt", "composer/cicd_sample/constraints.txt"],
+  "ignorePaths" : ["composer/**/constraints.txt", "composer/blog/**/constraints.txt"],
   "packageRules": [
     {
       "packagePatterns": ["pytest"],

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "requirements-composer.txt", "constraints.txt", "constraints-test.txt"]
   },
-  "ignorePaths" : ["composer/**/constraints.txt", "composer/blog/**/constraints.txt"],
+  "ignorePaths" : ["composer/**/constraints.txt", "composer/blog/**/constraints.txt", "composer/airflow_1_samples/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": ["pytest"],


### PR DESCRIPTION
Refactoring to use glob paths. With [this repo](https://github.com/leahecole/testrepo), I copied the composer subdirectory. I copied the proposed renovate config to the repo and constraints files like the ones from this repo.
WIP comment:
This is [a screenshot](https://screenshot.googleplex.com/z4uBbo4v4NtdmG3) of the dependency dashboard with current ignorepaths
This is [a screenshot](https://screenshot.googleplex.com/9HQ36sApckwCvv8) with the proposed glob-based ignorepaths in place

If you go to the [dependency dashboard](https://github.com/leahecole/testrepo/issues/5) you can also see no constraints files show up in there

