### PR TITLE
[DLP] Implemented dlp_redact_image_all_infotypes with unit test cases

### DIFF
--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -374,6 +374,11 @@ if __name__ == "__main__":
         help="The MIME type of the file. If not specified, the type is "
         "inferred via the Python standard library's mimetypes module.",
     )
+    all_info_types_parser.add_argument(
+        "--mime_type",
+        help="The MIME type of the file. If not specified, the type is "
+        "inferred via the Python standard library's mimetypes module.",
+    )
 
     args = parser.parse_args()
 

--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -366,7 +366,8 @@ if __name__ == "__main__":
 
     all_info_types_parser = subparsers.add_parser(
         "all_info_types",
-        help="Redact all infoTypes from an image."
+        help="Redact all infoTypes from an image.",
+        parents=[common_args_parser],
     )
     all_info_types_parser.add_argument(
         "--mime_type",

--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -277,7 +277,6 @@ def redact_image_listed_info_types(
 # [END dlp_redact_image_listed_infotypes]
 
 
-
 # [START dlp_redact_image_all_infotypes]
 def redact_image_all_info_types(
     project,

--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -368,6 +368,11 @@ if __name__ == "__main__":
         "all_info_types",
         help="Redact all infoTypes from an image."
     )
+    all_info_types_parser.add_argument(
+        "--mime_type",
+        help="The MIME type of the file. If not specified, the type is "
+        "inferred via the Python standard library's mimetypes module.",
+    )
 
     args = parser.parse_args()
 

--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -179,6 +179,104 @@ def redact_image_all_text(
 
 # [END dlp_redact_image_all_text]
 
+
+# [START dlp_redact_image_listed_infotypes]
+def redact_image_listed_info_types(
+    project,
+    filename,
+    output_filename,
+    info_types,
+    min_likelihood=None,
+    mime_type=None
+):
+    """Uses the Data Loss Prevention API to redact protected data in an image.
+       Args:
+           project: The Google Cloud project id to use as a parent resource.
+           filename: The path to the file to inspect.
+           output_filename: The path to which the redacted image will be written.
+               A full list of info type categories can be fetched from the API.
+           info_types: A list of strings representing info types to look for.
+               A full list of info type categories can be fetched from the API.
+           min_likelihood: A string representing the minimum likelihood threshold
+               that constitutes a match. One of: 'LIKELIHOOD_UNSPECIFIED',
+               'VERY_UNLIKELY', 'UNLIKELY', 'POSSIBLE', 'LIKELY', 'VERY_LIKELY'.
+           mime_type: The MIME type of the file. If not specified, the type is
+               inferred via the Python standard library's mimetypes module.
+       Returns:
+           None; the response from the API is printed to the terminal.
+       """
+
+    # Import the client library
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries (protos are also accepted).
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Prepare image_redaction_configs, a list of dictionaries. Each dictionary
+    # contains an info_type and optionally the color used for the replacement.
+    # The color is omitted in this sample, so the default (black) will be used.
+    image_redaction_configs = []
+    if info_types is not None:
+        for info_type in info_types:
+            image_redaction_configs.append({"info_type": info_type})
+
+    # Construct the configuration dictionary. Keys which are None may
+    # optionally be omitted entirely.
+    inspect_config = {
+        "min_likelihood": min_likelihood,
+        "info_types": info_types
+    }
+
+    # If mime_type is not specified, guess it from the filename.
+    if mime_type is None:
+        mime_guess = mimetypes.MimeTypes().guess_type(filename)
+        mime_type = mime_guess[0] or "application/octet-stream"
+
+    # Select the content type index from the list of supported types.
+    supported_content_types = {
+        None: 0,  # "Unspecified"
+        "image/jpeg": 1,
+        "image/bmp": 2,
+        "image/png": 3,
+        "image/svg": 4,
+        "text/plain": 5,
+    }
+    content_type_index = supported_content_types.get(mime_type, 0)
+
+    # Construct the byte_item, containing the file's byte data.
+    with open(filename, mode="rb") as f:
+        byte_item = {"type_": content_type_index, "data": f.read()}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.redact_image(
+        request={
+            "parent": parent,
+            "inspect_config": inspect_config,
+            "image_redaction_configs": image_redaction_configs,
+            "byte_item": byte_item,
+        }
+    )
+
+    # Write out the results.
+    with open(output_filename, mode="wb") as f:
+        f.write(response.redacted_image)
+    print(
+        "Wrote {byte_count} to {filename}".format(
+            byte_count=len(response.redacted_image), filename=output_filename
+        )
+    )
+
+
+# [END dlp_redact_image_listed_infotypes]
+
+
 if __name__ == "__main__":
     default_project = os.environ.get("GOOGLE_CLOUD_PROJECT")
 
@@ -240,6 +338,37 @@ if __name__ == "__main__":
         parents=[common_args_parser],
     )
 
+    listed_info_types_parser = subparsers.add_parser(
+        "lister_info_types",
+        help="Redact specific infoTypes from an image.",
+        parents=[common_args_parser],
+    )
+    listed_info_types_parser.add_argument(
+        "--info_types",
+        nargs="+",
+        help="Strings representing info types to look for. A full list of "
+        "info categories and types is available from the API. Examples "
+        'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
+    )
+    listed_info_types_parser.add_argument(
+        "--min_likelihood",
+        help="A string representing the minimum likelihood threshold"
+        "that constitutes a match. One of: 'LIKELIHOOD_UNSPECIFIED', "
+        "'VERY_UNLIKELY', 'UNLIKELY', 'POSSIBLE', 'LIKELY', 'VERY_LIKELY'.",
+        default=None,
+    )
+    info_types_parser.add_argument(
+        "--mime_type",
+        help="The MIME type of the file. If not specified, the type is "
+        "inferred via the Python standard library's mimetypes module.",
+        default=None,
+    )
+
+    all_info_types_parser = subparsers.add_parser(
+        "all_info_types",
+        help="Redact all infoTypes from an image."
+    )
+
     args = parser.parse_args()
 
     if args.content == "info_types":
@@ -256,4 +385,13 @@ if __name__ == "__main__":
             args.project,
             args.filename,
             args.output_filename,
+        )
+    elif args.content == "lister_info_types":
+        redact_image_listed_info_types(
+            args.project,
+            args.filename,
+            args.output_filename,
+            args.info_types,
+            min_likelihood=args.min_likelihood,
+            mime_type=args.mime_type,
         )

--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -374,11 +374,6 @@ if __name__ == "__main__":
         help="The MIME type of the file. If not specified, the type is "
         "inferred via the Python standard library's mimetypes module.",
     )
