### PR TITLE
chore: remove 3.6 status from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Python samples for [Google Cloud Platform products][cloud].
 
-[![Build Status][py-2.7-shield]][py-2.7-link] [![Build Status][py-3.6-shield]][py-3.6-link] [![Build Status][py-3.7-shield]][py-3.7-link] [![Build Status][py-3.8-shield]][py-3.8-link] [![Build Status][py-3.9-shield]][py-3.9-link] [![Build Status][py-3.10-shield]][py-3.10-link]
+[![Build Status][py-2.7-shield]][py-2.7-link] [![Build Status][py-3.7-shield]][py-3.7-link] [![Build Status][py-3.8-shield]][py-3.8-link] [![Build Status][py-3.9-shield]][py-3.9-link] [![Build Status][py-3.10-shield]][py-3.10-link]
 
 ## Google Cloud Samples
 
@@ -69,8 +69,6 @@ Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md).
 
 [py-2.7-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-2.7.svg
 [py-2.7-link]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-2.7.html
-[py-3.6-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-3.6.svg
-[py-3.6-link]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-3.6.html
 [py-3.7-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-3.7.svg
 [py-3.7-link]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-3.7.html
 [py-3.8-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-3.8.svg


### PR DESCRIPTION
## Description

Removes 3.6 status from the main README, 3.6 tests have been removed previously.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
