### PR TITLE
Fix: replace pytest.yield_fixture with pytest.fixture

### DIFF
--- a/appengine/standard/appengine_helper.py
+++ b/appengine/standard/appengine_helper.py
@@ -118,7 +118,7 @@ def run_taskqueue_tasks(testbed, app):
 
 # py.test helpers
 
-@pytest.yield_fixture
+@pytest.fixture
 def testbed():
     """py.test fixture for the GAE testbed."""
     testbed = setup_testbed()

--- a/datastore/cloud-client/snippets_test.py
+++ b/datastore/cloud-client/snippets_test.py
@@ -36,7 +36,7 @@ class CleanupClient(datastore.Client):
             )
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def client():
     client = CleanupClient(PROJECT)
     yield client

--- a/datastore/cloud-client/tasks_test.py
+++ b/datastore/cloud-client/tasks_test.py
@@ -23,7 +23,7 @@ import tasks
 PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def client():
     # We use namespace for isolating builds.
     namespace = uuid.uuid4().hex

--- a/dns/api/main_test.py
+++ b/dns/api/main_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google, Inc.
+# Copyright 2015, Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/dns/api/main_test.py
+++ b/dns/api/main_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google LLC
+# Copyright 2015 Google, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/dns/api/main_test.py
+++ b/dns/api/main_test.py
@@ -33,7 +33,7 @@ def delay_rerun(*args):
     return True
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def client():
     client = dns.Client(PROJECT)
 
@@ -47,7 +47,7 @@ def client():
             pass
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def zone(client):
     zone = client.zone(TEST_ZONE_NAME, TEST_ZONE_DNS_NAME)
     zone.description = TEST_ZONE_DESCRIPTION


### PR DESCRIPTION
## Description

Replace the deprecated `pytest.yield_fixture` with `pytest.fixture`

Fixes #8232

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved.
