### PR TITLE
ci: update default flakybot priority to p2

### DIFF
--- a/.github/flakybot.yaml
+++ b/.github/flakybot.yaml
@@ -1,0 +1,15 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+issuePriority: p2


### PR DESCRIPTION
Please review and reject if you would like to keep policy at p1 for new Flakybot issues.