### PR TITLE
Revert "chore(deps): update dependency apache-airflow-providers-cncf-kubernetes to v5.1.0"

### DIFF
--- a/composer/workflows/requirements.txt
+++ b/composer/workflows/requirements.txt
@@ -2,7 +2,7 @@
 # see https://airflow.apache.org/docs/apache-airflow/stable/installation/installing-from-pypi.html#constraints-files
 apache-airflow==2.3.3
 apache-airflow-providers-apache-beam==4.1.0
-apache-airflow-providers-cncf-kubernetes==5.1.0
+apache-airflow-providers-cncf-kubernetes==5.0.0
 apache-airflow-providers-google==8.3.0
 scipy==1.8.1; python_version > '3.0'
 apache-airflow-providers-amazon==4.0.0


### PR DESCRIPTION
Reverts GoogleCloudPlatform/python-docs-samples#8867

This was merged without the 3.8 check running, which is the only check that's enabled for Composer - it ended up breaking in the periodic build because it clashes with the constraints. It'll get upraded when we bump the version of Airflow! 😄 