### PR TITLE
fix: migrate run markdown-preview sample to bleach 6

### DIFF
--- a/run/markdown-preview/renderer/main.py
+++ b/run/markdown-preview/renderer/main.py
@@ -29,9 +29,9 @@ def index():
     html = markdown.markdown(data)
 
     # Keep the paragraph tags
-    bleach.sanitizer.ALLOWED_TAGS.append('p')
+    allowed_tags = list(bleach.sanitizer.ALLOWED_TAGS) + ['p']
     # Sanitize and return
-    clean = bleach.clean(html, strip=True)
+    clean = bleach.clean(html, strip=True, tags=allowed_tags)
     return clean
 
 

--- a/run/markdown-preview/renderer/requirements.txt
+++ b/run/markdown-preview/renderer/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.1.0
 gunicorn==20.1.0
 Markdown==3.4
-bleach==5.0.0
+bleach==6.0.0


### PR DESCRIPTION
The list of allowed tags in bleach 6 is now a `frozenset` rather than a `list`. The existing logic tries to append an extra element, which now fails. This PR creates a new list from the frozenset instead.