### PR TITLE
ppai/weather: add timeout to vertex training

### DIFF
--- a/people-and-planet-ai/weather-forecasting/notebooks/3-training.ipynb
+++ b/people-and-planet-ai/weather-forecasting/notebooks/3-training.ipynb
@@ -1364,6 +1364,7 @@
         "from google.cloud import aiplatform\n",
         "\n",
         "epochs = 100\n",
+        "timeout_min = 60  # 1 hour\n",
         "\n",
         "# Cloud Storage paths.\n",
         "data_path = f\"/gcs/{bucket}/weather/data\"\n",
@@ -1376,7 +1377,7 @@
         "    display_name=\"weather-forecasting\",\n",
         "    python_package_gcs_uri=f\"gs://{bucket}/weather/weather-model-1.0.0.tar.gz\",\n",
         "    python_module_name=\"weather.trainer\",\n",
-        "    container_uri=\"us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.1-11:latest\",\n",
+        "    container_uri=\"us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.1-13:latest\",\n",
         ")\n",
         "job.run(\n",
         "    machine_type=\"n1-highmem-8\",\n",
@@ -1387,6 +1388,7 @@
         "        f\"--model-path={model_path}\",\n",
         "        f\"--epochs={epochs}\",\n",
         "    ],\n",
+        "    timeout=timeout_min * 60,  # in seconds\n",
         ")"
       ],
       "id": "Ny4x99GiS2Lm"

--- a/people-and-planet-ai/weather-forecasting/serving/weather-model/pyproject.toml
+++ b/people-and-planet-ai/weather-forecasting/serving/weather-model/pyproject.toml
@@ -18,6 +18,7 @@ name = "weather-model"
 version = "1.0.0"
 dependencies = [
     "datasets==2.8.0",
+    "torch==1.13.1",  # make sure this matches the `container_uri` in `notebooks/3-training.ipynb`
     "transformers==4.25.1",
 ]
 

--- a/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
@@ -1,4 +1,3 @@
 ../../serving/weather-model
 build==0.10.0
 google-cloud-aiplatform==1.21.0
-torch==1.13.1

--- a/people-and-planet-ai/weather-forecasting/tests/training_tests/test_training.py
+++ b/people-and-planet-ai/weather-forecasting/tests/training_tests/test_training.py
@@ -82,6 +82,7 @@ def test_train_model(
                     "data_path": data_path_gcs.replace("gs://", "/gcs/"),
                     "model_path": f"/gcs/{bucket_name}/test/weather/model-vertex",
                     "epochs": 2,
+                    "timeout_min": 5,  # should take a couple seconds, so timeout in 5 minutes
                 }
             },
         },


### PR DESCRIPTION
## Description

Adds a timeout to the Vertex AI training job to avoid having long running jobs during testing.

**Note**: Tests will still fail until #9272 is fixed, but this will avoid the long running hanged jobs.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
