### PR TITLE
try replacing backoff with native retry

### DIFF
--- a/asset/snippets/quickstart_batchgetassetshistory_test.py
+++ b/asset/snippets/quickstart_batchgetassetshistory_test.py
@@ -17,8 +17,7 @@
 import os
 import uuid
 
-import backoff
-from google.api_core.exceptions import InvalidArgument
+from google.api_core.retry import Retry
 from google.cloud import storage
 import pytest
 
@@ -52,7 +51,7 @@ def test_batch_get_assets_history(asset_bucket, capsys):
         bucket_asset_name,
     ]
 
-    @backoff.on_exception(backoff.expo, (AssertionError, InvalidArgument), max_time=60)
+    @Retry(timeout=60)
     def eventually_consistent_test():
         quickstart_batchgetassetshistory.batch_get_assets_history(PROJECT, asset_names)
         out, _ = capsys.readouterr()

--- a/asset/snippets/quickstart_batchgetassetshistory_test.py
+++ b/asset/snippets/quickstart_batchgetassetshistory_test.py
@@ -18,6 +18,7 @@ import os
 import uuid
 
 from google.api_core.retry import Retry
+from google.api_core.exceptions import InvalidArgument
 from google.cloud import storage
 import pytest
 
@@ -51,7 +52,7 @@ def test_batch_get_assets_history(asset_bucket, capsys):
         bucket_asset_name,
     ]
 
-    @Retry(timeout=60)
+    @Retry(on_error=InvalidArgument, timeout=60)
     def eventually_consistent_test():
         quickstart_batchgetassetshistory.batch_get_assets_history(PROJECT, asset_names)
         out, _ = capsys.readouterr()

--- a/asset/snippets/quickstart_batchgetassetshistory_test.py
+++ b/asset/snippets/quickstart_batchgetassetshistory_test.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import backoff
 import os
 import uuid
 
-from google.api_core.retry import Retry
 from google.api_core.exceptions import InvalidArgument
 from google.cloud import storage
 import pytest
@@ -52,7 +52,7 @@ def test_batch_get_assets_history(asset_bucket, capsys):
         bucket_asset_name,
     ]
 
-    @Retry(on_error=InvalidArgument, timeout=60)
+    @backoff.on_exception(backoff.expo, (AssertionError, InvalidArgument))
     def eventually_consistent_test():
         quickstart_batchgetassetshistory.batch_get_assets_history(PROJECT, asset_names)
         out, _ = capsys.readouterr()


### PR DESCRIPTION
## Description
This test has had a flaky issue for multiple different reasons - I thought we could try using the native method since we're not taking advantage of the `max_tries` aspect of backoff. Assigned @nicain and @kweinmeister because of previous threads, but feel free to reassign

Fixes #9292

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
