### PR TITLE
chore: Update license header config to ignore year

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -16,7 +16,8 @@ ignoreFiles:
   - "**/constraints-test.txt"
   - "**/apt.txt"
   - "**/ghcnd-stations.txt"
-  
+
+ignoreLicenseYear: true
 
 sourceFileExtensions:
   - "ts"


### PR DESCRIPTION
Temporarily setting this to `true` while repo migrations are underway.