### PR TITLE
[DLP] Implemented dlp_redact_image_all_infotypes with unit test cases

### DIFF
--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -301,7 +301,7 @@ def redact_image_all_info_types(
 
     # Construct the byte_item, containing the file's byte data.
     with open(filename, mode="rb") as f:
-        byte_item = {"type_": 'IMAGE', "data": f.read()}
+        byte_item = {"type_": google.cloud.dlp_v2.FileType.IMAGE, "data": f.read()}
 
     # Convert the project id into a full resource id.
     parent = f"projects/{project}"

--- a/dlp/snippets/redact.py
+++ b/dlp/snippets/redact.py
@@ -277,6 +277,52 @@ def redact_image_listed_info_types(
 # [END dlp_redact_image_listed_infotypes]
 
 
+# [START dlp_redact_image_all_infotypes]
+def redact_image_all_info_types(
+    project,
+    filename,
+    output_filename,
+):
+    """Uses the Data Loss Prevention API to redact protected data in an image.
+       Args:
+           project: The Google Cloud project id to use as a parent resource.
+           filename: The path to the file to inspect.
+           output_filename: The path to which the redacted image will be written.
+               A full list of info type categories can be fetched from the API.
+       Returns:
+           None; the response from the API is printed to the terminal.
+    """
+
+    # Import the client library
+    import google.cloud.dlp
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct the byte_item, containing the file's byte data.
+    with open(filename, mode="rb") as f:
+        byte_item = {"type_": 'IMAGE', "data": f.read()}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.redact_image(
+        request={
+            "parent": parent,
+            "byte_item": byte_item,
+        }
+    )
+
+    # Write out the results.
+    with open(output_filename, mode="wb") as f:
+        f.write(response.redacted_image)
+    print(f"Wrote {len(response.redacted_image)} to {output_filename}")
+
+
+# [END dlp_redact_image_all_infotypes]
+
+
 if __name__ == "__main__":
     default_project = os.environ.get("GOOGLE_CLOUD_PROJECT")
 
@@ -364,6 +410,12 @@ if __name__ == "__main__":
         default=None,
     )
 
+    all_info_types_parser = subparsers.add_parser(
+        "all_info_types",
+        help="Redact all infoTypes from an image.",
+        parents=[common_args_parser],
+    )
+
     args = parser.parse_args()
 
     if args.content == "info_types":
@@ -389,4 +441,10 @@ if __name__ == "__main__":
             args.info_types,
             min_likelihood=args.min_likelihood,
             mime_type=args.mime_type,
+        )
+    elif args.content == "all_info_types":
+        redact_image_all_info_types(
+            args.project,
+            args.filename,
+            args.output_filename,
         )

--- a/dlp/snippets/redact_test.py
+++ b/dlp/snippets/redact_test.py
@@ -73,3 +73,17 @@ def test_redact_image_listed_info_types(tempdir, capsys):
 
     out, _ = capsys.readouterr()
     assert output_filepath in out
+
+
+def test_redact_image_all_info_types(tempdir, capsys):
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+    output_filepath = os.path.join(tempdir, "redacted.png")
+
+    redact.redact_image_all_info_types(
+        GCLOUD_PROJECT,
+        test_filepath,
+        output_filepath,
+    )
+
+    out, _ = capsys.readouterr()
+    assert output_filepath in out


### PR DESCRIPTION
## Description
[DLP] Implemented dlp_redact_image_all_infotypes with unit test cases. Java equivalent:
https://cloud.google.com/dlp/docs/redacting-sensitive-data-images.md#dlp-redact-image-all-infotypes-java

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [x] Please **merge** this PR for me once it is approved.
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
