### PR TITLE
fix: pubsublite spark connector test

### DIFF
--- a/pubsublite/spark-connector/spark_streaming_test.py
+++ b/pubsublite/spark-connector/spark_streaming_test.py
@@ -184,7 +184,7 @@ def test_spark_streaming_to_pubsublite(
         "pyspark_job": {
             "main_python_file_uri": pyfile("spark_streaming_to_pubsublite_example.py"),
             "jar_file_uris": [
-                "gs://spark-lib/pubsublite/pubsublite-spark-sql-streaming-LATEST-with-dependencies.jar"
+                "gs://pubsublite-spark/pubsublite-spark-sql-streaming-1.0.0-with-dependencies.jar"
             ],
             "properties": {"spark.master": "yarn"},
             "logging_config": {"driver_log_levels": {"root": LoggingConfig.Level.INFO}},


### PR DESCRIPTION
fixes #9308 fixes #9309 

the pub/sub lite spark connector maintainer forgot to update the public gcs location of the connector jar (see b/275751052)

i removed the lifecycle rules in the test gcs bucket for now and will add it back and restore the test to the original state after the bug fix.