### PR TITLE
fix: Updated wait_for_ready to fix flacky tests

### DIFF
--- a/kms/snippets/noxfile_config.py
+++ b/kms/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/kms/snippets/snippets_test.py
+++ b/kms/snippets/snippets_test.py
@@ -207,7 +207,7 @@ def wait_for_ready(client, key_version_name):
         key_version = client.get_crypto_key_version(request={'name': key_version_name})
         if key_version.state == kms.CryptoKeyVersion.CryptoKeyVersionState.ENABLED:
             return
-        time.sleep(0.1*(i**2))
+        time.sleep((i+1)**2)
     pytest.fail('{} not ready'.format(key_version_name))
 
 

--- a/kms/snippets/snippets_test.py
+++ b/kms/snippets/snippets_test.py
@@ -203,7 +203,7 @@ def symmetric_key_id(client, project_id, location_id, key_ring_id):
 
 
 def wait_for_ready(client, key_version_name):
-    for i in range(5):
+    for i in range(4):
         key_version = client.get_crypto_key_version(request={'name': key_version_name})
         if key_version.state == kms.CryptoKeyVersion.CryptoKeyVersionState.ENABLED:
             return


### PR DESCRIPTION
## Description

Fixes #9125

Updated sleep to have longer time outs (1-32 seconds) to avoid flackyness.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] Please **merge** this PR for me once it is approved.