### PR TITLE
fix: use backoff exception to gracefully exit and fail

### DIFF
--- a/compute/oslogin/requirements-test.txt
+++ b/compute/oslogin/requirements-test.txt
@@ -1,4 +1,4 @@
-backoff==1.11.1; python_version < "3.7"
-backoff==2.0.0; python_version >= "3.7"
+backoff===1.11.1; python_version < "3.7"
+backoff===2.0.0; python_version >= "3.7"
 pytest==7.0.1
 mock==4.0.3

--- a/compute/oslogin/requirements-test.txt
+++ b/compute/oslogin/requirements-test.txt
@@ -1,3 +1,4 @@
+backoff==1.11.1; python_version < "3.7"
+backoff==2.0.0; python_version >= "3.7"
 pytest==7.0.1
 mock==4.0.3
-retrying==1.3.3

--- a/compute/oslogin/service_account_ssh_test.py
+++ b/compute/oslogin/service_account_ssh_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import backoff
 import base64
+import backoff
 import json
 import os
 import random

--- a/compute/oslogin/service_account_ssh_test.py
+++ b/compute/oslogin/service_account_ssh_test.py
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import backoff
 import base64
 import json
 import os
 import random
-import time
 from subprocess import CalledProcessError
+import time
 
-from google.oauth2 import service_account
 from google.auth.exceptions import RefreshError
+from google.oauth2 import service_account
 import googleapiclient.discovery
-from retrying import retry
 
 from service_account_ssh import main
 
@@ -89,9 +89,9 @@ def test_main(capsys):
     # More exceptions could be raised, keeping track of ones I could
     # find for now.
     @backoff.on_exception(backoff.expo,
-                      (CalledProcessError,
-                      RefreshError),
-                      max_tries=5)
+                          (CalledProcessError,
+                           RefreshError),
+                          max_tries=5)
     def ssh_login():
         main(cmd, project, test_id, zone, oslogin, account, hostname)
         out, _ = capsys.readouterr()

--- a/compute/oslogin/service_account_ssh_test.py
+++ b/compute/oslogin/service_account_ssh_test.py
@@ -100,9 +100,7 @@ def test_main(capsys):
 
     # Test SSH to the instance.
     ssh_login()
-
-    finally:
-        cleanup_resources(compute, iam, project, test_id, zone, account_email)
+    cleanup_resources(compute, iam, project, test_id, zone, account_email)
 
 
 def setup_resources(

--- a/compute/oslogin/service_account_ssh_test.py
+++ b/compute/oslogin/service_account_ssh_test.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import base64
-import backoff
 import json
 import os
 import random
 from subprocess import CalledProcessError
 import time
 
+import backoff
 from google.auth.exceptions import RefreshError
 from google.oauth2 import service_account
 import googleapiclient.discovery

--- a/compute/oslogin/service_account_ssh_test.py
+++ b/compute/oslogin/service_account_ssh_test.py
@@ -17,8 +17,10 @@ import json
 import os
 import random
 import time
+from subprocess import CalledProcessError
 
 from google.oauth2 import service_account
+from google.auth.exceptions import RefreshError
 import googleapiclient.discovery
 from retrying import retry
 
@@ -84,11 +86,11 @@ def test_main(capsys):
         'oslogin', 'v1', cache_discovery=False, credentials=credentials)
     account = 'users/' + account_email
 
-    # Multiple exception types can be raised, using generic Exception as a catch all.
-    # I was not able to track all the exception types that can be raised from this block
-    # of code.
+    # More exceptions could be raised, keeping track of ones I could
+    # find for now.
     @backoff.on_exception(backoff.expo,
-                      Exception,
+                      (CalledProcessError,
+                      RefreshError),
                       max_tries=5)
     def ssh_login():
         main(cmd, project, test_id, zone, oslogin, account, hostname)


### PR DESCRIPTION
## Description

The current retry is making tests fail out. Instead of indefinitely waiting, retrying with a specific number should help determine whether test passes / fails. 

Unfortunately I can't get the test to pass, but happy to incorporate ideas to help get this test passing. For now, they no longer will be timing out after ~5 hours, instead they'll fail or pass immediately.

Fixes #8219. Towards #7277.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
