### PR TITLE
[DLP] Implemented dlp_deidentify_table_row_suppress with unit test cases

### DIFF
--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -2218,7 +2218,7 @@ if __name__ == "__main__":
     table_row_suppress_parser = subparsers.add_parser(
         "deid_table_row_suppress",
         help="De-identify sensitive data in a table by suppressing "
-             "entire row/s based on a condition.",
+        "entire row/s based on a condition.",
     )
     table_row_suppress_parser.add_argument(
         "project",
@@ -2231,14 +2231,14 @@ if __name__ == "__main__":
     table_row_suppress_parser.add_argument(
         "--condition_field",
         help="A table Field within the record this condition is evaluated "
-             "against.",
+        "against.",
     )
     table_row_suppress_parser.add_argument(
         "--condition_operator",
         help="Operator used to compare the field or infoType to the value. "
-             "One of: RELATIONAL_OPERATOR_UNSPECIFIED, EQUAL_TO, NOT_EQUAL_TO, "
-             "GREATER_THAN, LESS_THAN, GREATER_THAN_OR_EQUALS, LESS_THAN_OR_EQUALS, "
-             "EXISTS.",
+        "One of: RELATIONAL_OPERATOR_UNSPECIFIED, EQUAL_TO, NOT_EQUAL_TO, "
+        "GREATER_THAN, LESS_THAN, GREATER_THAN_OR_EQUALS, LESS_THAN_OR_EQUALS, "
+        "EXISTS.",
     )
     table_row_suppress_parser.add_argument(
         "--condition_value",

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -20,6 +20,7 @@ import argparse
 
 from typing import List
 from typing import Dict
+from typing import List
 
 
 # [START dlp_deidentify_masking]

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -1130,9 +1130,7 @@ def deidentify_with_exception_list(
 
 
 # [START dlp_deidentify_table_bucketing]
-from typing import Dict  # noqa: F811, E402, I100
-from typing import List  # noqa: F811, E402, I100
-from typing import Union  # noqa: F811, E402, I100
+from typing import Dict, List, Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 from google.cloud.dlp_v2 import types  # noqa: F811, E402
@@ -1233,9 +1231,7 @@ def deidentify_table_bucketing(
 
 
 # [START dlp_deidentify_table_condition_infotypes]
-from typing import Dict  # noqa: F811, E402, I100
-from typing import List  # noqa: F811, E402, I100
-from typing import Union  # noqa: F811, E402, I100
+from typing import Dict, List, Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 from google.cloud.dlp_v2 import types  # noqa: F811, E402
@@ -1355,9 +1351,7 @@ def deidentify_table_condition_replace_with_info_types(
 
 
 # [START dlp_deidentify_table_condition_masking]
-from typing import Dict  # noqa: F811, E402, I100
-from typing import List  # noqa: F811, E402, I100
-from typing import Union  # noqa: F811, E402, I100
+from typing import Dict, List, Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 from google.cloud.dlp_v2 import types  # noqa: F811, E402
@@ -1466,9 +1460,7 @@ def deidentify_table_condition_masking(
 
 
 # [START dlp_deidentify_table_infotypes]
-from typing import Dict  # noqa: F811, E402, I100
-from typing import List  # noqa: F811, E402, I100
-from typing import Union  # noqa: F811, E402, I100
+from typing import Dict, List, Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 
@@ -1641,9 +1633,7 @@ def deindentify_with_dictionary_replacement(
 
 
 # [START dlp_deidentify_table_row_suppress]
-from typing import Dict  # noqa: F811, E402, I100
-from typing import List  # noqa: F811, E402, I100
-from typing import Union  # noqa: F811, E402, I100
+from typing import Dict, List, Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -1130,7 +1130,9 @@ def deidentify_with_exception_list(
 
 
 # [START dlp_deidentify_table_bucketing]
+from typing import Dict  # noqa: F811, E402, I100
 from typing import List  # noqa: F811, E402, I100
+from typing import Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 from google.cloud.dlp_v2 import types  # noqa: F811, E402
@@ -1138,7 +1140,7 @@ from google.cloud.dlp_v2 import types  # noqa: F811, E402
 
 def deidentify_table_bucketing(
     project: str,
-    table_data: str,
+    table_data: Dict[str, Union[List[str], List[List[str]]]],
     deid_content_list: List[str],
     bucket_size: int,
     bucketing_lower_bound: int,
@@ -1148,7 +1150,7 @@ def deidentify_table_bucketing(
     table by replacing them with fixed size bucket ranges.
     Args:
         project: The Google Cloud project id to use as a parent resource.
-        table_data: Json string representing table data.
+        table_data: Dictionary representing table data.
         deid_content_list: A list of fields in table to de-identify.
         bucket_size: Size of each bucket for fixed sized bucketing
             (except for minimum and maximum buckets). So if ``bucketing_lower_bound`` = 10,
@@ -1163,34 +1165,14 @@ def deidentify_table_bucketing(
        the response from the API is also printed to the terminal.
 
     Example:
-    table_data = {
-       "header":[
-           "email",
-           "phone number",
-           "age"
-       ],
-       "rows":[
-           [
-               "robertfrost@xyz.com",
-               "4232342345"
-               "35"
-           ],
-           [
-               "johndoe@pqr.com",
-               "4253458383"
-               "68"
-           ]
-       ]
-    }
-
     >> $ python deid.py deid_table_bucketing \
         '{"header": ["email", "phone number", "age"],
-        "rows": [["robertfrost@xyz.com", "4232342345", "35"],
-        ["johndoe@pqr.com", "4253458383", "68"]]}' \
+        "rows": [["robertfrost@example.com", "4232342345", "35"],
+        ["johndoe@example.com", "4253458383", "68"]]}' \
         ["age"] 10 0 100
         >>  '{"header": ["email", "phone number", "age"],
-            "rows": [["robertfrost@xyz.com", "4232342345", "30:40"],
-            ["johndoe@pqr.com", "4253458383", "60:70"]]}'
+            "rows": [["robertfrost@example.com", "4232342345", "30:40"],
+            ["johndoe@example.com", "4253458383", "60:70"]]}'
     """
 
     # Instantiate a client.
@@ -1251,7 +1233,9 @@ def deidentify_table_bucketing(
 
 
 # [START dlp_deidentify_table_condition_infotypes]
+from typing import Dict  # noqa: F811, E402, I100
 from typing import List  # noqa: F811, E402, I100
+from typing import Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 from google.cloud.dlp_v2 import types  # noqa: F811, E402
@@ -1259,12 +1243,12 @@ from google.cloud.dlp_v2 import types  # noqa: F811, E402
 
 def deidentify_table_condition_replace_with_info_types(
     project: str,
-    table_data: str,
+    table_data: Dict[str, Union[List[str], List[List[str]]]],
     deid_content_list: List[str],
     info_types: List[str],
     condition_field: str = None,
     condition_operator: str = None,
-    condition_value: str = None,
+    condition_value: int = None,
 ) -> types.dlp.Table:
     """Uses the Data Loss Prevention API to de-identify sensitive data in a
     table by replacing them with info-types based on a condition.
@@ -1286,33 +1270,13 @@ def deidentify_table_condition_replace_with_info_types(
        the response from the API is also printed to the terminal.
 
     Example:
-    table_data = {
-       "header":[
-           "email",
-           "phone number"
-           "age"
-       ],
-       "rows":[
-           [
-               "robertfrost@xyz.com",
-               "4232342345"
-               "45"
-           ],
-           [
-               "johndoe@pqr.com",
-               "4253458383"
-               "63"
-           ]
-       ]
-    }
-
     >> $ python deid.py deid_table_condition_replace \
     '{"header": ["email", "phone number", "age"],
-    "rows": [["robertfrost@xyz.com", "4232342345", "45"],
-    ["johndoe@pqr.com", "4253458383", "63"]]}' ["email"] \
+    "rows": [["robertfrost@example.com", "4232342345", "45"],
+    ["johndoe@example.com", "4253458383", "63"]]}' ["email"] \
     ["EMAIL_ADDRESS"] "age" "GREATER_THAN" 50
     >> '{"header": ["email", "phone number", "age"],
-        "rows": [["robertfrost@xyz.com", "4232342345", "45"],
+        "rows": [["robertfrost@example.com", "4232342345", "45"],
         ["[EMAIL_ADDRESS]", "4253458383", "63"]]}'
     """
 
@@ -1391,7 +1355,9 @@ def deidentify_table_condition_replace_with_info_types(
 
 
 # [START dlp_deidentify_table_condition_masking]
+from typing import Dict  # noqa: F811, E402, I100
 from typing import List  # noqa: F811, E402, I100
+from typing import Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 from google.cloud.dlp_v2 import types  # noqa: F811, E402
@@ -1399,11 +1365,11 @@ from google.cloud.dlp_v2 import types  # noqa: F811, E402
 
 def deidentify_table_condition_masking(
     project: str,
-    table_data: str,
+    table_data: Dict[str, Union[List[str], List[List[str]]]],
     deid_content_list: List[str],
     condition_field: str = None,
     condition_operator: str = None,
-    condition_value: str = None,
+    condition_value: int = None,
     masking_character: str = None,
 ) -> types.dlp.Table:
     """ Uses the Data Loss Prevention API to de-identify sensitive data in a
@@ -1425,37 +1391,14 @@ def deidentify_table_condition_masking(
         the response from the API is also printed to the terminal.
 
     Example:
-    table_data = {
-        "header":[
-            "email",
-            "phone number",
-            "age",
-            "happiness_score"
-        ],
-        "rows":[
-            [
-                "robertfrost@xyz.com",
-                "4232342345",
-                "35",
-                "21"
-            ],
-            [
-                "johndoe@pqr.com",
-                "4253458383",
-                "64",
-                "34"
-            ]
-        ]
-    }
-
     >> $ python deid.py deid_table_condition_mask \
     '{"header": ["email", "phone number", "age", "happiness_score"],
-    "rows": [["robertfrost@xyz.com", "4232342345", "35", "21"],
-    ["johndoe@pqr.com", "4253458383", "64", "34"]]}' \
+    "rows": [["robertfrost@example.com", "4232342345", "35", "21"],
+    ["johndoe@example.com", "4253458383", "64", "34"]]}' \
     ["happiness_score"] "age" "GREATER_THAN" 50
     >> '{"header": ["email", "phone number", "age", "happiness_score"],
-        "rows": [["robertfrost@xyz.com", "4232342345", "35", "21"],
-        ["johndoe@pqr.com", "4253458383", "64", "**"]]}'
+        "rows": [["robertfrost@example.com", "4232342345", "35", "21"],
+        ["johndoe@example.com", "4253458383", "64", "**"]]}'
     """
 
     # Instantiate a client.
@@ -1523,13 +1466,18 @@ def deidentify_table_condition_masking(
 
 
 # [START dlp_deidentify_table_infotypes]
+from typing import Dict  # noqa: F811, E402, I100
 from typing import List  # noqa: F811, E402, I100
+from typing import Union  # noqa: F811, E402, I100
 
 import google.cloud.dlp  # noqa: F811, E402
 
 
 def deidentify_table_replace_with_info_types(
-    project: str, table_data: str, info_types: List[str], deid_content_list: List[str]
+    project: str,
+    table_data: Dict[str, Union[List[str], List[List[str]]]],
+    info_types: List[str],
+    deid_content_list: List[str],
 ) -> None:
     """ Uses the Data Loss Prevention API to de-identify sensitive data in a
       table by replacing them with info type.
