### PR TITLE
Upgrade flex storage sample app to python 3.11.

### DIFF
--- a/appengine/flexible/storage/app.yaml
+++ b/appengine/flexible/storage/app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@ env: flex
 entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
-  python_version: 3
+  operating_system: "ubuntu22"
+  # We also support 3.8, 3.9 and 3.10.
+  # See https://cloud.google.com/appengine/docs/flexible/python/runtime#interpreter for more info.
+  runtime_version: "3.11"
 
 #[START gae_flex_storage_yaml]
 env_variables:
-    CLOUD_STORAGE_BUCKET: your-bucket-name
+  CLOUD_STORAGE_BUCKET: your-bucket-name
 #[END gae_flex_storage_yaml]

--- a/appengine/flexible/storage/main.py
+++ b/appengine/flexible/storage/main.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2023 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ from google.cloud import storage
 app = Flask(__name__)
 
 # Configure this environment variable via app.yaml
-CLOUD_STORAGE_BUCKET = os.environ['CLOUD_STORAGE_BUCKET']
+CLOUD_STORAGE_BUCKET = os.environ["CLOUD_STORAGE_BUCKET"]
 
 
-@app.route('/')
+@app.route("/")
 def index() -> str:
     return """
 <form method="POST" action="/upload" enctype="multipart/form-data">
@@ -36,13 +36,13 @@ def index() -> str:
 """
 
 
-@app.route('/upload', methods=['POST'])
+@app.route("/upload", methods=["POST"])
 def upload() -> str:
     """Process the uploaded file and upload it to Google Cloud Storage."""
-    uploaded_file = request.files.get('file')
+    uploaded_file = request.files.get("file")
 
     if not uploaded_file:
-        return 'No file uploaded.', 400
+        return "No file uploaded.", 400
 
     # Create a Cloud Storage client.
     gcs = storage.Client()
@@ -54,8 +54,7 @@ def upload() -> str:
     blob = bucket.blob(uploaded_file.filename)
 
     blob.upload_from_string(
-        uploaded_file.read(),
-        content_type=uploaded_file.content_type
+        uploaded_file.read(), content_type=uploaded_file.content_type
     )
 
     # Make the blob public. This is not necessary if the
@@ -69,15 +68,20 @@ def upload() -> str:
 
 @app.errorhandler(500)
 def server_error(e: Union[Exception, int]) -> str:
-    logging.exception('An error occurred during a request.')
-    return """
+    logging.exception("An error occurred during a request.")
+    return (
+        """
     An internal error occurred: <pre>{}</pre>
     See logs for full stacktrace.
-    """.format(e), 500
+    """.format(
+            e
+        ),
+        500,
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # This is used when running locally. Gunicorn is used to run the
     # application on Google App Engine. See entrypoint in app.yaml.
-    app.run(host='127.0.0.1', port=8080, debug=True)
+    app.run(host="127.0.0.1", port=8080, debug=True)
 # [END gae_flex_storage_app]

--- a/appengine/flexible/storage/main_test.py
+++ b/appengine/flexible/storage/main_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2023 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ def client() -> flask.testing.FlaskClient:
 
 
 def test_index(client: flask.testing.FlaskClient) -> None:
-    r = client.get('/')
+    r = client.get("/")
     assert r.status_code == 200
 
 
@@ -50,17 +50,12 @@ def test_upload(client: flask.testing.FlaskClient, blob_name: str) -> None:
     # Upload a simple file
     file_content = b"This is some test content."
 
-    r = client.post(
-        '/upload',
-        data={
-            'file': (BytesIO(file_content), blob_name)
-        }
-    )
+    r = client.post("/upload", data={"file": (BytesIO(file_content), blob_name)})
 
     assert r.status_code == 200
 
     # The app should return the public cloud storage URL for the uploaded
     # file. Download and verify it.
-    cloud_storage_url = r.data.decode('utf-8')
+    cloud_storage_url = r.data.decode("utf-8")
     r = requests.get(cloud_storage_url)
-    assert r.text.encode('utf-8') == file_content
+    assert r.text.encode("utf-8") == file_content

--- a/appengine/flexible/storage/noxfile_config.py
+++ b/appengine/flexible/storage/noxfile_config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7"],
+    "ignored_versions": ["2.7", "3.6"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup)). Answer: doesn't work on my local machine due to a permission issue.  
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
