### PR TITLE
fix: Flaky failures

### DIFF
--- a/appengine/standard_python3/bundled-services/deferred/django/main.py
+++ b/appengine/standard_python3/bundled-services/deferred/django/main.py
@@ -28,6 +28,7 @@ my_key = os.environ.get("GAE_VERSION", "Missing")
 
 class Counter(ndb.Model):
     count = ndb.IntegerProperty(indexed=False)
+    updated_at = ndb.DateTimeProperty(auto_now=True)
 
 
 def do_something_later(key, amount):

--- a/appengine/standard_python3/bundled-services/deferred/django/main.py
+++ b/appengine/standard_python3/bundled-services/deferred/django/main.py
@@ -32,9 +32,9 @@ class Counter(ndb.Model):
 
 
 def do_something_later(key, amount):
-    entity = Counter.get_or_insert(key, count=0)
+    entity = Counter.get_or_insert(key, count=0, retries=2)
     entity.count += amount
-    entity.put()
+    entity.put(retries=2)
 
 
 def increment_counter(request):
@@ -51,7 +51,7 @@ def increment_counter(request):
 
 
 def view_counter(request):
-    counter = Counter.get_or_insert(my_key, count=0)
+    counter = Counter.get_or_insert(my_key, count=0, retries=2)
     return HttpResponse(str(counter.count))
 
 

--- a/appengine/standard_python3/bundled-services/deferred/flask/main.py
+++ b/appengine/standard_python3/bundled-services/deferred/flask/main.py
@@ -28,6 +28,7 @@ app.wsgi_app = wrap_wsgi_app(app.wsgi_app, use_deferred=True)
 
 class Counter(ndb.Model):
     count = ndb.IntegerProperty(indexed=False)
+    updated_at = ndb.DateTimeProperty(auto_now=True)
 
 
 def do_something_later(key, amount):

--- a/appengine/standard_python3/bundled-services/deferred/flask/main.py
+++ b/appengine/standard_python3/bundled-services/deferred/flask/main.py
@@ -32,9 +32,9 @@ class Counter(ndb.Model):
 
 
 def do_something_later(key, amount):
-    entity = Counter.get_or_insert(key, count=0)
+    entity = Counter.get_or_insert(key, count=0, retries=2)
     entity.count += amount
-    entity.put()
+    entity.put(retries=2)
 
 
 @app.route("/counter/increment")
@@ -53,7 +53,7 @@ def increment_counter():
 
 @app.route("/counter/get")
 def view_counter():
-    counter = Counter.get_or_insert(my_key, count=0)
+    counter = Counter.get_or_insert(my_key, count=0, retries=2)
     return str(counter.count)
 
 

--- a/appengine/standard_python3/bundled-services/deferred/wsgi/main.py
+++ b/appengine/standard_python3/bundled-services/deferred/wsgi/main.py
@@ -25,6 +25,7 @@ my_key = os.environ.get("GAE_VERSION", "Missing")
 
 class Counter(ndb.Model):
     count = ndb.IntegerProperty(indexed=False)
+    updated_at = ndb.DateTimeProperty(auto_now=True)
 
 
 def do_something_later(key, amount):

--- a/appengine/standard_python3/bundled-services/deferred/wsgi/main.py
+++ b/appengine/standard_python3/bundled-services/deferred/wsgi/main.py
@@ -29,9 +29,9 @@ class Counter(ndb.Model):
 
 
 def do_something_later(key, amount):
-    entity = Counter.get_or_insert(key, count=0)
+    entity = Counter.get_or_insert(key, count=0, retries=2)
     entity.count += amount
-    entity.put()
+    entity.put(retries=2)
 
 
 def IncrementCounter(environ, start_response):
@@ -49,7 +49,7 @@ def IncrementCounter(environ, start_response):
 
 
 def ViewCounter(environ, start_response):
-    counter = Counter.get_or_insert(my_key, count=0)
+    counter = Counter.get_or_insert(my_key, count=0, retries=2)
     start_response("200 OK", [("Content-Type", "text/html")])
     return [str(counter.count).encode("utf-8")]
 


### PR DESCRIPTION
## Description

Fixes #8330 #8347 #8339 

Logs show failures are due to datastore fetch timeouts. That shouldn't be happening, but retries should fix it. Also added an automatic timestamp and will create a policy to regularly delete old data to prevent database from growing too much.