### PR TITLE
include people-and-planet-ai in auto-label.yaml

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -60,6 +60,7 @@ path:
     monitoring: "monitoring"
     notebooks: "notebooks"
     optimization: "cloudoptimization"
+    people-and-planet-ai: "people-and-planet-ai"
     profiler: "cloudprofiler"
     pubsub: "pubsub"
     pubsublite: "pubsublite"


### PR DESCRIPTION
This PR updates `auto-label.yaml` to include  `people-and-planet-ai/` which is used in [blunderbuss configuration](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/54f19f06894940230ac1d6cd5e11547cc265c816/.github/blunderbuss.yml#L112).