### PR TITLE
chore: remove unused `host` from URL in SQL Server samples

### DIFF
--- a/cloud-sql/sql-server/client-side-encryption/snippets/cloud_sql_connection_pool.py
+++ b/cloud-sql/sql-server/client-side-encryption/snippets/cloud_sql_connection_pool.py
@@ -45,7 +45,7 @@ def init_tcp_connection_engine(
     pool = sqlalchemy.create_engine(
         # This allows us to use the pytds sqlalchemy dialect, but also set the
         # bytes_to_unicode flag to False, which is not supported by the dialect
-        "mssql+pytds://localhost",
+        "mssql+pytds://",
         creator=connect_with_pytds,
     )
 

--- a/cloud-sql/sql-server/sqlalchemy/connect_connector.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_connector.py
@@ -63,7 +63,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
         return conn
 
     pool = sqlalchemy.create_engine(
-        "mssql+pytds://localhost",
+        "mssql+pytds://",
         creator=getconn,
         # [START_EXCLUDE]
         # Pool size is the maximum number of permanent connections to keep.

--- a/cloud-sql/sql-server/sqlalchemy/connection_test.py
+++ b/cloud-sql/sql-server/sqlalchemy/connection_test.py
@@ -95,6 +95,6 @@ def test_cast_vote(client: FlaskClient) -> None:
 def test_connector_connection(client: FlaskClient) -> None:
     del os.environ["INSTANCE_HOST"]
     app.db = app.init_connection_pool()
-    assert str(app.db.url) == "mssql+pytds://localhost"
+    assert str(app.db.url) == "mssql+pytds://"
     test_get_votes(client)
     test_cast_vote(client)


### PR DESCRIPTION
In latest version of `sqlalchemy-pytds` library #9145, the `host` param has become optional in the SQLAlchemy engine URL, our samples previously had a dummy value of `localhost` set to fulfill the required host param. Now that it is optional, we can remove `localhost` from the URL for simplicity and to avoid confusion. 
