### PR TITLE
fix(pubsublite): pyspark pip install

### DIFF
--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -206,7 +206,6 @@ def _session_tests(
         else:
             session.install("-r", "requirements.txt")
 
-
     if os.path.exists("requirements-test.txt"):
         with open("requirements-test.txt") as rtfile:
             packages += rtfile.read()
@@ -216,7 +215,6 @@ def _session_tests(
             )
         else:
             session.install("-r", "requirements-test.txt")
-
 
     if INSTALL_LIBRARY_FROM_SOURCE:
         session.install("-e", _get_repo_root())

--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -224,6 +224,8 @@ def _session_tests(
         concurrent_args.extend(['--workers', 'auto', '--tests-per-worker', 'auto'])
     elif "pytest-xdist" in packages:
         concurrent_args.extend(['-n', 'auto'])
+    elif "pyspark" in packages:
+        concurrent_args.extend(['--use-pep517'])
 
     session.run(
         "pytest",

--- a/pubsublite/spark-connector/README.md
+++ b/pubsublite/spark-connector/README.md
@@ -84,9 +84,15 @@ Get the connector's uber jar from this [public Cloud Storage location]. Alternat
    > by running `deactivate`.
 
 1. Install the required packages.
+
     ```bash
-    python -m pip install -U -r requirements.txt
+    python -m pip install -U -r requirements.txt --use-pep517
     ```
+
+    `--use-pep517` is needed for `pip≥23.1`
+   ([`setup.py` install deprecation](https://github.com/pypa/pip/issues/8559))
+   unless you choose to build the Spark JARs and install the source distribution
+   ([Spark documentation](https://spark.apache.org/docs/latest/building-spark.html#pyspark-pip-installable)).
 
 ## Creating a Spark cluster on Dataproc
 


### PR DESCRIPTION
Fixes #9378 

The changes in `noxfile-template.py` effectively adds a `--use-pep517` flag to `pip install`. 

Copied from the text output:

```
nox > python -m pip install -r requirements.txt --use-pep517
```

This is required for pip≥23.1 as described in https://github.com/pypa/pip/issues/8559

Otherwise, we need to build the Spark Jar and install the source distribution as described in the Spark official documentation for this test: https://spark.apache.org/docs/latest/building-spark.html#pyspark-pip-installable