### PR TITLE
fix: mark expected failure

### DIFF
--- a/people-and-planet-ai/weather-forecasting/tests/training_tests/test_training.py
+++ b/people-and-planet-ai/weather-forecasting/tests/training_tests/test_training.py
@@ -55,6 +55,7 @@ def data_path_gcs(bucket_name: str) -> str:
     return path_gcs
 
 
+@pytest.mark.xfail(reason="temporary API service issues")
 def test_train_model(
     project: str,
     bucket_name: str,


### PR DESCRIPTION
## Description

Fixes #9272 and #9277 

Vertex AI issues causing failures in tests, not due to the sample. Mark as expected to fail, will remove the mark when the underlying issue is resolved.