### PR TITLE
test: buffing up timeout for e2e test

### DIFF
--- a/run/image-processing/e2e_test.py
+++ b/run/image-processing/e2e_test.py
@@ -229,7 +229,7 @@ def test_end_to_end(input_bucket, output_bucket):
     blob.upload_from_filename("test-images/zombie.jpg", content_type="image/jpeg")
 
     # Wait for image processing to complete
-    time.sleep(30)
+    time.sleep(60)
 
     for x in range(10):
         # Check for blurred image in output bucket


### PR DESCRIPTION
## Description

Fixes #8144 

Flaky issue seems to stem from how fast the image is uploaded to the bucket. As this depends on a test GCP project, going ahead and buffing up the timeout to observe if that helps with the flaky test. Will revisit if this occurs again.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
