### PR TITLE
Pin perl version to 5.34.0 for Airflow Kubernetes Pod Operator example

### DIFF
--- a/composer/airflow_1_samples/kubernetes_pod_operator.py
+++ b/composer/airflow_1_samples/kubernetes_pod_operator.py
@@ -142,7 +142,7 @@ with models.DAG(
         task_id='ex-pod-affinity',
         name='ex-pod-affinity',
         namespace='default',
-        image='perl',
+        image='perl:5.34.0',
         cmds=['perl'],
         arguments=['-Mbignum=bpi', '-wle', 'print bpi(2000)'],
         # affinity allows you to constrain which nodes your pod is eligible to
@@ -184,7 +184,7 @@ with models.DAG(
         task_id='ex-all-configs',
         name='pi',
         namespace='default',
-        image='perl',
+        image='perl:5.34.0',
         # Entrypoint of the container, if not specified the Docker container's
         # entrypoint is used. The cmds parameter is templated.
         cmds=['perl'],

--- a/composer/workflows/kubernetes_pod_operator.py
+++ b/composer/workflows/kubernetes_pod_operator.py
@@ -146,7 +146,7 @@ with models.DAG(
         task_id='ex-pod-affinity',
         name='ex-pod-affinity',
         namespace='default',
-        image='perl',
+        image='perl:5.34.0',
         cmds=['perl'],
         arguments=['-Mbignum=bpi', '-wle', 'print bpi(2000)'],
         # affinity allows you to constrain which nodes your pod is eligible to
@@ -188,7 +188,7 @@ with models.DAG(
         task_id='ex-all-configs',
         name='pi',
         namespace='default',
-        image='perl',
+        image='perl:5.34.0',
         # Entrypoint of the container, if not specified the Docker container's
         # entrypoint is used. The cmds parameter is templated.
         cmds=['perl'],


### PR DESCRIPTION
## Description


Fixes #8122

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.

