### PR TITLE
[DLP] Implemented dlp_deidentify_table_bucketing

### DIFF
--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -1023,6 +1023,113 @@ def deidentify_with_exception_list(
 # [END dlp_deidentify_exception_list]
 
 
+# [START dlp_deidentify_table_bucketing]
+def deidentify_table_bucketing(
+    project,
+    table_data,
+    deid_content_list,
+    bucket_size,
+    bucketing_lower_bound,
+    bucketing_upper_bound
+):
+    """Uses the Data Loss Prevention API to de-identify sensitive data in a
+    table by replacing them with fixed size bucket ranges.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        table_data: Json string representing table data.
+        deid_content_list: A list of fields in table to de-identify.
+        bucket_size: Size of each bucket for fixed sized bucketing
+            (except for minimum and maximum buckets). So if ``bucketing_lower_bound`` = 10,
+            ``bucketing_upper_bound`` = 89, and ``bucket_size`` = 10, then the
+            following buckets would be used: -10, 10-20, 20-30, 30-40,
+            40-50, 50-60, 60-70, 70-80, 80-89, 89+.
+       bucketing_lower_bound: Lower bound value of buckets.
+       bucketing_upper_bound:  Upper bound value of buckets.
+
+    Returns:
+       De-identified table is returned;
+       the response from the API is also printed to the terminal.
+
+    Example:
+    table_data = {
+       "header":[
+           "email",
+           "phone number"
+       ],
+       "rows":[
+           [
+               "robertfrost@xyz.com",
+               "4232342345"
+           ],
+           [
+               "johndoe@pqr.com",
+               "4253458383"
+           ]
+       ]
+    }
+    """
+
+    # Import the client library
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Construct the `table`. For more details on the table schema, please see
+    # https://cloud.google.com/dlp/docs/reference/rest/v2/ContentItem#Table
+    headers = [{"name": val} for val in table_data["header"]]
+    rows = []
+    for row in table_data["rows"]:
+        rows.append({"values": [{"string_value": cell_val} for cell_val in row]})
+
+    table = {"headers": headers, "rows": rows}
+
+    # Construct the `item`.
+    item = {"table": table}
+
+    # Construct fixed sized bucketing configuration
+    fixed_size_bucketing_config = {
+        "bucket_size": bucket_size,
+        "lower_bound": {"integer_value": bucketing_lower_bound},
+        "upper_bound": {"integer_value": bucketing_upper_bound}
+    }
+
+    # Specify fields to be de-identified
+    deid_content_list = [{"name": _i} for _i in deid_content_list]
+
+    # Construct Deidentify Config
+    deidentify_config = {
+        "record_transformations": {
+            "field_transformations": [
+                {
+                    "fields": deid_content_list,
+                    "primitive_transformation": {
+                        "fixed_size_bucketing_config": fixed_size_bucketing_config
+                    }
+                }
+            ]
+        }
+    }
+
+    # Call the API.
+    response = dlp.deidentify_content(request={
+        "parent": parent,
+        "deidentify_config": deidentify_config,
+        "item": item
+    })
+
+    # Print the results.
+    print("Table after de-identification: {}".format(response.item.table))
+
+    # Return the response.
+    return response.item.table
+
+# [END dlp_deidentify_table_bucketing]
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(
@@ -1282,6 +1389,36 @@ if __name__ == "__main__":
         help="The list of strings to ignore matches against.",
     )
 
+    table_bucketing_parser = subparsers.add_parser(
+        "deid_table_bucketing",
+        help="De-identify sensitive data in a table by replacing "
+             "them with fixed size bucket ranges.",
+    )
+    table_bucketing_parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    table_bucketing_parser.add_argument(
+        "--table_data",
+        help="Json string representing table data",
+    )
+    table_bucketing_parser.add_argument(
+        "--deid_content_list",
+        help="A list of fields in table to de-identify."
+    )
+    table_bucketing_parser.add_argument(
+        "--bucket_size",
+        help="Size of each bucket for fixed sized bucketing.",
+    )
+    table_bucketing_parser.add_argument(
+        "--bucketing_lower_bound",
+        help="Lower bound value of buckets.",
+    )
+    table_bucketing_parser.add_argument(
+        "--bucketing_upper_bound",
+        help="Upper bound value of buckets.",
+    )
+
     args = parser.parse_args()
 
     if args.content == "deid_mask":
@@ -1342,4 +1479,13 @@ if __name__ == "__main__":
             args.content_string,
             args.info_types,
             args.exception_list,
+        )
+    elif args.content == "deid_table_bucketing":
+        deidentify_table_bucketing(
+            args.project,
+            args.table_data,
+            args.deid_content_list,
+            args.bucket_size,
+            args.bucketing_lower_bound,
+            args.bucketing_upper_bound,
         )

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -1054,19 +1054,31 @@ def deidentify_table_bucketing(
     table_data = {
        "header":[
            "email",
-           "phone number"
+           "phone number",
+           "age"
        ],
        "rows":[
            [
                "robertfrost@xyz.com",
                "4232342345"
+               "35"
            ],
            [
                "johndoe@pqr.com",
                "4253458383"
+               "68"
            ]
        ]
     }
+
+    >> $ python deid.py deid_table_bucketing \
+        '{"header": ["email", "phone number", "age"],
+        "rows": [["robertfrost@xyz.com", "4232342345", "35"],
+        ["johndoe@pqr.com", "4253458383", "68"]]}' \
+        ["age"] 10 0 100
+        >>  '{"header": ["email", "phone number", "age"],
+            "rows": [["robertfrost@xyz.com", "4232342345", "30:40"],
+            ["johndoe@pqr.com", "4253458383", "60:70"]]}'
     """
 
     # Import the client library

--- a/dlp/snippets/deid_test.py
+++ b/dlp/snippets/deid_test.py
@@ -39,6 +39,10 @@ CSV_FILE = os.path.join(os.path.dirname(__file__), "resources/dates.csv")
 DATE_SHIFTED_AMOUNT = 30
 DATE_FIELDS = ["birth_date", "register_date"]
 CSV_CONTEXT_FIELD = "name"
+TABLE_DATA = {"header": ["age", "patient", "happiness_score"],
+              "rows": [["101", "Charles Dickens", "95"],
+                       ["22", "Jane Austen", "21"],
+                       ["90", "Mark Twain", "75"]]}
 
 
 @pytest.fixture(scope="module")
@@ -305,3 +309,24 @@ def test_deidentify_with_exception_list(capsys):
 
     assert "gary@example.org" not in out
     assert "jack@example.org accessed record of user: [EMAIL_ADDRESS]" in out
+
+
+def test_deidentify_table_bucketing(capsys):
+    deid_list = ["happiness_score"]
+    bucket_size = 10
+    lower_bound = 0
+    upper_bound = 100
+
+    deid.deidentify_table_bucketing(
+        GCLOUD_PROJECT,
+        TABLE_DATA,
+        deid_list,
+        bucket_size,
+        lower_bound,
+        upper_bound,
+    )
+
+    out, _ = capsys.readouterr()
+    assert "string_value: \"90:100\"" in out
+    assert "string_value: \"20:30\"" in out
+    assert "string_value: \"70:80\"" in out


### PR DESCRIPTION
## Description
[DLP] Implemented dlp_deidentify_table_bucketing with unit test cases. Java equivalent: https://cloud.google.com/dlp/docs/examples-deid-tables.md#dlp-deid-table-bucketing-java


Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
