### PR TITLE
use `logging.warning` in helloworld

### DIFF
--- a/functions/helloworld/main.py
+++ b/functions/helloworld/main.py
@@ -213,7 +213,7 @@ def hello_error_2(request):
     import logging
     import sys
     print(RuntimeError('I failed you (print to stdout)'))
-    logging.warn(RuntimeError('I failed you (logging.warn)'))
+    logging.warning(RuntimeError('I failed you (logging.warning)'))
     logging.error(RuntimeError('I failed you (logging.error)'))
     sys.stderr.write('I failed you (sys.stderr.write)\n')
 


### PR DESCRIPTION

## Description

This PR replaces `logging.warn` which is deprecated as of Python 3.3, in favor of `logging.warning`


Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ x] Please **merge** this PR for me once it is approved