### PR TITLE
chore(docker): Update Dockerfile to install pip for every Python3 version

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -117,7 +117,7 @@ RUN set -ex \
   && export GNUPGHOME="$(mktemp -d)" \
   && echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
   && /tmp/fetch_gpg_keys.sh \
-  && for PYTHON_VERSION in 2.7.18 3.6.15 3.7.12 3.8.12 3.9.7 3.10.0; do \
+  && for PYTHON_VERSION in 2.7.18 3.6.15 3.7.12 3.8.13 3.9.13 3.10.5; do \
   wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
   && wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
   && gpg --batch --verify python-${PYTHON_VERSION}.tar.xz.asc python-${PYTHON_VERSION}.tar.xz \
@@ -160,7 +160,11 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
 RUN python3.9 /tmp/get-pip.py
 RUN python3.8 /tmp/get-pip.py
 RUN python3.7 /tmp/get-pip.py
+RUN python3.6 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
+
+# Test Pip
+RUN python3 -m pip
 
 # Install "virtualenv", since the vast majority of users of this image
 # will want it.
@@ -193,4 +197,4 @@ RUN useradd -d /h -u ${UID} ${USERNAME}
 # Allow nopasswd sudo
 RUN echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-CMD ["python3.10"]
+CMD ["python3"]

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -165,6 +165,7 @@ RUN rm /tmp/get-pip.py
 
 # Test Pip
 RUN python3 -m pip
+RUN python3.6 -m pip
 RUN python3.7 -m pip
 RUN python3.8 -m pip
 RUN python3.9 -m pip

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -156,8 +156,10 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   # https://github.com/docker-library/python/pull/100
   && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
-# Ensure Pip for python3
-RUN python3 /tmp/get-pip.py
+# Ensure Pip for all python3 versions
+RUN python3.9 /tmp/get-pip.py
+RUN python3.8 /tmp/get-pip.py
+RUN python3.7 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
 
 # Install "virtualenv", since the vast majority of users of this image

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -165,6 +165,10 @@ RUN rm /tmp/get-pip.py
 
 # Test Pip
 RUN python3 -m pip
+RUN python3.7 -m pip
+RUN python3.8 -m pip
+RUN python3.9 -m pip
+RUN python3.10 -m pip
 
 # Install "virtualenv", since the vast majority of users of this image
 # will want it.

--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -117,7 +117,7 @@ RUN set -ex \
   && export GNUPGHOME="$(mktemp -d)" \
   && echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
   && /tmp/fetch_gpg_keys.sh \
-  && for PYTHON_VERSION in 2.7.18 3.6.15 3.7.12 3.8.13 3.9.13 3.10.5; do \
+  && for PYTHON_VERSION in 2.7.18 3.7.12 3.8.13 3.9.13 3.10.5; do \
   wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
   && wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
   && gpg --batch --verify python-${PYTHON_VERSION}.tar.xz.asc python-${PYTHON_VERSION}.tar.xz \
@@ -160,12 +160,10 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
 RUN python3.9 /tmp/get-pip.py
 RUN python3.8 /tmp/get-pip.py
 RUN python3.7 /tmp/get-pip.py
-RUN python3.6 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
 
 # Test Pip
 RUN python3 -m pip
-RUN python3.6 -m pip
 RUN python3.7 -m pip
 RUN python3.8 -m pip
 RUN python3.9 -m pip


### PR DESCRIPTION
Make sure that every version of Python gets PIP installed.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
