### PR TITLE
chore: update SQL Server samples to use pytds

### DIFF
--- a/cloud-sql/sql-server/sqlalchemy/Dockerfile
+++ b/cloud-sql/sql-server/sqlalchemy/Dockerfile
@@ -17,16 +17,6 @@
 FROM python:3.10-buster
 
 RUN apt-get update
-RUN apt install unixodbc-dev -y
-
-# Add SQL Server ODBC Driver 17 for Ubuntu 18.04
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
-RUN apt-get update
-RUN ACCEPT_EULA=Y apt-get install -y --allow-unauthenticated msodbcsql17
-RUN ACCEPT_EULA=Y apt-get install -y --allow-unauthenticated mssql-tools
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bash_profile
-RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.
@@ -44,13 +34,6 @@ COPY . ./
 
 # Copy any certificates if present.
 COPY ./certs /app/certs
-
-# Use server certificate for encrypted connection.
-# Conditionally copy the server-ca.pem file to the container image if the file is present.
-COPY Dockerfile ./certs/server-ca.pem* /usr/local/share/ca-certificates/
-# Rename the copied server-ca.pem file if it exists.
-RUN mv /usr/local/share/ca-certificates/server-ca.pem /usr/local/share/ca-certificates/server-ca.crt; exit 0
-RUN update-ca-certificates
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/cloud-sql/sql-server/sqlalchemy/connect_tcp.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_tcp.py
@@ -34,41 +34,34 @@ def connect_tcp_socket() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
     db_port = os.environ["DB_PORT"]  # e.g. 1433
 
-    # [END cloud_sql_sqlserver_sqlalchemy_sslcerts]
-    driver_name = "mssql+pytds"
-    query = {
-        "driver": "ODBC Driver 17 for SQL Server"
-    }
     # [END cloud_sql_sqlserver_sqlalchemy_connect_tcp]
-    # [START cloud_sql_sqlserver_sqlalchemy_sslcerts]
+    # [START_EXCLUDE]
+    connect_args={}
+    # [END_EXCLUDE]
     # For deployments that connect directly to a Cloud SQL instance without
     # using the Cloud SQL Proxy, configuring SSL certificates will ensure the
     # connection is encrypted.
     if os.environ.get("DB_ROOT_CERT"):  # e.g. '/path/to/my/server-ca.pem'
-        driver_name = "mssql+pyodbc"
-        query = {
-            "driver": "ODBC Driver 17 for SQL Server",
-            "Encrypt": "yes",
-            "Trusted_Connection": "no"
+        connect_args = {
+            "cafile" : os.environ["DB_ROOT_CERT"],
+            "validate_host": False,
         }
-    if os.environ.get("CLOUD_SQL_AUTH_PROXY_IP_ADDRESS_TYPE") == "PRIVATE":
-        driver_name = "mssql+pyodbc"
-        query = {
-            "driver": "ODBC Driver 17 for SQL Server"
-        }
+
     # [START cloud_sql_sqlserver_sqlalchemy_connect_tcp]
     pool = sqlalchemy.create_engine(
         # Equivalent URL:
-        # <driver_name>://<db_user>:<db_pass>@<db_host>:<db_port>/<db_name>?driver=ODBC+Driver+17+for+SQL+Server
+        # mssql+pytds://<db_user>:<db_pass>@<db_host>:<db_port>/<db_name>
         sqlalchemy.engine.url.URL.create(
-            drivername=driver_name,
+            drivername="mssql+pytds",
             username=db_user,
             password=db_pass,
             database=db_name,
             host=db_host,
             port=db_port,
-            query=query,
         ),
+        # [END cloud_sql_sqlserver_sqlalchemy_connect_tcp]
+        connect_args=connect_args,
+        # [START cloud_sql_sqlserver_sqlalchemy_connect_tcp]
         # [START_EXCLUDE]
         # [START cloud_sql_sqlserver_sqlalchemy_limit]
         # Pool size is the maximum number of permanent connections to keep.

--- a/cloud-sql/sql-server/sqlalchemy/connect_tcp.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_tcp.py
@@ -36,7 +36,7 @@ def connect_tcp_socket() -> sqlalchemy.engine.base.Engine:
 
     # [END cloud_sql_sqlserver_sqlalchemy_connect_tcp]
     # [START_EXCLUDE]
-    connect_args={}
+    connect_args = {}
     # [END_EXCLUDE]
     # For deployments that connect directly to a Cloud SQL instance without
     # using the Cloud SQL Proxy, configuring SSL certificates will ensure the

--- a/cloud-sql/sql-server/sqlalchemy/requirements.txt
+++ b/cloud-sql/sql-server/sqlalchemy/requirements.txt
@@ -1,7 +1,6 @@
 Flask==2.1.0
 gunicorn==20.1.0
 python-tds==1.11.0
-pyodbc==4.0.34
 pyopenssl==22.0.0
 SQLAlchemy==1.4.38
 cloud-sql-python-connector==0.6.1


### PR DESCRIPTION
Consolidating SQL Server samples to [`pytds`](https://python-tds.readthedocs.io/en/latest/index.html) driver for all paths. 

Enables Private IP + SSL TCP connection with App Engine.