### PR TITLE
Fix: use current Django

### DIFF
--- a/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
@@ -1,4 +1,5 @@
-Django==3.2.8
-django-environ==0.9.0
+Django==3.2.8; python_version<"3.8"
+Django==4.1.7; python_version>"3.7"
+django-environ==0.10.0
 google-cloud-logging==3.2.2
 appengine-python-standard>=0.2.3


### PR DESCRIPTION
Python 3.11 tests for bundled services with Django are failing. The tests use an older library version for Python 3.7 compatibility that seems to cause the Python 3.11 problem.

This uses Python version conditions in requirements.txt to satisfy both platforms.