### PR TITLE
fix: May need slight wait before responsive

### DIFF
--- a/appengine/standard_python3/bundled-services/blobstore/wsgi/main_test.py
+++ b/appengine/standard_python3/bundled-services/blobstore/wsgi/main_test.py
@@ -15,6 +15,7 @@
 import json
 import re
 import subprocess
+import time
 import uuid
 
 import backoff
@@ -63,6 +64,7 @@ def version():
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
 
+    time.sleep(10)      # There may be a short delay before responsive
     yield project_id, version_id
 
     gcloud_cli(f"app versions delete {version_id}")


### PR DESCRIPTION
After the `gcloud app deploy` command returns, the instance may still need a few seconds before it is responsive. Add a short wait so that tests don't fail for that reason.

## Description

Fixes #8495 
