### PR TITLE
chore: removed obsolete redirects from Vision, TTS

### DIFF
--- a/texttospeech/cloud-client/.gitignore
+++ b/texttospeech/cloud-client/.gitignore
@@ -1,1 +1,0 @@
-output.mp3

--- a/texttospeech/cloud-client/README.rst
+++ b/texttospeech/cloud-client/README.rst
@@ -1,3 +1,0 @@
-These samples have been moved.
-
-https://github.com/googleapis/python-texttospeech/tree/main/samples

--- a/vision/cloud-client/README.md
+++ b/vision/cloud-client/README.md
@@ -1,3 +1,0 @@
-These samples have been moved.
-
-https://github.com/googleapis/python-vision/tree/main/samples


### PR DESCRIPTION
The `vision` and `texttospeech` directories had out-of-date redirect pages for the samples.