### PR TITLE
fix: pin urllib3 as a workaround

### DIFF
--- a/run/idp-sql/requirements.txt
+++ b/run/idp-sql/requirements.txt
@@ -4,3 +4,4 @@ pg8000==1.29.4
 gunicorn==20.1.0
 firebase-admin==6.1.0
 structlog==22.1.0
+urllib3<2.0.0 #https://stackoverflow.com/questions/76175361/firebase-authentication-httpresponse-object-has-no-attribute-strict-status


### PR DESCRIPTION
Fixes #9897

Error message `AttributeError: 'HTTPResponse' object has no attribute 'strict'` in the logs for the cloud run service that acts as a test fixture. Googling this lead to: https://stackoverflow.com/questions/76175361/firebase-authentication-httpresponse-object-has-no-attribute-strict-status

Suggested workaround:
urllib3<2.0.0