### PR TITLE
chore(GAE Python3): add HTTP retries to flaky test

### DIFF
--- a/appengine/standard_python3/bundled-services/blobstore/django/main_test.py
+++ b/appengine/standard_python3/bundled-services/blobstore/django/main_test.py
@@ -65,6 +65,15 @@ def version():
     result = gcloud_cli(f"app deploy --no-promote --version={uuid.uuid4().hex}")
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
+    version_hostname = f"{version_id}-dot-{project_id}.appspot.com"
+
+    # Wait for app to initialize
+    @backoff.on_exception(backoff.expo, requests.exceptions.HTTPError, max_tries=3)
+    def wait_for_app(url):
+        r = requests.get(url)
+        r.raise_for_status()
+
+    wait_for_app(f"https://{version_hostname}/")
 
     yield project_id, version_id
 

--- a/appengine/standard_python3/bundled-services/blobstore/flask/main_test.py
+++ b/appengine/standard_python3/bundled-services/blobstore/flask/main_test.py
@@ -65,6 +65,15 @@ def version():
     result = gcloud_cli(f"app deploy --no-promote --version={uuid.uuid4().hex}")
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
+    version_hostname = f"{version_id}-dot-{project_id}.appspot.com"
+
+    # Wait for app to initialize
+    @backoff.on_exception(backoff.expo, requests.exceptions.HTTPError, max_tries=3)
+    def wait_for_app(url):
+        r = requests.get(url)
+        r.raise_for_status()
+
+    wait_for_app(f"https://{version_hostname}/")
 
     yield project_id, version_id
 

--- a/appengine/standard_python3/bundled-services/deferred/django/main_test.py
+++ b/appengine/standard_python3/bundled-services/deferred/django/main_test.py
@@ -65,6 +65,12 @@ def version():
     result = gcloud_cli(f"app deploy --no-promote --version={uuid.uuid4().hex}")
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
+    version_hostname = f"{version_id}-dot-{project_id}.appspot.com"
+    
+    # Wait for app to initialize
+    for i in range(6):
+        if requests.get(f"https://{version_hostname}/counter/get").status != 200:
+            time.sleep(2 ** i)
 
     yield project_id, version_id
 

--- a/appengine/standard_python3/bundled-services/deferred/flask/main_test.py
+++ b/appengine/standard_python3/bundled-services/deferred/flask/main_test.py
@@ -65,6 +65,15 @@ def version():
     result = gcloud_cli(f"app deploy --no-promote --version={uuid.uuid4().hex}")
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
+    version_hostname = f"{version_id}-dot-{project_id}.appspot.com"
+
+    # Wait for app to initialize
+    @backoff.on_exception(backoff.expo, requests.exceptions.HTTPError, max_tries=3)
+    def wait_for_app(url):
+        r = requests.get(url)
+        r.raise_for_status()
+
+    wait_for_app(f"https://{version_hostname}/counter/get")
 
     yield project_id, version_id
 

--- a/appengine/standard_python3/bundled-services/deferred/wsgi/main_test.py
+++ b/appengine/standard_python3/bundled-services/deferred/wsgi/main_test.py
@@ -65,6 +65,15 @@ def version():
     result = gcloud_cli(f"app deploy --no-promote --version={uuid.uuid4().hex}")
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
+    version_hostname = f"{version_id}-dot-{project_id}.appspot.com"
+
+    # Wait for app to initialize
+    @backoff.on_exception(backoff.expo, requests.exceptions.HTTPError, max_tries=3)
+    def wait_for_app(url):
+        r = requests.get(url)
+        r.raise_for_status()
+
+    wait_for_app(f"https://{version_hostname}/counter/get")
 
     yield project_id, version_id
 

--- a/appengine/standard_python3/bundled-services/mail/django/main_test.py
+++ b/appengine/standard_python3/bundled-services/mail/django/main_test.py
@@ -65,6 +65,15 @@ def version():
     result = gcloud_cli(f"app deploy --no-promote --version={uuid.uuid4().hex}")
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
+    version_hostname = f"{version_id}-dot-{project_id}.appspot.com"
+
+    # Wait for app to initialize
+    @backoff.on_exception(backoff.expo, requests.exceptions.HTTPError, max_tries=3)
+    def wait_for_app(url):
+        r = requests.get(url)
+        r.raise_for_status()
+
+    wait_for_app(f"https://{version_hostname}/")
 
     yield project_id, version_id
 

--- a/appengine/standard_python3/bundled-services/mail/wsgi/main_test.py
+++ b/appengine/standard_python3/bundled-services/mail/wsgi/main_test.py
@@ -65,6 +65,15 @@ def version():
     result = gcloud_cli(f"app deploy --no-promote --version={uuid.uuid4().hex}")
     version_id = result["versions"][0]["id"]
     project_id = result["versions"][0]["project"]
+    version_hostname = f"{version_id}-dot-{project_id}.appspot.com"
+
+    # Wait for app to initialize
+    @backoff.on_exception(backoff.expo, requests.exceptions.HTTPError, max_tries=3)
+    def wait_for_app(url):
+        r = requests.get(url)
+        r.raise_for_status()
+
+    wait_for_app(f"https://{version_hostname}/")
 
     yield project_id, version_id
 


### PR DESCRIPTION
Fixes #8852

@engelke I'd argue we should apply this change to other GAE Python 3 samples too, to prevent _future_ flakiness. **WDYT?**