### PR TITLE
ppai/weather: add notice of vertex issue

### DIFF
--- a/people-and-planet-ai/weather-forecasting/notebooks/3-training.ipynb
+++ b/people-and-planet-ai/weather-forecasting/notebooks/3-training.ipynb
@@ -1277,6 +1277,8 @@
       "source": [
         "# ☁️ Train the model in Vertex AI\n",
         "\n",
+        "> ⚠️ Training in Vertex AI doesn't currently work due to an underlying issue when using the HuggingFace `Trainer` API in Vertex AI. For more information, see [#9272](https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9272).\n",
+        "\n",
         "For this example we're training on a very small dataset for a very small number of epochs.\n",
         "This means we don't have a representative number of examples and the model hasn't seen the data enough times, so it won't perform very well.\n",
         "\n",


### PR DESCRIPTION
## Description

Related to: #9272

Adds a notice to the sample for users following the sample to be aware that running the training job in Vertex AI will not work until the underlying issue is fixed.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
