### PR TITLE
pubsublite: limit tests in python 3.8

### DIFF
--- a/pubsublite/spark-connector/noxfile_config.py
+++ b/pubsublite/spark-connector/noxfile_config.py
@@ -22,8 +22,8 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # NOTE: We currently only run the test in Python 3.7 and 3.8.
-    "ignored_versions": ["2.7", "3.6", "3.9"],
+    # NOTE: We currently only run the test in Python 3.8.
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,


### PR DESCRIPTION
## Description

Fixes #8123 
Fixes #8124 

The flaky test was caused by parallel test runs in different Python version: `StatusCode.ALREADY_EXISTS`. There's really no need to test both Python 3.7 and 3.8 for this sample. Proposing that we just run tests in one Python version. 