### PR TITLE
ci: use prebuilt docker image in presubmits

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -156,7 +156,7 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
   # https://github.com/docker-library/python/pull/100
   && [ "$(pip list |tac|tac| awk -F '[ ()]+' '$1 == "pip" { print $2; exit }')" = "$PYTHON_PIP_VERSION" ]
 
-# Ensure Pip for all python3 versions
+# Ensure Pip for all python3 versions.
 RUN python3.9 /tmp/get-pip.py
 RUN python3.8 /tmp/get-pip.py
 RUN python3.7 /tmp/get-pip.py

--- a/.kokoro/lint/common.cfg
+++ b/.kokoro/lint/common.cfg
@@ -44,8 +44,3 @@ env_vars: {
     key: "RUN_TESTS_SESSION"
     value: "lint"
 }
-
-env_vars: {
-    key: "TRAMPOLINE_DOCKERFILE"
-    value: ".kokoro/docker/Dockerfile"
-}

--- a/.kokoro/python2.7/common.cfg
+++ b/.kokoro/python2.7/common.cfg
@@ -52,8 +52,3 @@ env_vars: {
     key: "BUILD_SPECIFIC_GCLOUD_PROJECT"
     value: "python-docs-samples-tests"
 }
-
-env_vars: {
-    key: "TRAMPOLINE_DOCKERFILE"
-    value: ".kokoro/docker/Dockerfile"
-}

--- a/.kokoro/python3.10/common.cfg
+++ b/.kokoro/python3.10/common.cfg
@@ -59,8 +59,3 @@ env_vars: {
     key: "NUM_TEST_WORKERS"
     value: "10"
 }
-
-env_vars: {
-    key: "TRAMPOLINE_DOCKERFILE"
-    value: ".kokoro/docker/Dockerfile"
-}

--- a/.kokoro/python3.7/common.cfg
+++ b/.kokoro/python3.7/common.cfg
@@ -59,8 +59,3 @@ env_vars: {
     key: "NUM_TEST_WORKERS"
     value: "10"
 }
-
-env_vars: {
-    key: "TRAMPOLINE_DOCKERFILE"
-    value: ".kokoro/docker/Dockerfile"
-}

--- a/.kokoro/python3.8/common.cfg
+++ b/.kokoro/python3.8/common.cfg
@@ -59,8 +59,3 @@ env_vars: {
     key: "NUM_TEST_WORKERS"
     value: "10"
 }
-
-env_vars: {
-    key: "TRAMPOLINE_DOCKERFILE"
-    value: ".kokoro/docker/Dockerfile"
-}

--- a/.kokoro/python3.9/common.cfg
+++ b/.kokoro/python3.9/common.cfg
@@ -59,8 +59,3 @@ env_vars: {
     key: "NUM_TEST_WORKERS"
     value: "10"
 }
-
-env_vars: {
-    key: "TRAMPOLINE_DOCKERFILE"
-    value: ".kokoro/docker/Dockerfile"
-}

--- a/.trampolinerc
+++ b/.trampolinerc
@@ -47,7 +47,7 @@ if [[ -z "${TRAMPOLINE_IMAGE:-}" ]]; then
 fi
 
 if [[ -z "${TRAMPOLINE_DOCKERFILE:-}" ]]; then
-    TRAMPOLINE_DOCKERFILE=".kokoro/docker/Dockerfile"
+    TRAMPOLINE_DOCKERFILE=""
 fi
 
 if [[ -z "${RUN_TESTS_SESSION:-}" ]]; then


### PR DESCRIPTION
Use a prebuilt docker image in presubmits to solve the issue where presubmits fail during the docker build step. See [this log](https://source.cloud.google.com/results/invocations/ed14226d-09e7-431d-aeaa-2f9d8d3b15d6/log) for an example of the failure where the docker build step timed out.

Towards https://github.com/GoogleCloudPlatform/python-docs-samples/issues/8873