### PR TITLE
Updates to `run/image-processing/e2e_test.py`

### DIFF
--- a/run/image-processing/cloudbuild.yaml
+++ b/run/image-processing/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
       ["build", "-t", "${_AR_REPO_URL}/vision-e2e-test:${BUILD_ID}", "."]
   - id: "Docker push to Artifact Registry"
     name: "gcr.io/cloud-builders/docker"
-    args: ["push", "${_AR_REPO_URL}/filesystem-e2e-test:${BUILD_ID}"]
+    args: ["push", "${_AR_REPO_URL}/vision-e2e-test:${BUILD_ID}"]
   # - id: "Deploy to Cloud Run"
   #   name: "gcr.io/cloud-builders/gcloud:latest"
   #   args:

--- a/run/image-processing/cloudbuild.yaml
+++ b/run/image-processing/cloudbuild.yaml
@@ -13,10 +13,11 @@ steps:
   - id: "Docker build"
     name: "gcr.io/cloud-builders/docker"
     args:
-      ["build", "-t", "${_AR_REPO_URL}/vision-e2e-test:${BUILD_ID}", "."]
+    # TODO: replace _TAG with $BUILD_ID
+      ["build", "-t", "${_AR_REPO_URL}/vision-e2e-test:${_TAG}", "."]
   - id: "Docker push to Artifact Registry"
     name: "gcr.io/cloud-builders/docker"
-    args: ["push", "${_AR_REPO_URL}/vision-e2e-test:${BUILD_ID}"]
+    args: ["push", "${_AR_REPO_URL}/vision-e2e-test:${_TAG}"]
 substitutions:
   _AR_REPO_URL: us-central1-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy
 

--- a/run/image-processing/cloudbuild.yaml
+++ b/run/image-processing/cloudbuild.yaml
@@ -17,23 +17,7 @@ steps:
   - id: "Docker push to Artifact Registry"
     name: "gcr.io/cloud-builders/docker"
     args: ["push", "${_AR_REPO_URL}/vision-e2e-test:${BUILD_ID}"]
-  # - id: "Deploy to Cloud Run"
-  #   name: "gcr.io/cloud-builders/gcloud:latest"
-  #   args:
-  #     - beta
-  #     - run
-  #     - deploy
-  #     - ${_SERVICE_NAME}
-  #     - --image=${_AR_REPO_URL}/filesystem-e2e-test:${BUILD_ID}
-  #     - --execution-environment=gen2
-  #     - --vpc-connector=${_CONNECTOR}
-  #     - --update-env-vars=FILESTORE_IP_ADDRESS=${_FILESTORE_IP_ADDRESS},FILE_SHARE_NAME=${_FILESHARE}
-  #     - --region=${_DEPLOY_REGION}
-  #     - --no-allow-unauthenticated
-
 substitutions:
-  # _DEPLOY_REGION: us-central1
-  # _FILESHARE: vol1
   _AR_REPO_URL: us-central1-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy
 
 options:

--- a/run/image-processing/cloudbuild.yaml
+++ b/run/image-processing/cloudbuild.yaml
@@ -1,0 +1,40 @@
+# Copyright 2023 Google LLC
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: "Docker build"
+    name: "gcr.io/cloud-builders/docker"
+    args:
+      ["build", "-t", "${_AR_REPO_URL}/vision-e2e-test:${BUILD_ID}", "."]
+  - id: "Docker push to Artifact Registry"
+    name: "gcr.io/cloud-builders/docker"
+    args: ["push", "${_AR_REPO_URL}/filesystem-e2e-test:${BUILD_ID}"]
+  # - id: "Deploy to Cloud Run"
+  #   name: "gcr.io/cloud-builders/gcloud:latest"
+  #   args:
+  #     - beta
+  #     - run
+  #     - deploy
+  #     - ${_SERVICE_NAME}
+  #     - --image=${_AR_REPO_URL}/filesystem-e2e-test:${BUILD_ID}
+  #     - --execution-environment=gen2
+  #     - --vpc-connector=${_CONNECTOR}
+  #     - --update-env-vars=FILESTORE_IP_ADDRESS=${_FILESTORE_IP_ADDRESS},FILE_SHARE_NAME=${_FILESHARE}
+  #     - --region=${_DEPLOY_REGION}
+  #     - --no-allow-unauthenticated
+
+substitutions:
+  # _DEPLOY_REGION: us-central1
+  # _FILESHARE: vol1
+  _AR_REPO_URL: us-central1-docker.pkg.dev/${PROJECT_ID}/cloud-run-source-deploy
+
+options:
+  dynamic_substitutions: true

