### PR TITLE
ci: remove 3.11 from Dockerfile

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -117,7 +117,7 @@ RUN set -ex \
   && export GNUPGHOME="$(mktemp -d)" \
   && echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
   && /tmp/fetch_gpg_keys.sh \
-  && for PYTHON_VERSION in 2.7.18 3.7.12 3.8.13 3.9.13 3.10.5 3.11.1; do \
+  && for PYTHON_VERSION in 2.7.18 3.7.12 3.8.13 3.9.13 3.10.5; do \
   wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
   && wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
   && gpg --batch --verify python-${PYTHON_VERSION}.tar.xz.asc python-${PYTHON_VERSION}.tar.xz \
@@ -157,7 +157,6 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
 # Ensure Pip for all python3 versions
-RUN python3.11 /tmp/get-pip.py
 RUN python3.9 /tmp/get-pip.py
 RUN python3.8 /tmp/get-pip.py
 RUN python3.7 /tmp/get-pip.py
@@ -169,7 +168,6 @@ RUN python3.7 -m pip
 RUN python3.8 -m pip
 RUN python3.9 -m pip
 RUN python3.10 -m pip
-RUN python3.11 -m pip
 
 # Install "virtualenv", since the vast majority of users of this image
 # will want it.


### PR DESCRIPTION
#8995 reverted 3.11 support, but it looks like it didn't remove 3.11 from the Docker build image. While testing this problem, I observed that the `docker build` step was responsible for the build freezing.