### PR TITLE
chore: cleanup un-wanted region tags

### DIFF
--- a/cdn/snippets.py
+++ b/cdn/snippets.py
@@ -30,7 +30,6 @@ import hmac
 from six.moves import urllib
 
 
-# [START sign_url]
 # [START cloudcdn_sign_url]
 def sign_url(url, key_name, base64_key, expiration_time):
     """Gets the Signed URL string for the specified URL and configuration.
@@ -115,10 +114,8 @@ def sign_url_prefix(url, url_prefix, key_name, base64_key, expiration_time):
 
     print(signed_url)
 # [END cloudcdn_sign_url_prefix]
-# [END sign_url]
 
 
-# [START cdn_sign_cookie]
 # [START cloudcdn_sign_cookie]
 def sign_cookie(url_prefix, key_name, base64_key, expiration_time):
     """Gets the Signed cookie value for the specified URL prefix and configuration.
@@ -151,7 +148,6 @@ def sign_cookie(url_prefix, key_name, base64_key, expiration_time):
     signed_policy = u'Cloud-CDN-Cookie={policy}:Signature={signature}'.format(
             policy=policy, signature=signature)
     print(signed_policy)
-# [END cdn_sign_cookie]
 # [END cloudcdn_sign_cookie]
 
 


### PR DESCRIPTION
Old region tags are replaced with product specific region tags. Please check b/272509882 for more details.

Region tags were added using https://github.com/GoogleCloudPlatform/python-docs-samples/pull/9258

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
