### PR TITLE
Fix: Datastore samples: `exclude_from_indexes` expects a tuple, not a…

### DIFF
--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -213,7 +213,7 @@ def entity_with_parent(client):
 def properties(client):
     # [START datastore_properties]
     key = client.key("Task")
-    task = datastore.Entity(key, exclude_from_indexes=["description"])
+    task = datastore.Entity(key, exclude_from_indexes=("description",))
     task.update(
         {
             "category": "Personal",
@@ -224,6 +224,7 @@ def properties(client):
             "percent_complete": 10.5,
         }
     )
+    client.put(task)
     # [END datastore_properties]
 
     return task

--- a/datastore/cloud-client/tasks.py
+++ b/datastore/cloud-client/tasks.py
@@ -45,7 +45,7 @@ def add_task(client: datastore.Client, description: str):
 
     # Create an unsaved Entity object, and tell Datastore not to index the
     # `description` field
-    task = datastore.Entity(key, exclude_from_indexes=["description"])
+    task = datastore.Entity(key, exclude_from_indexes=("description",))
 
     # Apply new field values and save the Task entity to Datastore
     task.update(


### PR DESCRIPTION
… list

Updated the sample to pass in a tuple instead of a list.
Also ensure that we call client.put() so the changes persist.

Fix internal issue 233485333

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
