### PR TITLE
fix: adding in sleep for flaky test and minor reformatting

### DIFF
--- a/cloudbuild/snippets/noxfile_config.py
+++ b/cloudbuild/snippets/noxfile_config.py
@@ -35,6 +35,5 @@ TEST_CONFIG_OVERRIDE = {
     # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
-    "envs": {
-    },
+    "envs": {},
 }

--- a/cloudbuild/snippets/quickstart.py
+++ b/cloudbuild/snippets/quickstart.py
@@ -41,9 +41,9 @@ def quickstart() -> None:
     # The following build steps will output "hello world"
     # For more information on build configuration, see
     # https://cloud.google.com/build/docs/configuring-builds/create-basic-configuration
-    build.steps = [{"name": "ubuntu",
-                    "entrypoint": "bash",
-                    "args": ["-c", "echo hello world"]}]
+    build.steps = [
+        {"name": "ubuntu", "entrypoint": "bash", "args": ["-c", "echo hello world"]}
+    ]
 
     operation = client.create_build(project_id=project_id, build=build)
     # Print the in-progress operation
@@ -53,6 +53,8 @@ def quickstart() -> None:
     result = operation.result()
     # Print the completed status
     print("RESULT:", result.status)
+
+
 # [END cloudbuild_quickstart]
 
 

--- a/cloudbuild/snippets/quickstart_test.py
+++ b/cloudbuild/snippets/quickstart_test.py
@@ -14,13 +14,17 @@
 
 
 import pytest
-
+import time
 import quickstart
 
 
 def test_quickstart(capsys: pytest.CaptureFixture) -> None:
     quickstart.quickstart()
     out, _ = capsys.readouterr()
+
+    # Wait 5 seconds
+    time.sleep(5)
+
     # Prints in-progress message
     assert "hello world" in out
     # Prints final status

--- a/cloudbuild/snippets/quickstart_test.py
+++ b/cloudbuild/snippets/quickstart_test.py
@@ -14,8 +14,8 @@
 
 
 import pytest
-import time
 import quickstart
+import time
 
 
 def test_quickstart(capsys: pytest.CaptureFixture) -> None:


### PR DESCRIPTION
## Description

Fixes #9206

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
