### PR TITLE
[DLP] Implemenetd dlp_inspect_image_listed_infotypes with unit test cases

### DIFF
--- a/dlp/snippets/inspect_content.py
+++ b/dlp/snippets/inspect_content.py
@@ -991,14 +991,15 @@ def inspect_image_file_listed_infotypes(
     info_types: List[str],
     include_quote=True,
 ) -> None:
-    """Uses the Data Loss Prevention API to analyze strings for protected data
-    in image file for given info types.
+    """Uses the Data Loss Prevention API to analyze strings in an image for
+    data matching the given infoTypes.
     Args:
         project: The Google Cloud project id to use as a parent resource.
-        filename: The path to the file to inspect.
-        info_types:
-        include_quote: Boolean for whether to display a quote of the detected
-            information in the results.
+        filename: The path of the image file to inspect.
+        info_types:  A list of strings representing infoTypes to look for.
+            A full list of info type categories can be fetched from the API.
+        include_quote: Boolean for whether to display a matching snippet of
+            the detected information in the results.
     """
     # Import the client library
     import google.cloud.dlp
@@ -1007,11 +1008,10 @@ def inspect_image_file_listed_infotypes(
     dlp = google.cloud.dlp_v2.DlpServiceClient()
 
     # Prepare info_types by converting the list of strings into a list of
-    # dictionaries (protos are also accepted).
+    # dictionaries.
     info_types = [{"name": info_type} for info_type in info_types]
 
-    # Construct the configuration dictionary. Keys which are None may
-    # optionally be omitted entirely.
+    # Construct the configuration dictionary.
     inspect_config = {
         "info_types": info_types,
         "include_quote": include_quote,
@@ -1036,9 +1036,10 @@ def inspect_image_file_listed_infotypes(
     # Print out the results.
     if response.result.findings:
         for finding in response.result.findings:
-            print("Quote: {}".format(finding.quote))
             print("Info type: {}".format(finding.info_type.name))
-            print("Likelihood: {}".format(finding.likelihood))
+            if include_quote:
+                print("Quote: {}".format(finding.quote))
+            print("Likelihood: {} \n".format(finding.likelihood))
     else:
         print("No findings.")
 

--- a/dlp/snippets/inspect_content_test.py
+++ b/dlp/snippets/inspect_content_test.py
@@ -328,6 +328,19 @@ def test_inspect_image_file_all_infotypes(capsys):
     assert "Info type: EMAIL_ADDRESS" in out
 
 
+def test_inspect_image_file_listed_infotypes(capsys):
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+
+    inspect_content.inspect_image_file_listed_infotypes(
+        GCLOUD_PROJECT,
+        test_filepath,
+        ["EMAIL_ADDRESS"],
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Info type: EMAIL_ADDRESS" in out
+
+
 def delete_dlp_job(out):
     for line in str(out).split("\n"):
         if "Job name" in line:


### PR DESCRIPTION
## Description
Implemenetd dlp_inspect_image_listed_infotypes with unit test cases. Java equivalent: https://cloud.google.com/dlp/docs/samples/dlp-inspect-image-listed-infotypes#dlp_inspect_image_listed_infotypes-java

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved