### PR TITLE
fix: slow down secretmanager writes

### DIFF
--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -13,6 +13,7 @@
 
 import base64
 import os
+import time
 import uuid
 
 from google.api_core import exceptions
@@ -70,6 +71,7 @@ def secret_id(client, project_id):
     secret_path = client.secret_path(project_id, secret_id)
     print("deleting secret {}".format(secret_id))
     try:
+        time.sleep(1)
         client.delete_secret(request={"name": secret_path})
     except exceptions.NotFound:
         # Secret was already deleted, probably in the test
@@ -82,6 +84,7 @@ def secret(client, project_id, secret_id):
     print("creating secret {}".format(secret_id))
 
     parent = f"projects/{project_id}"
+    time.sleep(1)
     secret = client.create_secret(
         request={
             "parent": parent,
@@ -100,6 +103,7 @@ def secret_version(client, secret):
     print("adding secret version to {}".format(secret_id))
     parent = client.secret_path(project_id, secret_id)
     payload = "hello world!".encode("UTF-8")
+    time.sleep(1)
     version = client.add_secret_version(
         request={"parent": parent, "payload": {"data": payload}}
     )


### PR DESCRIPTION
## Description

Fixes flaky secretmanager test

There is a hard quota of 240 writes per second for the secret manager service. Adding one second delay to each test fixture that causes such a write to avoid occasionally exceeding quota.