### PR TITLE
chore: update PPAI time series dependencies

### DIFF
--- a/people-and-planet-ai/timeseries-classification/requirements-test.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements-test.txt
@@ -1,3 +1,3 @@
-google-api-python-client==2.47.0
-pytest-xdist==2.5.0
-pytest==7.0.1
+google-api-python-client==2.76.0
+pytest-xdist==3.1.0
+pytest==7.2.1

--- a/people-and-planet-ai/timeseries-classification/requirements.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements.txt
@@ -1,6 +1,6 @@
-Flask==2.1.0
-apache-beam[gcp]==2.35.0
-google-cloud-aiplatform==1.12.1
+Flask==2.2.2
+apache-beam[gcp]==2.44.0
+google-cloud-aiplatform==1.21.0
 gunicorn==20.1.0
-pandas==1.3.5
-tensorflow==2.9.1
+pandas==1.5.3
+tensorflow==2.9.3


### PR DESCRIPTION
Splitting out some PPAI dependency updates into a separate PR, because of timeouts. FYI @davidcavazos 