### PR TITLE
docs(api-key-samples): patch for flaky test, added sleep time

### DIFF
--- a/auth/api-client/api_key_test.py
+++ b/auth/api-client/api_key_test.py
@@ -37,7 +37,7 @@ SERVICE_ACCOUNT_FILE = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 @pytest.fixture(scope="module")
 def api_key():
     api_key = create_api_key.create_api_key(PROJECT)
-    sleep(10)
+    sleep(20)
     yield api_key
     delete_api_key.delete_api_key(PROJECT, get_key_id(api_key.name))
 

--- a/auth/api-client/api_key_test.py
+++ b/auth/api-client/api_key_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import re
+from time import sleep
 
 from _pytest.capture import CaptureFixture
 import google.auth.transport.requests
@@ -36,6 +37,7 @@ SERVICE_ACCOUNT_FILE = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 @pytest.fixture(scope="module")
 def api_key():
     api_key = create_api_key.create_api_key(PROJECT)
+    sleep(10)
     yield api_key
     delete_api_key.delete_api_key(PROJECT, get_key_id(api_key.name))
 


### PR DESCRIPTION
Fixes #8787 

The flakiness could be because the key creation wasn't completed before the tests started executing.
