### PR TITLE
fix: make STS quickstart runnable with default params

### DIFF
--- a/storagetransfer/quickstart.py
+++ b/storagetransfer/quickstart.py
@@ -26,7 +26,8 @@ import argparse
 from google.cloud import storage_transfer
 
 
-def create_one_time_transfer(project_id: str = "my_project_id", source_bucket: str = "my_source_bucket",
+def create_one_time_transfer(project_id: str = "my_project_id",
+                             source_bucket: str = "my_source_bucket",
                              sink_bucket: str = "my_sink_bucket"):
     """Creates a one-time transfer job."""
 
@@ -72,16 +73,19 @@ if __name__ == "__main__":
     parser.add_argument(
         '--project-id',
         help='The ID of the Google Cloud Platform Project that owns the job',
-        required=True)
+        required=False)
     parser.add_argument(
         '--source-bucket',
         help='S3 source bucket name',
-        required=True)
+        required=False)
     parser.add_argument(
         '--sink-bucket',
         help='Cloud Storage bucket name',
-        required=True)
+        required=False)
 
     args = parser.parse_args()
 
-    create_one_time_transfer(**vars(args))
+    if args.project_id is None and args.source_bucket is None and args.sink_bucket is None:
+        create_one_time_transfer()
+    else:
+        create_one_time_transfer(**vars(args))


### PR DESCRIPTION
This is a followup to https://github.com/GoogleCloudPlatform/python-docs-samples/pull/9171

I added default values, but it's not possible to use them from the command line since the arg parser considered them required. I forgot to include this in the original PR, so this fixes that so that the quickstart can be run from the command line at the end of the STS Neos tutorial 