### PR TITLE
Fix 311 ocr

### DIFF
--- a/functions/ocr/app/constraints.txt
+++ b/functions/ocr/app/constraints.txt
@@ -1,0 +1,13 @@
+# Explicitly listing more packages than just the direct script dependencies to
+# avoid PIP taking too long while resolving dependencies.
+# See https://pip.pypa.io/en/stable/topics/dependency-resolution/#backtracking
+google-api-core==2.11.0
+google-auth==2.16.2
+google-cloud-core==2.3.2
+google-crc32c==1.5.0
+google-resumable-media==2.4.1
+googleapis-common-protos==1.59.0
+grpc-google-iam-v1==0.12.6
+grpcio==1.51.3
+grpcio-status==1.51.3
+protobuf==4.22.1

--- a/functions/ocr/app/constraints.txt
+++ b/functions/ocr/app/constraints.txt
@@ -4,10 +4,4 @@
 google-api-core==2.11.0
 google-auth==2.16.2
 google-cloud-core==2.3.2
-google-crc32c==1.5.0
-google-resumable-media==2.4.1
-googleapis-common-protos==1.59.0
-grpc-google-iam-v1==0.12.6
-grpcio==1.51.3
-grpcio-status==1.51.3
 protobuf==4.22.1

--- a/functions/ocr/app/requirements.txt
+++ b/functions/ocr/app/requirements.txt
@@ -1,17 +1,4 @@
-# Explicitly listing more packages than just the direct script dependencies to
-# avoid PIP taking too long while resolving dependencies.
-# See https://pip.pypa.io/en/stable/topics/dependency-resolution/#backtracking
-google-api-core==2.11.0
-google-auth==2.16.2
-google-cloud-core==2.3.2
 google-cloud-pubsub==2.15.1
-google-cloud-storage==2.0.0; python_version < '3.7'
-google-cloud-storage==2.7.0; python_version >= '3.7'
+google-cloud-storage==2.7.0
 google-cloud-translate==3.11.0
 google-cloud-vision==3.4.0
-google-crc32c==1.5.0
-google-resumable-media==2.4.1
-googleapis-common-protos==1.59.0
-grpc-google-iam-v1==0.12.6
-grpcio==1.51.3
-grpcio-status==1.51.3

--- a/functions/ocr/app/requirements.txt
+++ b/functions/ocr/app/requirements.txt
@@ -1,5 +1,17 @@
-google-cloud-pubsub==2.9.0
+# Explicitly listing more packages than just the direct script dependencies to
+# avoid PIP taking too long while resolving dependencies.
+# See https://pip.pypa.io/en/stable/topics/dependency-resolution/#backtracking
+google-api-core==2.11.0
+google-auth==2.16.2
+google-cloud-core==2.3.2
+google-cloud-pubsub==2.15.1
 google-cloud-storage==2.0.0; python_version < '3.7'
-google-cloud-storage==2.1.0; python_version > '3.6'
-google-cloud-translate==3.8.0
-google-cloud-vision==3.1.0
+google-cloud-storage==2.7.0; python_version >= '3.7'
+google-cloud-translate==3.11.0
+google-cloud-vision==3.4.0
+google-crc32c==1.5.0
+google-resumable-media==2.4.1
+googleapis-common-protos==1.59.0
+grpc-google-iam-v1==0.12.6
+grpcio==1.51.3
+grpcio-status==1.51.3


### PR DESCRIPTION
Making the requirements list a bit more verbose, to avoid PIP taking too long resolving dependencies in the 3.11 build.
