### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "pip_requirements": {
     "fileMatch": ["requirements-test.txt", "requirements-composer.txt", "constraints.txt", "constraints-test.txt"]
   },
-  "ignorePaths" : ["composer/**/constraints.txt", "composer/blog/**/constraints.txt", "composer/airflow_1_samples/requirements.txt"],
+  "ignorePaths" : ["composer/**/constraints.txt", "composer/blog/**/constraints.txt", "composer/airflow_1_samples/requirements.txt", "appengine/standard"],
   "packageRules": [
     {
       "packagePatterns": ["pytest"],


### PR DESCRIPTION
## Description

Don't update /appengine/standard dependencies that are legacy Python 2.7 code and packages.