### PR TITLE
docs(kms): Adding notes about required roles for running tests

### DIFF
--- a/kms/snippets/README.md
+++ b/kms/snippets/README.md
@@ -43,8 +43,6 @@ The service account running the tests needs to have the following roles:
  * roles/cloudkms.publicKeyViewer
  * roles/cloudkms.signerVerifier
 
-
-
 ## Additional Information
 
 These samples use the [Google Cloud Client Library for Python][client_library_python].

--- a/kms/snippets/README.md
+++ b/kms/snippets/README.md
@@ -34,6 +34,17 @@ To run this sample:
 
 More information about the Cloud KMS quickstart is available at https://cloud.google.com/kms/docs/quickstart
 
+## Test permissions
+
+The service account running the tests needs to have the following roles:
+ * roles/cloudkms.admin
+ * roles/cloudkms.cryptoKeyEncrypterDecrypter
+ * roles/cloudkms.cryptoOperator
+ * roles/cloudkms.publicKeyViewer
+ * roles/cloudkms.signerVerifier
+
+
+
 ## Additional Information
 
 These samples use the [Google Cloud Client Library for Python][client_library_python].

--- a/kms/snippets/snippets_test.py
+++ b/kms/snippets/snippets_test.py
@@ -10,6 +10,16 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
+"""
+Tests for the KMS samples.
+
+The service account running the tests needs to have the following roles:
+ * roles/cloudkms.admin
+ * roles/cloudkms.cryptoKeyEncrypterDecrypter
+ * roles/cloudkms.cryptoOperator
+ * roles/cloudkms.publicKeyViewer
+ * roles/cloudkms.signerVerifier
+"""
 
 import datetime
 import hashlib


### PR DESCRIPTION
## Description

Issue #9125

Pull Request #9168 

Adding comments about required permissions for the service account running the tests. Had to figure it out manually for all the python version specific projects.