### PR TITLE
Remove arbitrary equals - not supported by MEND renovate

### DIFF
--- a/appengine/flexible/scipy/requirements.txt
+++ b/appengine/flexible/scipy/requirements.txt
@@ -3,7 +3,7 @@ Flask==2.0.3; python_version < '3.7'
 gunicorn==20.1.0
 imageio==2.14.0
 numpy==1.22.0; python_version > "3.7"
-numpy===1.21.4; python_version <= "3.7"
+numpy==1.21.4; python_version <= "3.7"
 pillow==9.2.0
 scipy==1.8.0; python_version > "3.7"
 scipy==1.7.3; python_version <= "3.7"

--- a/appengine/standard/firebase/firenotes/backend/requirements.txt
+++ b/appengine/standard/firebase/firenotes/backend/requirements.txt
@@ -1,8 +1,8 @@
-Flask===1.1.4; python_version < '3.0'
-Flask===2.1.0; python_version > '3.0'
-pyjwt===1.7.1; python_version < '3.0'
+Flask==1.1.4; python_version < '3.0'
+Flask==2.1.0; python_version > '3.0'
+pyjwt==1.7.1; python_version < '3.0'
 flask-cors==3.0.10
-google-auth===2.6.2; python_version < '3.0'
-google-auth===2.6.2; python_version > '3.0'
+google-auth==2.6.2; python_version < '3.0'
+google-auth==2.6.2; python_version > '3.0'
 requests==2.27.1
 requests-toolbelt==0.10.0

--- a/appengine/standard/migration/taskqueue/counter/requirements.txt
+++ b/appengine/standard/migration/taskqueue/counter/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.4; python_version < '3.0'
 Flask==2.1.0; python_version > '3.0'
 google-cloud-datastore==2.7.1; python_version >= "3.0"
-google-cloud-datastore===1.15.5; python_version < "3.0"
+google-cloud-datastore==1.15.5; python_version < "3.0"
 google-cloud-tasks==2.7.1 ; python_version >= "3.0"
 google-cloud-tasks==1.5.2 ; python_version < "3.0"

--- a/appengine/standard/migration/taskqueue/pull-counter/requirements.txt
+++ b/appengine/standard/migration/taskqueue/pull-counter/requirements.txt
@@ -1,7 +1,7 @@
 Flask==1.1.4; python_version < '3.0'
 Flask==2.1.0; python_version > '3.0'
 google-cloud-datastore==2.7.1 ; python_version >= "3.0"
-google-cloud-datastore===1.15.5 ; python_version < "3.0"
+google-cloud-datastore==1.15.5 ; python_version < "3.0"
 google-cloud-pubsub==2.9.0 ; python_version >= "3.0"
 # 1.7.0 is the latest compatible version for Python 2.
 google-cloud-pubsub==1.7.2 ; python_version < "3.0"

--- a/bigquery/datalab-migration/requirements.txt
+++ b/bigquery/datalab-migration/requirements.txt
@@ -2,7 +2,7 @@ grpcio==1.47.0
 google-cloud-bigquery[pandas,pyarrow]==2.34.4
 # datalab has outdated dependencies that require google-api-core < 2
 # The last version of google-cloud-bigquery-storage that supports google-api-core 1.x is 2.13.2
-google-cloud-bigquery-storage===2.13.2
+google-cloud-bigquery-storage==2.13.2
 datalab==1.2.1
 ipython==8.0.1
 pyarrow==6.0.1

--- a/compute/oslogin/requirements-test.txt
+++ b/compute/oslogin/requirements-test.txt
@@ -1,5 +1,5 @@
-backoff===1.11.1; python_version < "3.7"
-backoff===2.0.0; python_version >= "3.7"
+backoff==1.11.1; python_version < "3.7"
+backoff==2.0.0; python_version >= "3.7"
 pytest==7.0.1
 mock==4.0.3
 google-cloud-iam==2.9.0

--- a/iot/api-client/gcs_file_to_device/requirements.txt
+++ b/iot/api-client/gcs_file_to_device/requirements.txt
@@ -3,7 +3,7 @@ google-auth==2.6.2
 google-auth-httplib2==0.1.0
 google-cloud-iot==2.5.1
 google-cloud-pubsub==2.9.0
-google-cloud-storage===2.0.0; python_version < '3.7'
+google-cloud-storage==2.0.0; python_version < '3.7'
 google-cloud-storage==2.1.0; python_version > '3.6'
 cryptography==38.0.3
 paho-mqtt==1.6.1

--- a/language/snippets/classify_text/requirements.txt
+++ b/language/snippets/classify_text/requirements.txt
@@ -1,3 +1,3 @@
 google-cloud-language==2.6.1
 numpy==1.23.4; python_version > '3.7'
-numpy===1.21.4; python_version == '3.7'
+numpy==1.21.4; python_version == '3.7'


### PR DESCRIPTION
Mend Renovate's [dashboard](https://app.renovatebot.com/dashboard#github/GoogleCloudPlatform/python-docs-samples/959440112) for our repo has been showing a warning because [arbitrary equality](https://peps.python.org/pep-0440/#arbitrary-equality) is not supported in requirements files. I think that it was inadvertently added by a different bot 🤖 . Given that it's considered not great practice and is throwing warnings, i've removed the few instances of it to quiet our robot friend. 
![image](https://user-images.githubusercontent.com/6719667/210825481-96ebfbae-5161-4792-b4b3-64bce2daad67.png)
(alt text for image - screenshot of renovate bot job log showing "unexpected range error" and a message of "PEP440 arbitrary equality (===) not supported")
