### PR TITLE
fix: Updating dataproc quickstart test region

### DIFF
--- a/dataproc/snippets/quickstart/quickstart_test.py
+++ b/dataproc/snippets/quickstart/quickstart_test.py
@@ -25,7 +25,7 @@ import quickstart
 
 
 PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
-REGION = "us-central1"
+REGION = "northamerica-northeast1"
 
 JOB_FILE_NAME = "sum.py"
 SORT_CODE = (


### PR DESCRIPTION
Reduce stress on us-central1 default subnet and prevent failures. Uses a 100% carbon neutral cell

Fixes #9461
