### PR TITLE
fix: Use .message.data key to extract data from cloud_event

### DIFF
--- a/functions/v2/ocr/main.py
+++ b/functions/v2/ocr/main.py
@@ -137,7 +137,7 @@ def translate_text(cloud_event):
 
     # Extract the message body, expected to be a JSON representation of a
     # dictionary, and extract the fields from that dictionary.
-    data = cloud_event.data["message"]
+    data = cloud_event.data["message"]["data"]
     try:
         message_data = base64.b64decode(data)
         message = json.loads(message_data)
@@ -185,7 +185,7 @@ def save_result(cloud_event):
 
     # Extract the message body, expected to be a JSON representation of a
     # dictionary, and extract the fields from that dictionary.
-    data = cloud_event.data["message"]
+    data = cloud_event.data["message"]["data"]
     try:
         message_data = base64.b64decode(data)
         message = json.loads(message_data)

--- a/functions/v2/ocr/main_test.py
+++ b/functions/v2/ocr/main_test.py
@@ -71,16 +71,18 @@ class TestGCFPyOCRSample:
             "source": "https://example.com/event-producer",
         }
         data = {
-            "message": base64.b64encode(
-                json.dumps(
-                    {
-                        "text": "menu",
-                        "filename": "sample-file",
-                        "lang": "es",
-                        "src_lang": "en",
-                    }
-                ).encode("utf-8")
-            )
+            "message": {
+                "data": base64.b64encode(
+                    json.dumps(
+                        {
+                            "text": "menu",
+                            "filename": "sample-file",
+                            "lang": "es",
+                            "src_lang": "en",
+                        }
+                    ).encode("utf-8")
+                )
+            }
         }
 
         event = CloudEvent(attributes, data)
@@ -98,15 +100,17 @@ class TestGCFPyOCRSample:
             "source": "https://example.com/event-producer",
         }
         data = {
-            "message": base64.b64encode(
-                json.dumps(
-                    {
-                        "text": "menu",
-                        "filename": "sample-file",
-                        "lang": "fr",
-                    }
-                ).encode("utf-8")
-            )
+            "message": {
+                "data": base64.b64encode(
+                    json.dumps(
+                        {
+                            "text": "menu",
+                            "filename": "sample-file",
+                            "lang": "fr",
+                        }
+                    ).encode("utf-8")
+                )
+            }
         }
 
         event = CloudEvent(attributes, data)


### PR DESCRIPTION
## Description

Fixes #9838 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved