### PR TITLE
chore(functions/v2): Update sample signatures using functions framework

### DIFF
--- a/functions/http/main.py
+++ b/functions/http/main.py
@@ -34,6 +34,7 @@ import xmltodict
 # [START functions_http_xml]
 # [START functions_http_form_data]
 import functions_framework
+
 # [END functions_http_form_data]
 # [END functions_http_xml]
 # [END functions_http_cors_auth]

--- a/functions/http/main.py
+++ b/functions/http/main.py
@@ -29,11 +29,18 @@ from werkzeug.utils import secure_filename
 import xmltodict
 # [END functions_http_xml]
 
+# [START functions_http_cors]
+# [START functions_http_cors_auth]
+# [START functions_http_xml]
 # [START functions_http_form_data]
 import functions_framework
 # [END functions_http_form_data]
+# [END functions_http_xml]
+# [END functions_http_cors_auth]
+# [END functions_http_cors]
 
 # [START functions_http_xml]
+@functions_framework.http
 def parse_xml(request):
     """ Parses a document of type 'text/xml'
     Args:
@@ -95,6 +102,7 @@ def parse_multipart(request):
 
 
 # [START functions_http_cors]
+@functions_framework.http
 def cors_enabled_function(request):
     # For more information about CORS and CORS preflight requests, see:
     # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
@@ -122,6 +130,7 @@ def cors_enabled_function(request):
 
 
 # [START functions_http_cors_auth]
+@functions_framework.http
 def cors_enabled_function_auth(request):
     # For more information about CORS and CORS preflight requests, see
     # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request

--- a/functions/http/main.py
+++ b/functions/http/main.py
@@ -12,6 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START functions_http_cors]
+# [START functions_http_cors_auth]
+# [START functions_http_xml]
+# [START functions_http_form_data]
+import functions_framework
+
+# [END functions_http_form_data]
+# [END functions_http_xml]
+# [END functions_http_cors_auth]
+# [END functions_http_cors]
+
 # [START functions_http_xml]
 import json
 # [END functions_http_xml]
@@ -29,16 +40,6 @@ from werkzeug.utils import secure_filename
 import xmltodict
 # [END functions_http_xml]
 
-# [START functions_http_cors]
-# [START functions_http_cors_auth]
-# [START functions_http_xml]
-# [START functions_http_form_data]
-import functions_framework
-
-# [END functions_http_form_data]
-# [END functions_http_xml]
-# [END functions_http_cors_auth]
-# [END functions_http_cors]
 
 # [START functions_http_xml]
 @functions_framework.http

--- a/functions/http/main.py
+++ b/functions/http/main.py
@@ -29,9 +29,11 @@ from werkzeug.utils import secure_filename
 import xmltodict
 # [END functions_http_xml]
 
+# [START functions_http_form_data]
+import functions_framework
+# [END functions_http_form_data]
 
 # [START functions_http_xml]
-
 def parse_xml(request):
     """ Parses a document of type 'text/xml'
     Args:
@@ -56,6 +58,7 @@ def get_file_path(filename):
     return os.path.join(tempfile.gettempdir(), file_name)
 
 
+@functions_framework.http
 def parse_multipart(request):
     """ Parses a 'multipart/form-data' upload request
     Args:

--- a/functions/http/main.py
+++ b/functions/http/main.py
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START functions_http_xml]
+import json
+# [END functions_http_xml]
+
+# [START functions_http_form_data]
+import os
+import tempfile
+# [END functions_http_form_data]
+
 # [START functions_http_cors]
 # [START functions_http_cors_auth]
 # [START functions_http_xml]
@@ -22,15 +31,6 @@ import functions_framework
 # [END functions_http_xml]
 # [END functions_http_cors_auth]
 # [END functions_http_cors]
-
-# [START functions_http_xml]
-import json
-# [END functions_http_xml]
-
-# [START functions_http_form_data]
-import os
-import tempfile
-# [END functions_http_form_data]
 
 # [START functions_http_form_data]
 from werkzeug.utils import secure_filename

--- a/functions/http/requirements.txt
+++ b/functions/http/requirements.txt
@@ -1,3 +1,4 @@
+functions-framework==3.3.0
 google-cloud-storage==2.0.0; python_version < '3.7'
 google-cloud-storage==2.1.0; python_version > '3.6'
 xmltodict==0.13.0


### PR DESCRIPTION
Update the function signatures for the following samples using functions framework
https://cloud.google.com/functions/docs/samples/functions-http-form-data#functions_http_form_data-python
https://cloud.google.com/functions/docs/samples/functions-http-xml#functions_http_xml-python
https://cloud.google.com/functions/docs/samples/functions-http-cors#functions_http_cors-python
https://cloud.google.com/functions/docs/samples/functions-http-cors-auth#functions_http_cors_auth-python

Since they use a single file I decided to fix all of them :/.

Tested each of them by:
- Deploying a Gen2 function and sending sample `curl` requests
- Running tests