### PR TITLE
Return the base repo name from the github payload

### DIFF
--- a/run/deployment-previews/cloudbuild-configurations/cloudbuild-preview.yaml
+++ b/run/deployment-previews/cloudbuild-configurations/cloudbuild-preview.yaml
@@ -74,7 +74,7 @@ steps:
 substitutions:
   _SERVICE_NAME: myservice
   _REGION: us-central1
-  _GITHUB_REPO: $(pull_request.pull_request.head.repo.full_name)
+  _GITHUB_REPO: $(pull_request.base.repo.full_name)
 
 options:
   dynamicSubstitutions: true


### PR DESCRIPTION
## Description

Use the base repo name for the check status payload for deployment previews. This may have previously prevented external contributors from having the status of the preview tagged on their commit (unverified)

Also fix the value identifier (b/236910516)

The tests for the sample mock the repo_name, so this change isn't testable. Pending above bug resolution.


## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.6` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
