### PR TITLE
Round score to the first decimal

### DIFF
--- a/recaptchaenterprise/samples/demosite/app/backend/create_recaptcha_assessment.py
+++ b/recaptchaenterprise/samples/demosite/app/backend/create_recaptcha_assessment.py
@@ -65,4 +65,4 @@ def create_assessment(
     # Return the risk score.
     verdict = "Not a human" if response.risk_analysis.score < sample_threshold_score else "Human"
     return jsonify(
-        {'data': {"score": "{:.12f}".format(response.risk_analysis.score), "verdict": verdict}, "success": "true"})
+        {'data': {"score": "{:.1f}".format(response.risk_analysis.score), "verdict": verdict}, "success": "true"})


### PR DESCRIPTION
## Description

Round score to the first decimal. Scores never have a second decimal anyway, and the way it is truncated in the frontend can lead to the wrong value displayed (0.8 instead of 0.9 for a value of 0.89999999)

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
