### PR TITLE
chore(cloudsql): hide `connect_args` usage in basic TCP sample

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/connect_tcp.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_tcp.py
@@ -61,7 +61,9 @@ def connect_tcp_socket() -> sqlalchemy.engine.base.Engine:
             port=db_port,
             database=db_name,
         ),
+        # [END cloud_sql_postgres_sqlalchemy_connect_tcp]
         connect_args=connect_args,
+        # [START cloud_sql_postgres_sqlalchemy_connect_tcp]
         # [START_EXCLUDE]
         # [START cloud_sql_mysql_sqlalchemy_limit]
         # Pool size is the maximum number of permanent connections to keep.

--- a/cloud-sql/mysql/sqlalchemy/connect_tcp.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_tcp.py
@@ -32,8 +32,8 @@ def connect_tcp_socket() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
     db_port = os.environ["DB_PORT"]  # e.g. 3306
 
-    connect_args = {}
     # [END cloud_sql_mysql_sqlalchemy_connect_tcp]
+    connect_args = {}
     # For deployments that connect directly to a Cloud SQL instance without
     # using the Cloud SQL Proxy, configuring SSL certificates will ensure the
     # connection is encrypted.

--- a/cloud-sql/postgres/sqlalchemy/connect_tcp.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_tcp.py
@@ -33,8 +33,8 @@ def connect_tcp_socket() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
     db_port = os.environ["DB_PORT"]  # e.g. 5432
 
-    connect_args = {}
     # [END cloud_sql_postgres_sqlalchemy_connect_tcp]
+    connect_args = {}
     # For deployments that connect directly to a Cloud SQL instance without
     # using the Cloud SQL Proxy, configuring SSL certificates will ensure the
     # connection is encrypted.
@@ -61,7 +61,9 @@ def connect_tcp_socket() -> sqlalchemy.engine.base.Engine:
             port=db_port,
             database=db_name,
         ),
+        # [END cloud_sql_postgres_sqlalchemy_connect_tcp]
         connect_args=connect_args,
+        # [START cloud_sql_postgres_sqlalchemy_connect_tcp]
         # [START_EXCLUDE]
         # [START cloud_sql_postgres_sqlalchemy_limit]
         # Pool size is the maximum number of permanent connections to keep.


### PR DESCRIPTION
The `connect_args` variable is only required for TCP connections that use SSL. Updating region tag placement to hide them in regular TCP sample.

[Example sample](https://cloud.google.com/sql/docs/mysql/connect-admin-proxy#expandable-1) showing unnecessary `connect_args` argument.