### PR TITLE
fix: use same project for all testing

### DIFF
--- a/appengine/standard_python3/bundled-services/blobstore/django/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/blobstore/django/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/blobstore/flask/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/blobstore/flask/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/blobstore/wsgi/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/blobstore/wsgi/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/deferred/django/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/deferred/django/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/deferred/flask/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/deferred/flask/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/deferred/wsgi/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/deferred/wsgi/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/mail/django/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/mail/django/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/mail/flask/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/mail/flask/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/appengine/standard_python3/bundled-services/mail/wsgi/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/mail/wsgi/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/asset/snippets/noxfile_config.py
+++ b/asset/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/asset/snippets/noxfile_config.py
+++ b/asset/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/batch/noxfile_config.py
+++ b/batch/noxfile_config.py
@@ -13,5 +13,5 @@
 #  limitations under the License.
 
 TEST_CONFIG_OVERRIDE = {
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
 }

--- a/batch/noxfile_config.py
+++ b/batch/noxfile_config.py
@@ -13,5 +13,6 @@
 #  limitations under the License.
 
 TEST_CONFIG_OVERRIDE = {
-    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
 }

--- a/blog/introduction_to_data_models_in_cloud_datastore/noxfile_config.py
+++ b/blog/introduction_to_data_models_in_cloud_datastore/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/blog/introduction_to_data_models_in_cloud_datastore/noxfile_config.py
+++ b/blog/introduction_to_data_models_in_cloud_datastore/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/compute/client_library/noxfile_config.py
+++ b/compute/client_library/noxfile_config.py
@@ -14,6 +14,6 @@
 
 TEST_CONFIG_OVERRIDE = {
     # Tests in test_default_values.py require separate projects to not interfere with each other.
-    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
 }

--- a/compute/client_library/noxfile_config.py
+++ b/compute/client_library/noxfile_config.py
@@ -14,5 +14,6 @@
 
 TEST_CONFIG_OVERRIDE = {
     # Tests in test_default_values.py require separate projects to not interfere with each other.
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
 }

--- a/data-science-onramp/data-ingestion/noxfile_config.py
+++ b/data-science-onramp/data-ingestion/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/data-science-onramp/data-processing/noxfile_config.py
+++ b/data-science-onramp/data-processing/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/dataproc/snippets/noxfile_config.py
+++ b/dataproc/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/dialogflow/noxfile_config.py
+++ b/dialogflow/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/healthcare/api-client/v1/consent/noxfile_config.py
+++ b/healthcare/api-client/v1/consent/noxfile_config.py
@@ -28,8 +28,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/healthcare/api-client/v1/datasets/noxfile_config.py
+++ b/healthcare/api-client/v1/datasets/noxfile_config.py
@@ -28,8 +28,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/healthcare/api-client/v1/dicom/noxfile_config.py
+++ b/healthcare/api-client/v1/dicom/noxfile_config.py
@@ -28,8 +28,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/healthcare/api-client/v1/fhir/noxfile_config.py
+++ b/healthcare/api-client/v1/fhir/noxfile_config.py
@@ -27,8 +27,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/healthcare/api-client/v1/hl7v2/noxfile_config.py
+++ b/healthcare/api-client/v1/hl7v2/noxfile_config.py
@@ -28,8 +28,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/iam/api-client/noxfile_config.py
+++ b/iam/api-client/noxfile_config.py
@@ -33,8 +33,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/jobs/v3/api_client/noxfile_config.py
+++ b/jobs/v3/api_client/noxfile_config.py
@@ -28,8 +28,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/kms/snippets/noxfile_config.py
+++ b/kms/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
     # If you need to use a specific version of pip,
     # change pip_version_override to the string representation
     # of the version number, for example, "20.2.4"

--- a/monitoring/snippets/v3/alerts-client/noxfile_config.py
+++ b/monitoring/snippets/v3/alerts-client/noxfile_config.py
@@ -33,8 +33,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/monitoring/snippets/v3/cloud-client/noxfile_config.py
+++ b/monitoring/snippets/v3/cloud-client/noxfile_config.py
@@ -33,8 +33,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/monitoring/snippets/v3/uptime-check-client/noxfile_config.py
+++ b/monitoring/snippets/v3/uptime-check-client/noxfile_config.py
@@ -33,8 +33,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
 
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.

--- a/privateca/snippets/noxfile_config.py
+++ b/privateca/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/privateca/snippets/noxfile_config.py
+++ b/privateca/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/recaptcha_enterprise/snippets/noxfile_config.py
+++ b/recaptcha_enterprise/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/secretmanager/snippets/noxfile_config.py
+++ b/secretmanager/snippets/noxfile_config.py
@@ -30,8 +30,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},

--- a/securitycenter/snippets/noxfile_config.py
+++ b/securitycenter/snippets/noxfile_config.py
@@ -27,8 +27,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {

--- a/talent/noxfile_config.py
+++ b/talent/noxfile_config.py
@@ -27,8 +27,8 @@ TEST_CONFIG_OVERRIDE = {
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string
     # to use your own Cloud project.
-    # 'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
-    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    'gcloud_project_env': 'GOOGLE_CLOUD_PROJECT',
+    # "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {},


### PR DESCRIPTION
## Description

Does not use different projects for different versions of Python any more.