### PR TITLE
fix: remove dee-po team from texttospeech

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,7 +76,7 @@
 /secretmanager/**/*                    @GoogleCloudPlatform/aap-dpes @GoogleCloudPlatform/python-samples-reviewers
 /storage/**/*                          @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers
 /storagetransfer/**/*                  @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers
-/texttospeech/**/*                     @GoogleCloudPlatform/python-samples-reviewers
+/texttospeech/**/*                     @GoogleCloudPlatform/dee-data-ai @GoogleCloudPlatform/python-samples-reviewers
 /trace/**/*                            @ymotongpoo @GoogleCloudPlatform/python-samples-reviewers
 /translate/**/*                        @nicain @GoogleCloudPlatform/python-samples-reviewers
 /talent/**/*                           @GoogleCloudPlatform/python-samples-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -76,7 +76,7 @@
 /secretmanager/**/*                    @GoogleCloudPlatform/aap-dpes @GoogleCloudPlatform/python-samples-reviewers
 /storage/**/*                          @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers
 /storagetransfer/**/*                  @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers
-/texttospeech/**/*                     @GoogleCloudPlatform/dee-platform-ops @GoogleCloudPlatform/python-samples-reviewers
+/texttospeech/**/*                     @GoogleCloudPlatform/python-samples-reviewers
 /trace/**/*                            @ymotongpoo @GoogleCloudPlatform/python-samples-reviewers
 /translate/**/*                        @nicain @GoogleCloudPlatform/python-samples-reviewers
 /talent/**/*                           @GoogleCloudPlatform/python-samples-reviewers

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -90,6 +90,7 @@ assign_issues_by:
   - GoogleCloudPlatform/api-iot
 - labels:
   - 'api: language'
+  - 'api: texttospeech'
   to:
     - GoogleCloudPlatform/dee-data-ai
 - labels:

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -59,7 +59,6 @@ assign_issues_by:
   - m-strzelczyk
 - labels:
   - 'api: container'
-  - 'api: texttospeech'
   to:
   - GoogleCloudPlatform/dee-platform-ops
 - labels:


### PR DESCRIPTION
## Description
Blunderbuss assigned me https://github.com/GoogleCloudPlatform/python-docs-samples/issues/8697 . The Platform ops team doesn't maintain `texttospeech`. 🥲 
Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
