### PR TITLE
add retries for subnetwork not ready errors

### DIFF
--- a/dataproc/snippets/create_cluster_test.py
+++ b/dataproc/snippets/create_cluster_test.py
@@ -16,8 +16,8 @@ import os
 import uuid
 
 import backoff
-from google.api_core.exceptions import (InternalServerError, NotFound,
-                                        ServiceUnavailable, InvalidArgument)
+from google.api_core.exceptions import (InternalServerError, InvalidArgument, NotFound,
+                                        ServiceUnavailable)
 from google.cloud import dataproc_v1 as dataproc
 import pytest
 

--- a/dataproc/snippets/create_cluster_test.py
+++ b/dataproc/snippets/create_cluster_test.py
@@ -17,7 +17,7 @@ import uuid
 
 import backoff
 from google.api_core.exceptions import (InternalServerError, NotFound,
-                                        ServiceUnavailable)
+                                        ServiceUnavailable, InvalidArgument)
 from google.cloud import dataproc_v1 as dataproc
 import pytest
 
@@ -50,7 +50,8 @@ def teardown():
         print("Cluster already deleted")
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
+# InvalidArgument is thrown when the subnetwork is not ready
+@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable, InvalidArgument), max_tries=5)
 def test_cluster_create(capsys):
     # Wrapper function for client library function
     create_cluster.create_cluster(PROJECT_ID, REGION, CLUSTER_NAME)

--- a/dataproc/snippets/submit_job_test.py
+++ b/dataproc/snippets/submit_job_test.py
@@ -16,8 +16,8 @@ import os
 import uuid
 
 import backoff
-from google.api_core.exceptions import (InternalServerError, NotFound,
-                                        ServiceUnavailable, InvalidArgument)
+from google.api_core.exceptions import (InternalServerError, InvalidArgument, NotFound,
+                                        ServiceUnavailable)
 from google.cloud import dataproc_v1 as dataproc
 import pytest
 

--- a/dataproc/snippets/submit_job_test.py
+++ b/dataproc/snippets/submit_job_test.py
@@ -36,7 +36,6 @@ CLUSTER = {
 }
 
 
-
 @pytest.fixture(autouse=True)
 def setup_teardown():
     # Retry on InvalidArgument subnetwork not ready error

--- a/dataproc/snippets/submit_job_test.py
+++ b/dataproc/snippets/submit_job_test.py
@@ -17,7 +17,7 @@ import uuid
 
 import backoff
 from google.api_core.exceptions import (InternalServerError, NotFound,
-                                        ServiceUnavailable)
+                                        ServiceUnavailable, InvalidArgument)
 from google.cloud import dataproc_v1 as dataproc
 import pytest
 
@@ -36,7 +36,9 @@ CLUSTER = {
 }
 
 
+# Retry on InvalidArgument subnetwork not ready error
 @pytest.fixture(autouse=True)
