### PR TITLE
fix: minimize custom tests used

### DIFF
--- a/iam/api-client/custom_roles_test.py
+++ b/iam/api-client/custom_roles_test.py
@@ -14,6 +14,7 @@
 
 import os
 import uuid
+
 import pytest
 
 import custom_roles

--- a/iam/api-client/custom_roles_test.py
+++ b/iam/api-client/custom_roles_test.py
@@ -73,10 +73,11 @@ def test_edit_role(custom_role, capsys):
     custom_roles.edit_role(
         custom_role,
         GCLOUD_PROJECT,
-        CUSTOM_ROLE_TITLE,
+        "Python Test Custom Role",
+        "This is a python test custom role",
         "Updated",
-        CUSTOM_ROLE_PERMISSIONS,
-        CUSTOM_ROLE_STAGE,
+        ["iam.roles.get"],
+        "GA",
     )
     out, _ = capsys.readouterr()
     assert "Updated role:" in out

--- a/iam/api-client/custom_roles_test.py
+++ b/iam/api-client/custom_roles_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,47 +23,29 @@ import custom_roles
 
 GCLOUD_PROJECT = os.environ["GOOGLE_CLOUD_PROJECT"]
 
-CUSTOM_ROLE_NAME = "pythonTestCustomRole"
-CUSTOM_ROLE_TITLE = "Python Test Custom Role"
-CUSTOM_ROLE_DESCRIPTION = "This is a python test custom role"
-CUSTOM_ROLE_PERMISSIONS = ["iam.roles.get"]
-CUSTOM_ROLE_STAGE = "GA"
-CUSTOM_ROLE_EMAIL = (
-    CUSTOM_ROLE_NAME + "@" + GCLOUD_PROJECT + ".iam.gserviceaccount.com"
-)
 
-
+# A single custom role is created, used for all tests, then deleted, to minimize
+# the total number of custom roles in existence. Once a custom role is deleted,
+# it can take up to 14 days before it stops counting against the maximum number
+# of custom roles allowed.
+#
+# Since this fixture will throw an exception upon failing to create or delete
+# a custom role, there are no separatetests for those activities needed.
 @pytest.fixture(scope="module")
-def test_custom_role():
-    # This custom role is reused in read/update tests.
-    try:
-        custom_roles.create_role(
-            CUSTOM_ROLE_NAME,
-            GCLOUD_PROJECT,
-            CUSTOM_ROLE_TITLE,
-            CUSTOM_ROLE_DESCRIPTION,
-            CUSTOM_ROLE_PERMISSIONS,
-            CUSTOM_ROLE_STAGE,
-        )
-    except googleapiclient.errors.HttpError as e:
-        if "HttpError 409" not in str(e):
-            raise e
-        # Ignore error since we just reuse the same custom role.
-        print('Re-using the custom role "{}".'.format(CUSTOM_ROLE_NAME))
-    yield CUSTOM_ROLE_NAME
-    # we don't delete this custom role for future tests.
+def custom_role():
+    role_name = "pythonTestCustomRole" + str(uuid.uuid4().hex)
+    custom_roles.create_role(
+        role_name,
+        GCLOUD_PROJECT,
+        "Python Test Custom Role",
+        "This is a python test custom role",
+        ["iam.roles.get"],
+        "GA",
+    )
 
+    yield role_name
 
-@pytest.fixture(scope="function")
-def unique_custom_role_name():
-    UNIQUE_CUSTOM_ROLE_NAME = "pythonTestCustomRole" + str(uuid.uuid1().int)
-    yield UNIQUE_CUSTOM_ROLE_NAME
-
-    # Delete the custom role
-    try:
-        custom_roles.delete_role(UNIQUE_CUSTOM_ROLE_NAME, GCLOUD_PROJECT)
-    except googleapiclient.errors.HttpError:
-        print("Custom role already deleted.")
+    custom_roles.delete_role(role_name, GCLOUD_PROJECT)
 
 
 def test_query_testable_permissions(capsys):
@@ -75,28 +57,21 @@ def test_query_testable_permissions(capsys):
     assert "\n" in out
 
 
+def test_list_roles(capsys):
+    custom_roles.list_roles(GCLOUD_PROJECT)
+    out, _ = capsys.readouterr()
+    assert "roles/" in out
+
+
 def test_get_role(capsys):
     custom_roles.get_role("roles/appengine.appViewer")
     out, _ = capsys.readouterr()
     assert "roles/" in out
 
 
-def test_create_role(unique_custom_role_name, capsys):
-    custom_roles.create_role(
-        unique_custom_role_name,
-        GCLOUD_PROJECT,
-        CUSTOM_ROLE_TITLE,
-        CUSTOM_ROLE_DESCRIPTION,
-        CUSTOM_ROLE_PERMISSIONS,
-        CUSTOM_ROLE_STAGE,
-    )
-    out, _ = capsys.readouterr()
-    assert "Created role:" in out
-
-
-def test_edit_role(test_custom_role, capsys):
+def test_edit_role(custom_role, capsys):
     custom_roles.edit_role(
-        test_custom_role,
+        custom_role,
         GCLOUD_PROJECT,
         CUSTOM_ROLE_TITLE,
         "Updated",
@@ -107,27 +82,7 @@ def test_edit_role(test_custom_role, capsys):
     assert "Updated role:" in out
 
 
-def test_list_roles(capsys):
-    custom_roles.list_roles(GCLOUD_PROJECT)
-    out, _ = capsys.readouterr()
-    assert "roles/" in out
-
-
-def test_disable_role(test_custom_role, capsys):
-    custom_roles.disable_role(test_custom_role, GCLOUD_PROJECT)
+def test_disable_role(custom_role, capsys):
+    custom_roles.disable_role(custom_role, GCLOUD_PROJECT)
     out, _ = capsys.readouterr()
     assert "Disabled role:" in out
-
-
-def test_delete_role(unique_custom_role_name, capsys):
-    custom_roles.create_role(
-        unique_custom_role_name,
-        GCLOUD_PROJECT,
-        CUSTOM_ROLE_TITLE,
-        CUSTOM_ROLE_DESCRIPTION,
-        CUSTOM_ROLE_PERMISSIONS,
-        CUSTOM_ROLE_STAGE,
-    )
-    custom_roles.delete_role(unique_custom_role_name, GCLOUD_PROJECT)
-    out, _ = capsys.readouterr()
-    assert "Deleted role:" in out

--- a/iam/api-client/custom_roles_test.py
+++ b/iam/api-client/custom_roles_test.py
@@ -14,8 +14,6 @@
 
 import os
 import uuid
-
-import googleapiclient.errors
 import pytest
 
 import custom_roles


### PR DESCRIPTION
## Description

Fixes #9532 #9525 #9526 

There is a hard quota of 300 custom roles per project, and deleted custom roles still count against that quota for up to 14 days, so this test now creates and deletes only one custom role when run.