@@ -1549,16 +1497,16 @@ def deidentify_table_replace_with_info_types(
     '{
         "header": ["name", "email", "phone number"],
         "rows": [
-            ["Robert Frost", "robertfrost@xyz.com", "4232342345"],
-            ["John Doe", "johndoe@pqr.com", "4253458383"]
+            ["Robert Frost", "robertfrost@example.com", "4232342345"],
+            ["John Doe", "johndoe@example.com", "4253458383"]
         ]
     }' \
     ["PERSON_NAME"] ["name"]
     >> '{
             "header": ["name", "email", "phone number"],
             "rows": [
-                ["[PERSON_NAME]", "robertfrost@xyz.com", "4232342345"],
-                ["[PERSON_NAME]", "johndoe@pqr.com", "4253458383"]
+                ["[PERSON_NAME]", "robertfrost@example.com", "4232342345"],
+                ["[PERSON_NAME]", "johndoe@example.com", "4253458383"]
             ]
         }'
     """

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -21,6 +21,7 @@ import argparse
 from typing import List
 from typing import Dict
 from typing import List
+from typing import Union
 
 
 # [START dlp_deidentify_masking]
@@ -1694,7 +1695,7 @@ def deindentify_with_dictionary_replacement(
 # [START dlp_deidentify_table_row_suppress]
 def deidentify_table_suppress_row(
     project: str,
-    table_data: Dict[str, List[str]],
+    table_data: Dict[str, Union[List[str], List[List[str]]]],
     condition_field: str,
     condition_operator: str,
     condition_value: int,
@@ -1704,8 +1705,8 @@ def deidentify_table_suppress_row(
 
     Args:
         project: The Google Cloud project id to use as a parent resource.
-        table_data: Json string representing table data.
-        condition_field: A table Field within the record this condition is evaluated against.
+        table_data: Dictionary representing table data.
+        condition_field: A table field within the record this condition is evaluated against.
         condition_operator: Operator used to compare the field or infoType to the value. One of:
             RELATIONAL_OPERATOR_UNSPECIFIED, EQUAL_TO, NOT_EQUAL_TO, GREATER_THAN, LESS_THAN, GREATER_THAN_OR_EQUALS,
             LESS_THAN_OR_EQUALS, EXISTS.
@@ -1737,7 +1738,7 @@ def deidentify_table_suppress_row(
 
     table = {"headers": headers, "rows": rows}
 
-    # Construct the `item`.
+    # Construct the `item` containing the table data.
     item = {"table": table}
 
     # Construct condition list.

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 
 from typing import List
+from typing import Dict
 
 
 # [START dlp_deidentify_masking]
@@ -1691,12 +1692,12 @@ def deindentify_with_dictionary_replacement(
 
 # [START dlp_deidentify_table_row_suppress]
 def deidentify_table_suppress_row(
-    project,
-    table_data,
-    condition_field,
-    condition_operator,
-    condition_value
-):
+    project: str,
+    table_data: Dict[str, List[str]],
+    condition_field: str,
+    condition_operator: str,
+    condition_value: int,
+) -> None:
     """ Uses the Data Loss Prevention API to de-identify sensitive data in a
       table by suppressing entire row/s based on a condition.
 
