### PR TITLE
chore: migrate run/idp-sql to sqlalchemy 2

### DIFF
--- a/run/idp-sql/requirements.txt
+++ b/run/idp-sql/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.1.0
-SQLAlchemy==1.4.38
+SQLAlchemy==2.0.3
 pg8000==1.24.2
 gunicorn==20.1.0
 firebase-admin==6.0.0


### PR DESCRIPTION
SQLAlchemy 2.x PR updates are blocked on the `run/idp-sql` sample that uses 1.x syntax.