--- a/run/image-processing/e2e_test.py
+++ b/run/image-processing/e2e_test.py
@@ -29,7 +29,8 @@ import pytest
 
 SUFFIX = uuid.uuid4().hex[0:6]
 PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
-IMAGE_NAME = f"us-central1-docker.pkg.dev/{PROJECT}/cloud-run-source-deploy/vision-e2e-test/"
+AR_REPO_URL=f"us-central1-docker.pkg.dev/{PROJECT}/cloud-run-source-deploy"
+IMAGE_NAME = f"{AR_REPO_URL}/vision-e2e-test:{SUFFIX}"
 CLOUD_RUN_SERVICE = f"image-proc-{SUFFIX}"
 INPUT_BUCKET = f"image-proc-input-{SUFFIX}"
 OUTPUT_BUCKET = f"image-proc-output-{SUFFIX}"
@@ -47,7 +48,8 @@ def container_image():
             "--config",
             "cloudbuild.yaml",
             "--project",
-            PROJECT
+            PROJECT,
+            f"--substitutions=_TAG={SUFFIX}"
         ]
     )
     yield IMAGE_NAME

--- a/run/image-processing/e2e_test.py
+++ b/run/image-processing/e2e_test.py
@@ -30,7 +30,6 @@ import pytest
 SUFFIX = uuid.uuid4().hex[0:6]
 PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
 IMAGE_NAME = f"us-central1-docker.pkg.dev/{PROJECT}/cloud-run-source-deploy/vision-e2e-test/"
-# IMAGE_NAME = f"gcr.io/{PROJECT}/image-proc-{SUFFIX}"
 CLOUD_RUN_SERVICE = f"image-proc-{SUFFIX}"
 INPUT_BUCKET = f"image-proc-input-{SUFFIX}"
 OUTPUT_BUCKET = f"image-proc-output-{SUFFIX}"
@@ -45,11 +44,10 @@ def container_image():
             "gcloud",
             "builds",
             "submit",
-            "--tag",
-            IMAGE_NAME,
+            "--config",
+            "cloudbuild.yaml",
             "--project",
-            PROJECT,
-            "--quiet",
+            PROJECT
         ]
     )
     yield IMAGE_NAME

--- a/run/image-processing/e2e_test.py
+++ b/run/image-processing/e2e_test.py
@@ -29,7 +29,8 @@ import pytest
 
 SUFFIX = uuid.uuid4().hex[0:6]
 PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
-IMAGE_NAME = f"gcr.io/{PROJECT}/image-proc-{SUFFIX}"
+IMAGE_NAME = f"us-central1-docker.pkg.dev/{PROJECT}/cloud-run-source-deploy/vision-e2e-test/"
+# IMAGE_NAME = f"gcr.io/{PROJECT}/image-proc-{SUFFIX}"
 CLOUD_RUN_SERVICE = f"image-proc-{SUFFIX}"
 INPUT_BUCKET = f"image-proc-input-{SUFFIX}"
 OUTPUT_BUCKET = f"image-proc-output-{SUFFIX}"
@@ -52,21 +53,6 @@ def container_image():
         ]
     )
     yield IMAGE_NAME
-
-    # Delete container image
-    subprocess.check_call(
-        [
-            "gcloud",
-            "container",
-            "images",
-            "delete",
-            IMAGE_NAME,
-            "--quiet",
-            "--project",
-            PROJECT,
-        ]
-    )
-
 
 @pytest.fixture
 def deployed_service(container_image, output_bucket):

--- a/run/image-processing/e2e_test.py
+++ b/run/image-processing/e2e_test.py
@@ -29,7 +29,7 @@ import pytest
 
 SUFFIX = uuid.uuid4().hex[0:6]
 PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
-AR_REPO_URL=f"us-central1-docker.pkg.dev/{PROJECT}/cloud-run-source-deploy"
+AR_REPO_URL = f"us-central1-docker.pkg.dev/{PROJECT}/cloud-run-source-deploy"
 IMAGE_NAME = f"{AR_REPO_URL}/vision-e2e-test:{SUFFIX}"
 CLOUD_RUN_SERVICE = f"image-proc-{SUFFIX}"
 INPUT_BUCKET = f"image-proc-input-{SUFFIX}"
@@ -53,6 +53,7 @@ def container_image():
         ]
     )
     yield IMAGE_NAME
+
 
 @pytest.fixture
 def deployed_service(container_image, output_bucket):


### PR DESCRIPTION
## Description

Addresses #8832 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample


This PR makes a few changes to the e2e test for the `image-processing` sample:
- Uses a `cloudbuild.yaml` configuration to build and push image
- Retains image instead of deleting it
- Uses artifact registry instead of container registry

With this PR all images for image-processing e2e tests will be pushed to Artifact registry repo `cloud-run-source-deploy`
