### PR TITLE
test: add retries to monitoring tests

### DIFF
--- a/monitoring/snippets/v3/cloud-client/snippets_test.py
+++ b/monitoring/snippets/v3/cloud-client/snippets_test.py
@@ -18,7 +18,7 @@ import re
 import backoff
 from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import NotFound
-from google.api_core.exceptions import ServiceUnavailable;
+from google.api_core.exceptions import ServiceUnavailable
 import pytest
 
 import snippets

--- a/monitoring/snippets/v3/cloud-client/snippets_test.py
+++ b/monitoring/snippets/v3/cloud-client/snippets_test.py
@@ -66,11 +66,13 @@ def test_get_delete_metric_descriptor(capsys, custom_metric_descriptor):
         out, _ = capsys.readouterr()
     assert "Deleted metric" in out
 
+
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_metric_descriptors(capsys):
     snippets.list_metric_descriptors(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "logging.googleapis.com/byte_count" in out
+
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_resources(capsys):
@@ -78,11 +80,13 @@ def test_list_resources(capsys):
     out, _ = capsys.readouterr()
     assert "pubsub_topic" in out
 
+
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_get_resources(capsys):
     snippets.get_monitored_resource_descriptor(PROJECT_ID, "pubsub_topic")
     out, _ = capsys.readouterr()
     assert "A topic in Google Cloud Pub/Sub" in out
+
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series(capsys, write_time_series):
@@ -90,11 +94,13 @@ def test_list_time_series(capsys, write_time_series):
     out, _ = capsys.readouterr()
     assert "gce_instance" in out
 
+
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series_header(capsys, write_time_series):
     snippets.list_time_series_header(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "gce_instance" in out
+
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series_aggregate(capsys, write_time_series):
@@ -104,6 +110,7 @@ def test_list_time_series_aggregate(capsys, write_time_series):
     assert "interval" in out
     assert "start_time" in out
     assert "end_time" in out
+
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series_reduce(capsys, write_time_series):

--- a/monitoring/snippets/v3/cloud-client/snippets_test.py
+++ b/monitoring/snippets/v3/cloud-client/snippets_test.py
@@ -66,37 +66,37 @@ def test_get_delete_metric_descriptor(capsys, custom_metric_descriptor):
         out, _ = capsys.readouterr()
     assert "Deleted metric" in out
 
-
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_metric_descriptors(capsys):
     snippets.list_metric_descriptors(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "logging.googleapis.com/byte_count" in out
 
-
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_resources(capsys):
     snippets.list_monitored_resources(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "pubsub_topic" in out
 
-
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_get_resources(capsys):
     snippets.get_monitored_resource_descriptor(PROJECT_ID, "pubsub_topic")
     out, _ = capsys.readouterr()
     assert "A topic in Google Cloud Pub/Sub" in out
 
-
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series(capsys, write_time_series):
     snippets.list_time_series(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "gce_instance" in out
 
-
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series_header(capsys, write_time_series):
     snippets.list_time_series_header(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "gce_instance" in out
 
-
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series_aggregate(capsys, write_time_series):
     snippets.list_time_series_aggregate(PROJECT_ID)
     out, _ = capsys.readouterr()
@@ -105,7 +105,7 @@ def test_list_time_series_aggregate(capsys, write_time_series):
     assert "start_time" in out
     assert "end_time" in out
 
-
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_list_time_series_reduce(capsys, write_time_series):
     snippets.list_time_series_reduce(PROJECT_ID)
     out, _ = capsys.readouterr()

--- a/monitoring/snippets/v3/cloud-client/snippets_test.py
+++ b/monitoring/snippets/v3/cloud-client/snippets_test.py
@@ -18,6 +18,7 @@ import re
 import backoff
 from google.api_core.exceptions import InternalServerError
 from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import ServiceUnavailable;
 import pytest
 
 import snippets
@@ -67,42 +68,42 @@ def test_get_delete_metric_descriptor(capsys, custom_metric_descriptor):
     assert "Deleted metric" in out
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable), max_tries=3)
 def test_list_metric_descriptors(capsys):
     snippets.list_metric_descriptors(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "logging.googleapis.com/byte_count" in out
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable), max_tries=3)
 def test_list_resources(capsys):
     snippets.list_monitored_resources(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "pubsub_topic" in out
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable), max_tries=3)
 def test_get_resources(capsys):
     snippets.get_monitored_resource_descriptor(PROJECT_ID, "pubsub_topic")
     out, _ = capsys.readouterr()
     assert "A topic in Google Cloud Pub/Sub" in out
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable), max_tries=3)
 def test_list_time_series(capsys, write_time_series):
     snippets.list_time_series(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "gce_instance" in out
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable), max_tries=3)
 def test_list_time_series_header(capsys, write_time_series):
     snippets.list_time_series_header(PROJECT_ID)
     out, _ = capsys.readouterr()
     assert "gce_instance" in out
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable), max_tries=3)
 def test_list_time_series_aggregate(capsys, write_time_series):
     snippets.list_time_series_aggregate(PROJECT_ID)
     out, _ = capsys.readouterr()
@@ -112,7 +113,7 @@ def test_list_time_series_aggregate(capsys, write_time_series):
     assert "end_time" in out
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable), max_tries=3)
 def test_list_time_series_reduce(capsys, write_time_series):
     snippets.list_time_series_reduce(PROJECT_ID)
     out, _ = capsys.readouterr()


### PR DESCRIPTION
Monitoring tests failed a few weeks ago due to timeouts. This PR adds backoff support to retry these tests, reducing the chance of flakiness.

Fixes #8817 
Fixes #8818 
Fixes #8819 