### PR TITLE
fix: avoid name collisions

### DIFF
--- a/auth/api-client/api_key_test.py
+++ b/auth/api-client/api_key_test.py
@@ -14,6 +14,7 @@
 import os
 import re
 from time import sleep
+import uuid
 
 from _pytest.capture import CaptureFixture
 import backoff
@@ -37,7 +38,8 @@ SERVICE_ACCOUNT_FILE = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
 @pytest.fixture(scope="module")
 def api_key():
-    api_key = create_api_key.create_api_key(PROJECT)
+    suffix = uuid.uuid4().hex
+    api_key = create_api_key.create_api_key(PROJECT, suffix)
     sleep(300)
     yield api_key
     delete_api_key.delete_api_key(PROJECT, get_key_id(api_key.name))

--- a/auth/api-client/create_api_key.py
+++ b/auth/api-client/create_api_key.py
@@ -18,9 +18,9 @@ from google.cloud import api_keys_v2
 from google.cloud.api_keys_v2 import Key
 
 
-def create_api_key(project_id: str) -> Key:
+def create_api_key(project_id: str, suffix: str) -> Key:
     """
-    Creates and restrict an API key.
+    Creates and restrict an API key with name ending in "suffix".
 
     TODO(Developer):
     1. Before running this sample,
@@ -38,7 +38,7 @@ def create_api_key(project_id: str) -> Key:
     client = api_keys_v2.ApiKeysClient()
 
     key = api_keys_v2.Key()
-    key.display_name = "My first API key"
+    key.display_name = f"My first API key - {suffix}"
 
     # Initialize request and set arguments.
     request = api_keys_v2.CreateKeyRequest()


### PR DESCRIPTION
## Description

Since multiple instances of the auth test can run simultaneously, use a unique name for the key to avoid interference between them.