@@ -1709,30 +1710,7 @@ def deidentify_table_suppress_row(
             LESS_THAN_OR_EQUALS, EXISTS.
         condition_value: Value to compare against. [Mandatory, except for ``EXISTS`` tests.].
 
-    Returns:
-        De-identified table is returned;
-        the response from the API is also printed to the terminal.
-
     Example:
-    table_data = {
-        "header":[
-            "email",
-            "phone number",
-            "age"
-        ],
-        "rows":[
-            [
-                "robertfrost@xyz.com",
-                "4232342345",
-                "35"
-            ],
-            [
-                "johndoe@pqr.com",
-                "4253458383",
-                "64"
-            ]
-        ]
-    }
 
     >> $ python deid.py deid_table_row_suppress \
     '{"header": ["email", "phone number", "age"],
@@ -1798,9 +1776,6 @@ def deidentify_table_suppress_row(
 
     # Print the result.
     print("Table after de-identification: {}".format(response.item.table))
-
-    # Return the response.
-    return response.item.table
 
 
 # [END dlp_deidentify_table_row_suppress]

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -18,11 +18,6 @@ from __future__ import annotations
 
 import argparse
 
-from typing import List
-from typing import Dict
-from typing import List
-from typing import Union
-
 
 # [START dlp_deidentify_masking]
 from typing import List  # noqa: F811, E402

--- a/dlp/snippets/deid.py
+++ b/dlp/snippets/deid.py
@@ -1693,6 +1693,13 @@ def deindentify_with_dictionary_replacement(
 
 
 # [START dlp_deidentify_table_row_suppress]
+from typing import Dict  # noqa: F811, E402, I100
+from typing import List  # noqa: F811, E402, I100
+from typing import Union  # noqa: F811, E402, I100
+
+import google.cloud.dlp  # noqa: F811, E402
+
+
 def deidentify_table_suppress_row(
     project: str,
     table_data: Dict[str, Union[List[str], List[List[str]]]],
@@ -1716,15 +1723,12 @@ def deidentify_table_suppress_row(
 
     >> $ python deid.py deid_table_row_suppress \
     '{"header": ["email", "phone number", "age"],
-    "rows": [["robertfrost@xyz.com", "4232342345", "35"],
-    ["johndoe@pqr.com", "4253458383", "64"]]}' \
+    "rows": [["robertfrost@example.com", "4232342345", "35"],
+    ["johndoe@example.com", "4253458383", "64"]]}' \
     "age" "GREATER_THAN" 50
     >> '{"header": ["email", "phone number", "age"],
-        "rows": [["robertfrost@xyz.com", "4232342345", "35", "21"]]}'
+        "rows": [["robertfrost@example.com", "4232342345", "35", "21"]]}'
     """
-
-    # Import the client library
-    import google.cloud.dlp
 
     # Instantiate a client.
     dlp = google.cloud.dlp_v2.DlpServiceClient()

--- a/dlp/snippets/deid_test.py
+++ b/dlp/snippets/deid_test.py
@@ -457,7 +457,7 @@ def test_deindentify_with_dictionary_replacement(capsys: pytest.CaptureFixture) 
     assert "izumi@example.com" in out or "alex@example.com" in out or "tal@example.com" in out
 
 
-def test_deidentify_table_suppress_row(capsys):
+def test_deidentify_table_suppress_row(capsys: pytest.CaptureFixture) -> None:
     deid.deidentify_table_suppress_row(
         GCLOUD_PROJECT,
         TABLE_DATA,

--- a/dlp/snippets/deid_test.py
+++ b/dlp/snippets/deid_test.py
@@ -468,5 +468,6 @@ def test_deidentify_table_suppress_row(capsys):
 
     out, _ = capsys.readouterr()
 
-    assert "string_value: \"Jane Austen\"" in out
     assert "string_value: \"Charles Dickens\"" not in out
+    assert "string_value: \"Jane Austen\"" in out
+    assert "string_value: \"Mark Twain\"" not in out

--- a/dlp/snippets/deid_test.py
+++ b/dlp/snippets/deid_test.py
@@ -455,3 +455,18 @@ def test_deindentify_with_dictionary_replacement(capsys: pytest.CaptureFixture) 
     out, _ = capsys.readouterr()
     assert "aabernathy@example.com" not in out
     assert "izumi@example.com" in out or "alex@example.com" in out or "tal@example.com" in out
+
+
+def test_deidentify_table_suppress_row(capsys):
+    deid.deidentify_table_suppress_row(
+        GCLOUD_PROJECT,
+        TABLE_DATA,
+        "age",
+        "GREATER_THAN",
+        89
+    )
+
+    out, _ = capsys.readouterr()
+
+    assert "string_value: \"Jane Austen\"" in out
+    assert "string_value: \"Charles Dickens\"" not in out


### PR DESCRIPTION
## Description
[DLP] Implemented dlp_deidentify_table_row_suppress with unit test cases. Java equivalent: https://cloud.google.com/dlp/docs/examples-deid-tables.md#dlp-deid-table-row-suppress-java

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
