### PR TITLE
fix: update OWNERS and blunderbuss

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,8 +35,10 @@
 /compute/**/*                          @m-strzelczyk @GoogleCloudPlatform/dee-infra @GoogleCloudPlatform/python-samples-reviewers
 /container/**/*                        @GoogleCloudPlatform/dee-platform-ops @GoogleCloudPlatform/python-samples-reviewers
 /data-science-onramp/                  @leahecole @bradmiro @GoogleCloudPlatform/python-samples-reviewers
+/datacatalog/**/*                      @GoogleCloudPlatform/python-samples-reviewers
 /dataflow/**/*                         @davidcavazos @GoogleCloudPlatform/python-samples-reviewers
 /datalabeling/**/*                     @GoogleCloudPlatform/python-samples-reviewers @ivanmkc
+/dataproc/**/*                         @GoogleCloudPlatform/python-samples-reviewers
 /datastore/**/*                        @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/python-samples-reviewers
 /dns/**/*                              @GoogleCloudPlatform/python-samples-reviewers
 /endpoints/**/*                        @GoogleCloudPlatform/python-samples-reviewers
@@ -50,6 +52,7 @@
 /iap/**/*                              @GoogleCloudPlatform/python-samples-reviewers
 /iot/**/*                              @gcseh @GoogleCloudPlatform/api-iot @GoogleCloudPlatform/python-samples-reviewers
 /jobs/**/*                             @GoogleCloudPlatform/python-samples-reviewers
+/kms/**/**                             @GoogleCloudPlatform/dee-infra @GoogleCloudPlatform/python-samples-reviewers
 /kubernetes_engine/**/*                @GoogleCloudPlatform/python-samples-reviewers
 /kubernetes_engine/django_tutorial/**/*    @glasnt @GoogleCloudPlatform/python-samples-reviewers
 /media_cdn/**/*                        @justin-mp @msampathkumar @GoogleCloudPlatform/python-samples-reviewers
@@ -76,6 +79,3 @@
 /talent/**/*                           @GoogleCloudPlatform/python-samples-reviewers
 /vision/**/*                           @GoogleCloudPlatform/python-samples-reviewers
 /workflows/**/*                        @GoogleCloudPlatform/python-samples-reviewers
-/datacatalog/**/*                      @GoogleCloudPlatform/python-samples-reviewers
-/kms/**/**                             @GoogleCloudPlatform/dee-infra @GoogleCloudPlatform/python-samples-reviewers
-/dataproc/**/**                        @GoogleCloudPlatform/cloud-dpes @GoogleCloudPlatform/python-samples-reviewers

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -44,6 +44,7 @@ assign_issues_by:
   - GoogleCloudPlatform/torus-dpe
 - labels:
   - 'api: cloudsql'
+  - 'api: cloudtasks'
   to:
   - GoogleCloudPlatform/infra-db-dpes
 - labels:
@@ -58,6 +59,7 @@ assign_issues_by:
   - m-strzelczyk
 - labels:
   - 'api: container'
+  - 'api: texttospeech'
   to:
   - GoogleCloudPlatform/dee-platform-ops
 - labels:
@@ -131,26 +133,28 @@ assign_issues_by:
   to:
   - GoogleCloudPlatform/dee-observability
 - labels:
-  - 'api: texttospeech'
-  to:
-  - GoogleCloudPlatform/dee-platform-ops
-- labels:
-  - 'api: datacatalog'
-  to:
-  - GoogleCloudPlatform/python-samples-reviewers
-- labels:
   - 'api: kms'
   - 'api: cloudkms'
-  to: 
+  to:
   - GoogleCloudPlatform/dee-infra
 - labels:
   - 'api: vision'
   to:
-  - GoogleCloudPlatform/python-samples-reviewers
+  - GoogleCloudPlatform/ml-apis
 - labels:
+  - 'api: bigtable'
+  - 'api: datastore'
+  - 'api: firestore'
+  to:
+  - GoogleCloudPlatform/cloud-native-db-dpes
+- labels:
+  - 'api: datacatalog'
+  - 'api: dataproc'
+  - 'api: clouderrorreporting'
+  - 'api: talent'
   - 'api: vision'
   to:
-  - GoogleCloudPlatform/ml-apis
+  - GoogleCloudPlatform/python-samples-reviewers
 
 assign_prs_by:
 - labels:
@@ -169,21 +173,10 @@ assign_prs_by:
   to:
   - GoogleCloudPlatform/api-iot
 - labels:
-  - 'api: clouderrorreporting'
-  to:
-  - GoogleCloudPlatform/python-samples-reviewers
-- labels:
-  - 'api: talent'
-  to:
-  - GoogleCloudPlatform/python-samples-reviewers
-- labels:
+  - 'api: cloudsql'
   - 'api: cloudtasks'
   to:
   - GoogleCloudPlatform/infra-db-dpes
-- labels:
-  - 'api: dataproc'
-  to:
-  - GoogleCloudPlatform/cloud-dpes
 
 assign_issues:
   - GoogleCloudPlatform/python-samples-owners


### PR DESCRIPTION
## Description

Sorting CODEOWNERS entry, removing `GoogleCloudPlatform/cloud-dpes` team and updating blunderbuss.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
