### PR TITLE
fix: lint issue in appengine wsgi sample

### DIFF
--- a/appengine/standard_python3/bundled-services/mail/wsgi/main_test.py
+++ b/appengine/standard_python3/bundled-services/mail/wsgi/main_test.py
@@ -116,7 +116,7 @@ def test_send_receive(version):
             if "textPayload" in entry:
                 text_payloads += entry["textPayload"]
                 text_payloads += "\n"
-                
+
         if "Received" in text_payloads:
             break
 


### PR DESCRIPTION
## Description

Fixes lint issue in appengine/standard_python3/bundled-services/mail/wsgi/main_test.py

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
