### PR TITLE
add backoff to fix flaky test

### DIFF
--- a/composer/2022_airflow_summit/data_analytics_process_test.py
+++ b/composer/2022_airflow_summit/data_analytics_process_test.py
@@ -20,11 +20,11 @@ and checks the existence of a new output table in that dataset.
 import os
 import uuid
 
+import backoff
 from google.api_core.exceptions import Aborted, NotFound
 from google.cloud import bigquery
 from google.cloud import dataproc_v1 as dataproc
 from google.cloud import storage
-import backoff
 import pytest
 
 

--- a/composer/2022_airflow_summit/requirements-test.txt
+++ b/composer/2022_airflow_summit/requirements-test.txt
@@ -1,3 +1,4 @@
 pytest==7.0.1
 cloud-composer-dag-test-utils==1.0.0
 markupsafe==2.0.1
+backoff==2.0.1


### PR DESCRIPTION
## Description

Fixes #8021 

Note: It's a good idea to open an issue first for discussion.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
