### PR TITLE
fix: add fixture for dataproc batch and better test cleanup

### DIFF
--- a/composer/2022_airflow_summit/data_analytics_process_test.py
+++ b/composer/2022_airflow_summit/data_analytics_process_test.py
@@ -143,7 +143,7 @@ def bq_dataset(test_bucket):
 
 # Retry if we see a flaky 409 "subnet not ready" exception
 @backoff.on_exception(backoff.expo, Aborted, max_tries=3)
-def test_process(test_bucket, test_dataproc_batch):
+def test_process(test_dataproc_batch):
     # check that the results table isnt there
     with pytest.raises(NotFound):
         BQ_CLIENT.get_table(f"{BQ_DATASET}.{BQ_WRITE_TABLE}")

--- a/composer/2022_airflow_summit/data_analytics_process_test.py
+++ b/composer/2022_airflow_summit/data_analytics_process_test.py
@@ -63,6 +63,26 @@ BATCH_CONFIG = {
     },
 }
 
+@pytest.fixture(scope="module", autouse=True)
+def delete_dataproc_batch():
+    yield
+    dataproc_client = dataproc.BatchControllerClient(
+        client_options={
+            "api_endpoint": f"{DATAPROC_REGION}-dataproc.googleapis.com:443"
+        }
+    )
+    request = dataproc.DeleteBatchRequest(
+        name=BATCH_ID
+    )
+    # Make the request
+    operation = dataproc_client.delete_batch(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+
+    # Handle the response
+    print(response)
 
 @pytest.fixture(scope="module")
 def test_bucket():

--- a/composer/2022_airflow_summit/data_analytics_process_test.py
+++ b/composer/2022_airflow_summit/data_analytics_process_test.py
@@ -78,9 +78,13 @@ def test_dataproc_batch():
         name=f"projects/{PROJECT_ID}/locations/{DATAPROC_REGION}/batches/{BATCH_ID}"
     )
 
-    # Make the request - there will only be a response if the deletion fails
-    # otherwise response will be None
+    # Make the request
     response = dataproc_client.delete_batch(request=request)
+
+    # There will only be a response if the deletion fails
+    # otherwise response will be None
+    if response:
+        print(response)
 
 
 @pytest.fixture(scope="module")

--- a/composer/2022_airflow_summit/data_analytics_process_test.py
+++ b/composer/2022_airflow_summit/data_analytics_process_test.py
@@ -21,7 +21,7 @@ import os
 import uuid
 
 import backoff
-from google.api_core.exceptions import Aborted, NotFound
+from google.api_core.exceptions import Aborted, NotFound, AlreadyExists
 from google.cloud import bigquery
 from google.cloud import dataproc_v1 as dataproc
 from google.cloud import storage
@@ -124,7 +124,7 @@ def bq_dataset(test_bucket):
 
 
 # Retry if we see a flaky 409 "subnet not ready" exception
-@backoff.on_exception(backoff.expo, Aborted, max_tries=3)
+@backoff.on_exception(backoff.expo, (Aborted, AlreadyExists), max_tries=3)
 def test_process(test_bucket):
     # check that the results table isnt there
     with pytest.raises(NotFound):

--- a/composer/2022_airflow_summit/noxfile_config.py
+++ b/composer/2022_airflow_summit/noxfile_config.py
@@ -43,7 +43,7 @@ TEST_CONFIG_OVERRIDE = {
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"
-    "pip_version_override": "20.2.4",
+    "pip_version_override": "",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {"AIRFLOW_HOME": _tmpdir.name},


### PR DESCRIPTION
## Description

#8021 was similar but was throwing the `Aborted` error, this is giving a 409 `AlreadyExists` which was happening when it would retry but already find a batch there. I've added teardown logic to hopefully reduce the likelihood that an `AlreadyExists` happens.

Fixes #8254 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
