### PR TITLE
migrate code from googleapis/python-tasks

### DIFF
--- a/cloud_tasks/snippets/README.md
+++ b/cloud_tasks/snippets/README.md
@@ -1,0 +1,87 @@
+# Google Cloud Tasks Samples
+
+[![Open in Cloud Shell][shell_img]][shell_link]
+
+[shell_img]: http://gstatic.com/cloudssh/images/open-btn.png
+[shell_link]: https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/GoogleCloudPlatform/python-docs-samples&page=editor&open_in_editor=tasks/README.md
+
+This sample demonstrates how to use the
+[Cloud Tasks](https://cloud.google.com/tasks/docs/) client library.
+
+`create_http_task.py` is a simple command-line program to create
+tasks to be pushed to an URL endpoint.
+
+`create_http_task_with_token.py` is a simple command-line program to create
+tasks to be pushed to an URL endpoint with authorization header.
+
+## Prerequisites to run locally:
+
+Please refer to [Setting Up a Python Development Environment](https://cloud.google.com/python/setup).
+
+## Authentication
+
+To set up authentication, please refer to our
+[authentication getting started guide](https://cloud.google.com/docs/authentication/getting-started).
+
+## Install Dependencies
+
+To install the dependencies for this sample, use the following command:
+
+```
+pip install -r requirements.txt
+```
+
+This sample uses the common protos in the [googleapis](https://github.com/googleapis/googleapis)
+repository. For more info, see
+[Protocol Buffer Basics](https://developers.google.com/protocol-buffers/docs/pythontutorial).
+
+## Creating a queue
+
+To create a queue (named `my-queue`) using the Cloud SDK, use the following
+gcloud command:
+
+```
+gcloud tasks queues create my-queue
+```
+
+## Run the Sample Using the Command Line
+
+Set environment variables:
+
+First, your project ID:
+
+```
+export PROJECT_ID=my-project-id
+```
+
+Then the queue ID, as specified at queue creation time. Queue IDs already
+created can be listed with `gcloud tasks queues list`.
+
+```
+export QUEUE_ID=my-queue
+```
+
+And finally the location ID, which can be discovered with
+`gcloud tasks queues describe my-queue`, with the location embedded in
+the "name" value (for instance, if the name is
+"projects/my-project/locations/us-central1/queues/my-queue", then the
+location is "us-central1").
+
+```
+export LOCATION_ID=us-central1
+```
+
+### Creating Tasks with HTTP Targets
+
+Set an environment variable for the endpoint to your task handler. This is an
+example url:
+```
+export URL=https://example.com/task_handler
+```
+
+Running the sample will create a task and send the task to the specific URL
+endpoint, with a payload specified:
+
+```
+python create_http_task.py --project=$PROJECT_ID --queue=$QUEUE_ID --location=$LOCATION_ID --url=$URL --payload=hello
+```

--- a/cloud_tasks/snippets/create_queue.py
+++ b/cloud_tasks/snippets/create_queue.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START cloud_tasks_create_queue]
+def create_queue(project, queue_name, location):
+    """Create a task queue."""
+
+    from google.cloud import tasks_v2
+
+    # Create a client.
+    client = tasks_v2.CloudTasksClient()
+
+    # Construct the fully qualified location path.
+    parent = f"projects/{project}/locations/{location}"
+
+    # Construct the create queue request.
+    queue = {"name": client.queue_path(project, location, queue_name)}
+
+    # Use the client to create the queue.
+    response = client.create_queue(request={"parent": parent, "queue": queue})
+
+    print("Created queue {}".format(response.name))
+    return response
+
+
+# [END cloud_tasks_create_queue]

--- a/cloud_tasks/snippets/create_queue_test.py
+++ b/cloud_tasks/snippets/create_queue_test.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import uuid
+
+from google.cloud import tasks_v2
+import pytest
+
+import create_queue
+
+TEST_PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
+TEST_LOCATION = os.getenv("TEST_QUEUE_LOCATION", "us-central1")
+TEST_QUEUE_NAME = f"my-queue-{uuid.uuid4().hex}"
+
+
+@pytest.fixture()
+def test_queue():
+    client = tasks_v2.CloudTasksClient()
+    q = create_queue.create_queue(TEST_PROJECT_ID, TEST_QUEUE_NAME, TEST_LOCATION)
+
+    yield q
+
+    client.delete_queue(request={"name": q.name})
+
+
+def test_create_queue(capsys, test_queue):
+    out, _ = capsys.readouterr()
+    assert "Created queue" in out

--- a/cloud_tasks/snippets/delete_queue.py
+++ b/cloud_tasks/snippets/delete_queue.py
@@ -1,0 +1,32 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START cloud_tasks_delete_queue]
+def delete_queue(project, queue_name, location):
+    """Delete a task queue."""
+
+    from google.cloud import tasks_v2
+
+    # Create a client.
+    client = tasks_v2.CloudTasksClient()
+
+    # Get the fully qualified path to queue.
+    queue = client.queue_path(project, location, queue_name)
+
+    # Use the client to delete the queue.
+    client.delete_queue(request={"name": queue})
+    print("Deleted queue")
+
+
+# [END cloud_tasks_delete_queue]

--- a/cloud_tasks/snippets/delete_queue_test.py
+++ b/cloud_tasks/snippets/delete_queue_test.py
@@ -1,0 +1,52 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import uuid
+
+from google.api_core import exceptions
+from google.cloud import tasks_v2
+import pytest
+
+import delete_queue
+
+TEST_PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
+TEST_LOCATION = os.getenv("TEST_QUEUE_LOCATION", "us-central1")
+TEST_QUEUE_NAME = f"my-queue-{uuid.uuid4().hex}"
+
+
+@pytest.fixture()
+def test_queue():
+    client = tasks_v2.CloudTasksClient()
+    parent = f"projects/{TEST_PROJECT_ID}/locations/{TEST_LOCATION}"
+    queue = {
+        # The fully qualified path to the queue
+        "name": client.queue_path(TEST_PROJECT_ID, TEST_LOCATION, TEST_QUEUE_NAME),
+    }
+    q = client.create_queue(request={"parent": parent, "queue": queue})
+
+    yield q
+
+    try:
+        # Attempt to delete the queue in case the sample failed.
+        client.delete_queue(request={"name": q.name})
+    except exceptions.NotFound:
+        # The queue was already successfully deleted.
+        print("Queue already deleted successfully")
+
+
+def test_delete_queue(capsys, test_queue):
+    delete_queue.delete_queue(TEST_PROJECT_ID, TEST_QUEUE_NAME, TEST_LOCATION)
+    out, _ = capsys.readouterr()
+    assert "Deleted queue" in out

--- a/cloud_tasks/snippets/list_queues.py
+++ b/cloud_tasks/snippets/list_queues.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START cloud_tasks_list_queues]
+def list_queues(project, location):
+    """List all task queues."""
+
+    from google.cloud import tasks_v2
+
+    # Create a client.
+    client = tasks_v2.CloudTasksClient()
+
+    # Construct the fully qualified location path.
+    parent = f"projects/{project}/locations/{location}"
+
+    # Use the client to obtain the queues.
+    response = client.list_queues(request={"parent": parent})
+
+    # Print the results.
+    num_results = 0
+    for queue in response:
+        num_results = num_results + 1
+        print(queue.name)
+
+    if num_results == 0:
+        print("No queues found!")
+
+
+# [END cloud_tasks_list_queues]

--- a/cloud_tasks/snippets/list_queues_test.py
+++ b/cloud_tasks/snippets/list_queues_test.py
@@ -1,0 +1,54 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import uuid
+
+from google.cloud import tasks_v2
+import pytest
+
+import list_queues
+
+TEST_PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
+TEST_LOCATION = os.getenv("TEST_QUEUE_LOCATION", "us-central1")
+TEST_QUEUE_NAME = f"my-queue-{uuid.uuid4().hex}"
+
+
+@pytest.fixture()
+def test_queue():
+    client = tasks_v2.CloudTasksClient()
+    parent = f"projects/{TEST_PROJECT_ID}/locations/{TEST_LOCATION}"
+    queue = {
+        # The fully qualified path to the queue
+        "name": client.queue_path(TEST_PROJECT_ID, TEST_LOCATION, TEST_QUEUE_NAME),
+    }
+    q = client.create_queue(request={"parent": parent, "queue": queue})
+
+    yield q
+
+    client.delete_queue(request={"name": q.name})
+
+
+def test_list_queues_not_present(capsys):
+    list_queues.list_queues(TEST_PROJECT_ID, TEST_LOCATION)
+    out, _ = capsys.readouterr()
+
+    assert TEST_QUEUE_NAME not in out
+
+
+def test_list_queues_present(capsys, test_queue):
+    list_queues.list_queues(TEST_PROJECT_ID, TEST_LOCATION)
+    out, _ = capsys.readouterr()
+
+    assert TEST_QUEUE_NAME in out


### PR DESCRIPTION
- docs: add samples from python-docs-samples/tasks (#36)
- feat!: migrate to use microgen (#38)
- chore(python): add nox session to sort python imports (#254)

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
