### PR TITLE
testing(bigquery): skip all datalab tests

### DIFF
--- a/bigquery/datalab-migration/samples_test.py
+++ b/bigquery/datalab-migration/samples_test.py
@@ -273,6 +273,7 @@ def test_client_library_load_table_from_gcs_csv(to_delete):
     assert table.num_rows == 50
 
 
+@pytest.mark.skip("datalab is deprecated, remove tests in sept 2023")
 def test_datalab_load_table_from_dataframe(to_delete):
     """ Wrap test with retries to handle transient errors """
     @Retry()

--- a/bigquery/datalab-migration/samples_test.py
+++ b/bigquery/datalab-migration/samples_test.py
@@ -83,6 +83,7 @@ def test_datalab_query_magic(ipython_interactive):
     df = results.to_dataframe()
     assert len(df) == 100
 
+
 @pytest.mark.skip("datalab is deprecated, remove tests in sept 2023")
 def test_client_library_query_magic(ipython_interactive):
     import pandas

--- a/bigquery/datalab-migration/samples_test.py
+++ b/bigquery/datalab-migration/samples_test.py
@@ -83,7 +83,7 @@ def test_datalab_query_magic(ipython_interactive):
     df = results.to_dataframe()
     assert len(df) == 100
 
-
+@pytest.mark.skip("datalab is deprecated, remove tests in sept 2023")
 def test_client_library_query_magic(ipython_interactive):
     import pandas
 
@@ -106,6 +106,7 @@ def test_client_library_query_magic(ipython_interactive):
     assert len(df) == 100
 
 
+@pytest.mark.skip("datalab is deprecated, remove tests in sept 2023")
 def test_datalab_query_magic_results_variable(ipython_interactive):
     ip = _set_up_ipython('google.datalab.kernel')
 
@@ -155,6 +156,7 @@ def test_client_library_query_magic_results_variable(ipython_interactive):
     ip.user_ns.pop(variable_name)  # clean up variable
 
 
+@pytest.mark.skip("datalab is deprecated, remove tests in sept 2023")
 def test_datalab_list_tables_magic(ipython_interactive):
     ip = _set_up_ipython('google.datalab.kernel')
 
@@ -170,6 +172,7 @@ def test_datalab_list_tables_magic(ipython_interactive):
     assert "shakespeare" in html_element.data
 
 
+@pytest.mark.skip("datalab is deprecated, remove tests in sept 2023")
 def test_datalab_query():
     # [START bigquery_migration_datalab_query]
     import google.datalab.bigquery as bq
@@ -201,6 +204,7 @@ def test_client_library_query():
     assert len(df) == 100
 
 
+@pytest.mark.skip("datalab is deprecated, remove tests in sept 2023")
 def test_datalab_load_table_from_gcs_csv(to_delete):
     # [START bigquery_migration_datalab_load_table_from_gcs_csv]
     import google.datalab.bigquery as bq


### PR DESCRIPTION
Datalab has been been effectively frozen for years, and is deprecated. We're no longer investing in fixing these tests, but instead we'll skip them.

In Sept 2023, we'll be at the 1yr mark and can remove the tests and accompanying migration guide.

Fixes: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9458
Fixes: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9457
Fixes: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9456
Fixes: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9455
Fixes: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9372