-    all_info_types_parser.add_argument(
-        "--mime_type",
-        help="The MIME type of the file. If not specified, the type is "
-        "inferred via the Python standard library's mimetypes module.",
-    )
 
     args = parser.parse_args()
 

--- a/dlp/snippets/redact_test.py
+++ b/dlp/snippets/redact_test.py
@@ -73,3 +73,17 @@ def test_redact_image_listed_info_types(tempdir, capsys):
 
     out, _ = capsys.readouterr()
     assert output_filepath in out
+
+
+def test_redact_image_all_info_types(tempdir, capsys):
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+    output_filepath = os.path.join(tempdir, "redacted.png")
+
+    redact.redact_image_all_info_types(
+        GCLOUD_PROJECT,
+        test_filepath,
+        output_filepath,
+    )
+
+    out, _ = capsys.readouterr()
+    assert output_filepath in out

--- a/dlp/snippets/redact_test.py
+++ b/dlp/snippets/redact_test.py
@@ -58,3 +58,18 @@ def test_redact_image_all_text(tempdir, capsys):
 
     out, _ = capsys.readouterr()
     assert output_filepath in out
+
+
+def test_redact_image_listed_info_types(tempdir, capsys):
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+    output_filepath = os.path.join(tempdir, "redacted.png")
+
+    redact.redact_image_listed_info_types(
+        GCLOUD_PROJECT,
+        test_filepath,
+        output_filepath,
+        ["PHONE_NUMBER", "EMAIL_ADDRESS"],
+    )
+
+    out, _ = capsys.readouterr()
+    assert output_filepath in out


### PR DESCRIPTION
## Description
[DLP] Implemented dlp_inspect_image_all_infotypes with unit test cases. Java equivalent: https://cloud.google.com/dlp/docs/redacting-sensitive-data-images.md#dlp-redact-image-all-infotypes-java

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
