### PR TITLE
dataflow/ubuntu-container: use LTS ubuntu version

### DIFF
--- a/dataflow/custom-containers/ubuntu/Dockerfile
+++ b/dataflow/custom-containers/ubuntu/Dockerfile
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:impish
+FROM ubuntu:focal
 
 WORKDIR /pipeline
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
-COPY --from=apache/beam_python3.9_sdk:2.38.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.8_sdk:2.40.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]
 
 # Install Python with pip, dev tools, distutils, and a C++ compiler.
 COPY requirements.txt .
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl g++ python3.9-dev python3-distutils \
+        ca-certificates curl g++ python3-dev python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.9 10 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
     # Install the requirements.
     && pip install --no-cache-dir -r requirements.txt \

--- a/dataflow/custom-containers/ubuntu/requirements.txt
+++ b/dataflow/custom-containers/ubuntu/requirements.txt
@@ -1,1 +1,1 @@
-apache-beam[gcp]==2.37.0
+apache-beam[gcp]==2.40.0


### PR DESCRIPTION
## Description

It looks like Ubuntu Impish was not an LTS version and is no longer supported. Since Apache Beam still does not "officially" support Python 3.10 we can't move towards latest (Jammy), so I'm "downgrading" to Focal which is the previous LTS version. It uses Python 3.8 by default, so I also changed the Beam image to pull the boot files from.

I also updated the Beam version as a side effect :)

Fixes #8206

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
