### PR TITLE
fix: Adds InvalidArgument as caught exception

### DIFF
--- a/dataproc/snippets/submit_job_test.py
+++ b/dataproc/snippets/submit_job_test.py
@@ -16,8 +16,13 @@ import os
 import uuid
 
 import backoff
-from google.api_core.exceptions import (AlreadyExists, InternalServerError, NotFound,
-                                        ServiceUnavailable)
+from google.api_core.exceptions import (
+    AlreadyExists,
+    InternalServerError,
+    InvalidArgument,
+    NotFound,
+    ServiceUnavailable
+)
 from google.cloud import dataproc_v1 as dataproc
 import pytest
 
@@ -36,7 +41,7 @@ def cluster_client():
     )
 
 
-@backoff.on_exception(backoff.expo, ServiceUnavailable, max_tries=5)
+@backoff.on_exception(backoff.expo, (ServiceUnavailable, InvalidArgument), max_tries=5)
 def setup_cluster(cluster_client, curr_cluster_name):
 
     CLUSTER = {


### PR DESCRIPTION
Improves robustness for cluster setup in backoff/retry

Also requested IN_USE_ADDRESSES quota increase  IAM & Admin -> Quotas -> Service (Compute Engine API) -> Metric(In-use IP addresses) on us-central1 and europe-north1 because these quotas were exceeded during presubmit testing of this PR.

Fixes #9513