### PR TITLE
cleanup: Removing black from requirements

### DIFF
--- a/batch/requirements.txt
+++ b/batch/requirements.txt
@@ -1,3 +1,2 @@
-black==22.12.0
 google-cloud-batch==0.5.0
 google-cloud-logging==3.2.5


### PR DESCRIPTION
Removing unnecessary `black` requirement for batch. As suggested in #9071 
