### PR TITLE
fix flaky test: add httperror to backoff check

### DIFF
--- a/jobs/v3/api_client/commute_search_sample_test.py
+++ b/jobs/v3/api_client/commute_search_sample_test.py
@@ -15,8 +15,8 @@
 import re
 
 import backoff
-import pytest
 from googleapiclient.errors import HttpError
+import pytest
 
 import commute_search_sample
 

--- a/jobs/v3/api_client/commute_search_sample_test.py
+++ b/jobs/v3/api_client/commute_search_sample_test.py
@@ -16,6 +16,7 @@ import re
 
 import backoff
 import pytest
+from googleapiclient.errors import HttpError
 
 import commute_search_sample
 
@@ -28,7 +29,7 @@ def company_name():
 
 
 def test_commute_search_sample(company_name, capsys):
-    @backoff.on_exception(backoff.expo, AssertionError, max_time=240)
+    @backoff.on_exception(backoff.expo, (AssertionError, HttpError), max_time=240)
     def eventually_consistent_test():
         commute_search_sample.run_sample(company_name)
         out, _ = capsys.readouterr()


### PR DESCRIPTION
## Description

Fixes #9138 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