+@backoff.on_exception(backoff.expo, (InvalidArgument), max_tries=3)
 def setup_teardown():
     try:
         cluster_client = dataproc.ClusterControllerClient(

--- a/dataproc/snippets/submit_job_test.py
+++ b/dataproc/snippets/submit_job_test.py
@@ -37,7 +37,7 @@ CLUSTER = {
 
 
 # Retry on InvalidArgument subnetwork not ready error
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="module")
 @backoff.on_exception(backoff.expo, (InvalidArgument), max_tries=3)
 def setup_teardown():
     try:
@@ -71,7 +71,7 @@ def setup_teardown():
 
 
 @backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_submit_job(capsys):
+def test_submit_job(capsys, setup_teardown):
     submit_job.submit_job(PROJECT_ID, REGION, CLUSTER_NAME)
     out, _ = capsys.readouterr()
 

--- a/dataproc/snippets/submit_job_test.py
+++ b/dataproc/snippets/submit_job_test.py
@@ -38,39 +38,39 @@ CLUSTER = {
 
 @pytest.fixture(autouse=True)
 def setup_teardown():
+    cluster_client = dataproc.ClusterControllerClient(
+        client_options={
+            "api_endpoint": "{}-dataproc.googleapis.com:443".format(REGION)
+        }
+    )
+
     # Retry on InvalidArgument subnetwork not ready error
     @backoff.on_exception(backoff.expo, (InvalidArgument), max_tries=3)
-    def eventually_consistent_operation():
+    def setup():
+        # Create the cluster.
+        operation = cluster_client.create_cluster(
+            request={"project_id": PROJECT_ID, "region": REGION, "cluster": CLUSTER}
+        )
+        operation.result()
+
+    def teardown():
         try:
-            cluster_client = dataproc.ClusterControllerClient(
-                client_options={
-                    "api_endpoint": "{}-dataproc.googleapis.com:443".format(REGION)
+            operation = cluster_client.delete_cluster(
+                request={
+                    "project_id": PROJECT_ID,
+                    "region": REGION,
+                    "cluster_name": CLUSTER_NAME,
                 }
             )
-
-            # Create the cluster.
-            operation = cluster_client.create_cluster(
-                request={"project_id": PROJECT_ID, "region": REGION, "cluster": CLUSTER}
-            )
-            print("hi")
             operation.result()
-            print("yes")
-            yield
 
-        finally:
-            try:
-                operation = cluster_client.delete_cluster(
-                    request={
-                        "project_id": PROJECT_ID,
-                        "region": REGION,
-                        "cluster_name": CLUSTER_NAME,
-                    }
-                )
-                operation.result()
-
-            except NotFound:
-                print("Cluster already deleted")
-    eventually_consistent_operation()
+        except NotFound:
+            print("Cluster already deleted")
+    try:
+        setup()
+        yield
+    finally:
+        teardown()
 
 
 @backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)

--- a/dataproc/snippets/update_cluster_test.py
+++ b/dataproc/snippets/update_cluster_test.py
@@ -53,28 +53,30 @@ def cluster_client():
 def setup_teardown(cluster_client):
     # InvalidArgument is thrown when the subnetwork is not ready
     @backoff.on_exception(backoff.expo, (InvalidArgument), max_tries=3)
-    def eventually_consistent_operation():
+    def setup():
+        # Create the cluster.
+        operation = cluster_client.create_cluster(
+            request={"project_id": PROJECT_ID, "region": REGION, "cluster": CLUSTER}
+        )
+        operation.result()
+
+    def teardown():
         try:
-            # Create the cluster.
-            operation = cluster_client.create_cluster(
-                request={"project_id": PROJECT_ID, "region": REGION, "cluster": CLUSTER}
+            operation = cluster_client.delete_cluster(
+                request={
+                    "project_id": PROJECT_ID,
+                    "region": REGION,
+                    "cluster_name": CLUSTER_NAME,
+                }
             )
             operation.result()
-
-            yield
-        finally:
-            try:
-                operation = cluster_client.delete_cluster(
-                    request={
-                        "project_id": PROJECT_ID,
-                        "region": REGION,
-                        "cluster_name": CLUSTER_NAME,
-                    }
-                )
-                operation.result()
-            except NotFound:
-                print("Cluster already deleted")
-    eventually_consistent_operation()
+        except NotFound:
+            print("Cluster already deleted")
+    try:
+        setup()
+        yield
+    finally:
+        teardown()
 
 
 @backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)

--- a/dataproc/snippets/update_cluster_test.py
+++ b/dataproc/snippets/update_cluster_test.py
@@ -20,7 +20,7 @@ import uuid
 
 import backoff
 from google.api_core.exceptions import (InternalServerError, NotFound,
-                                        ServiceUnavailable)
+                                        ServiceUnavailable, InvalidArgument)
 from google.cloud.dataproc_v1.services.cluster_controller.client import \
     ClusterControllerClient
 import pytest
@@ -49,7 +49,9 @@ def cluster_client():
     return cluster_client
 
 
+# InvalidArgument is thrown when the subnetwork is not ready
 @pytest.fixture(autouse=True)
+@backoff.on_exception(backoff.expo, (InvalidArgument), max_tries=3)
 def setup_teardown(cluster_client):
     try:
         # Create the cluster.

--- a/dataproc/snippets/update_cluster_test.py
+++ b/dataproc/snippets/update_cluster_test.py
@@ -50,7 +50,7 @@ def cluster_client():
 
 
 # InvalidArgument is thrown when the subnetwork is not ready
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="module")
 @backoff.on_exception(backoff.expo, (InvalidArgument), max_tries=3)
 def setup_teardown(cluster_client):
     try:
@@ -76,7 +76,7 @@ def setup_teardown(cluster_client):
 
 
 @backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_update_cluster(capsys, cluster_client: ClusterControllerClient):
+def test_update_cluster(capsys, cluster_client: ClusterControllerClient, setup_teardown):
     # Wrapper function for client library function
     update_cluster.update_cluster(PROJECT_ID, REGION, CLUSTER_NAME, NEW_NUM_INSTANCES)
     new_num_cluster = cluster_client.get_cluster(

--- a/dataproc/snippets/update_cluster_test.py
+++ b/dataproc/snippets/update_cluster_test.py
@@ -19,8 +19,8 @@ import os
 import uuid
 
 import backoff
-from google.api_core.exceptions import (InternalServerError, NotFound,
-                                        ServiceUnavailable, InvalidArgument)
+from google.api_core.exceptions import (InternalServerError, InvalidArgument, NotFound,
+                                        ServiceUnavailable)
 from google.cloud.dataproc_v1.services.cluster_controller.client import \
     ClusterControllerClient
 import pytest


### PR DESCRIPTION
## Description

Fixes #9513
Fixes #9461 
Fixes #9445 

Even though I used the native retries in #9496, I went with `backoff` here because it was already in use in the sample. If you prefer i retrofit all of it to the native retry though, I can! I also think this will help with #9437 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
