### PR TITLE
ppai/timeseries: fix flaky tests

### DIFF
--- a/people-and-planet-ai/timeseries-classification/Dockerfile
+++ b/people-and-planet-ai/timeseries-classification/Dockerfile
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# NVIDIA CUDA container: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda
-# Supported NVIDIA images: https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md
-# TensorFlow/CUDA compatibility: https://www.tensorflow.org/install/source#gpu
 FROM python:3.10-slim
 
 WORKDIR /pipeline

--- a/people-and-planet-ai/timeseries-classification/create_datasets.py
+++ b/people-and-planet-ai/timeseries-classification/create_datasets.py
@@ -81,7 +81,7 @@ def run(
     try:
         return result._job.id
     except Exception:
-        return beam_args.get("job_name", "local_job")
+        return "local_job"
 
 
 if __name__ == "__main__":

--- a/people-and-planet-ai/timeseries-classification/create_datasets.py
+++ b/people-and-planet-ai/timeseries-classification/create_datasets.py
@@ -93,21 +93,17 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    # parser.add_argument("--raw-data-dir", required=True)
-    # parser.add_argument("--raw-labels-dir", required=True)
-    # parser.add_argument("--train-data-dir", required=True)
-    # parser.add_argument("--eval-data-dir", required=True)
+    parser.add_argument("--raw-data-dir", required=True)
+    parser.add_argument("--raw-labels-dir", required=True)
+    parser.add_argument("--train-data-dir", required=True)
+    parser.add_argument("--eval-data-dir", required=True)
     args, beam_args = parser.parse_known_args()
 
     job_id = run(
-        # raw_data_dir=args.raw_data_dir,
-        # raw_labels_dir=args.raw_labels_dir,
-        # train_data_dir=args.train_data_dir,
-        # eval_data_dir=args.eval_data_dir,
-        raw_data_dir="test_data",
-        raw_labels_dir="test_data",
-        train_data_dir="data",
-        eval_data_dir="data",
+        raw_data_dir=args.raw_data_dir,
+        raw_labels_dir=args.raw_labels_dir,
+        train_data_dir=args.train_data_dir,
+        eval_data_dir=args.eval_data_dir,
         train_eval_split=[80, 20],
         beam_args=beam_args,
     )

--- a/people-and-planet-ai/timeseries-classification/create_datasets.py
+++ b/people-and-planet-ai/timeseries-classification/create_datasets.py
@@ -40,11 +40,7 @@ def run(
         ]
     ).sort_values(by="start_time")
 
-    beam_options = PipelineOptions(
-        beam_args,
-        save_main_session=True,
-        requirements_file="requirements.txt",
-    )
+    beam_options = PipelineOptions(beam_args, save_main_session=True)
     pipeline = beam.Pipeline(options=beam_options)
 
     training_data, evaluation_data = (

--- a/people-and-planet-ai/timeseries-classification/create_datasets.py
+++ b/people-and-planet-ai/timeseries-classification/create_datasets.py
@@ -33,7 +33,6 @@ def run(
     train_eval_split: List[int],
     **beam_args: List[str],
 ) -> str:
-
     labels = pd.concat(
         [
             data_utils.read_labels(filename)
@@ -87,4 +86,29 @@ def run(
     try:
         return result._job.id
     except Exception:
-        return beam_args.get("job_name")
+        return beam_args.get("job_name", "local_job")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    # parser.add_argument("--raw-data-dir", required=True)
+    # parser.add_argument("--raw-labels-dir", required=True)
+    # parser.add_argument("--train-data-dir", required=True)
+    # parser.add_argument("--eval-data-dir", required=True)
+    args, beam_args = parser.parse_known_args()
+
+    job_id = run(
+        # raw_data_dir=args.raw_data_dir,
+        # raw_labels_dir=args.raw_labels_dir,
+        # train_data_dir=args.train_data_dir,
+        # eval_data_dir=args.eval_data_dir,
+        raw_data_dir="test_data",
+        raw_labels_dir="test_data",
+        train_data_dir="data",
+        eval_data_dir="data",
+        train_eval_split=[80, 20],
+        beam_args=beam_args,
+    )
+    print(f"job_id: {job_id}")

--- a/people-and-planet-ai/timeseries-classification/create_datasets.py
+++ b/people-and-planet-ai/timeseries-classification/create_datasets.py
@@ -31,7 +31,7 @@ def run(
     train_data_dir: str,
     eval_data_dir: str,
     train_eval_split: List[int],
-    **beam_args: List[str],
+    beam_args: List[str],
 ) -> str:
     labels = pd.concat(
         [
@@ -41,10 +41,9 @@ def run(
     ).sort_values(by="start_time")
 
     beam_options = PipelineOptions(
-        flags=[],
+        beam_args,
         save_main_session=True,
         requirements_file="requirements.txt",
-        **beam_args,
     )
     pipeline = beam.Pipeline(options=beam_options)
 

--- a/people-and-planet-ai/timeseries-classification/e2e_test.py
+++ b/people-and-planet-ai/timeseries-classification/e2e_test.py
@@ -217,7 +217,6 @@ def access_token() -> str:
 def create_datasets(
     service_url: str, access_token: str, raw_data_dir: str, raw_labels_dir: str
 ) -> str:
-
     response = requests.post(
         f"{service_url}/create-datasets",
         headers={"Authorization": f"Bearer {access_token}"},
@@ -278,10 +277,10 @@ def test_predict(service_url: str, access_token: str, train_model: None) -> None
         url=f"{service_url}/predict",
         headers={"Authorization": f"Bearer {access_token}"},
         json={"inputs": input_data.to_dict("list")},
-    ).json()
+    )
     logging.info(f"predict response: {response}")
 
-    predictions = pd.DataFrame(response["predictions"])
+    predictions = pd.DataFrame(response.json()["predictions"])
 
     # Check that we get non-empty predictions.
     assert "is_fishing" in predictions

--- a/people-and-planet-ai/timeseries-classification/e2e_test.py
+++ b/people-and-planet-ai/timeseries-classification/e2e_test.py
@@ -152,8 +152,7 @@ def service_url(bucket_name: str, container_image: str) -> str:
             "--platform=managed",
             f"--project={PROJECT}",
             f"--region={REGION}",
-            "--memory=1G",
-            "--timeout=30m",
+            "--memory=4G",
             f"--set-env-vars=PROJECT={PROJECT}",
             f"--set-env-vars=STORAGE_PATH=gs://{bucket_name}",
             f"--set-env-vars=REGION={REGION}",
@@ -217,16 +216,17 @@ def access_token() -> str:
 def create_datasets(
     service_url: str, access_token: str, raw_data_dir: str, raw_labels_dir: str
 ) -> str:
-    response = requests.post(
+    raw_response = requests.post(
         f"{service_url}/create-datasets",
         headers={"Authorization": f"Bearer {access_token}"},
         json={
             "raw_data_dir": raw_data_dir,
             "raw_labels_dir": raw_labels_dir,
         },
-    ).json()
-    logging.info(f"create_datasets response: {response}")
+    )
+    logging.info(f"create_datasets response: {raw_response}")
 
+    response = raw_response.json()
     job_id = response["job_id"]
     job_url = response["job_url"]
     logging.info(f"create_datasets job_id: {job_id}")
@@ -261,26 +261,27 @@ def create_datasets(
 @pytest.fixture(scope="session")
 def train_model(service_url: str, access_token: str, create_datasets: str) -> None:
     logging.info("Training model")
-    response = requests.post(
+    raw_response = requests.post(
         url=f"{service_url}/train-model",
         headers={"Authorization": f"Bearer {access_token}"},
         json={"train_epochs": 10, "batch_size": 8, "sync": True},
     )
-    logging.info(f"train_model response: {response}")
+    logging.info(f"train_model response: {raw_response}")
 
 
 def test_predict(service_url: str, access_token: str, train_model: None) -> None:
     with open("test_data/56980685061237.npz", "rb") as f:
         input_data = pd.DataFrame(np.load(f)["x"])
 
-    response = requests.post(
+    raw_response = requests.post(
         url=f"{service_url}/predict",
         headers={"Authorization": f"Bearer {access_token}"},
         json={"inputs": input_data.to_dict("list")},
     )
-    logging.info(f"predict response: {response}")
+    logging.info(f"predict response: {raw_response}")
 
-    predictions = pd.DataFrame(response.json()["predictions"])
+    response = raw_response.json()
+    predictions = pd.DataFrame(response["predictions"])
 
     # Check that we get non-empty predictions.
     assert "is_fishing" in predictions

--- a/people-and-planet-ai/timeseries-classification/local_test.py
+++ b/people-and-planet-ai/timeseries-classification/local_test.py
@@ -82,8 +82,8 @@ def test_e2e_local() -> None:
         cmd = [
             "python",
             "create_datasets.py",
-            f"--raw-data-dir=test_data",
-            f"--raw-labels-dir=test_data",
+            "--raw-data-dir=test_data",
+            "--raw-labels-dir=test_data",
             f"--train-data-dir={train_data_dir}",
             f"--eval-data-dir={eval_data_dir}",
         ]

--- a/people-and-planet-ai/timeseries-classification/local_test.py
+++ b/people-and-planet-ai/timeseries-classification/local_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import subprocess
 import tempfile
 from unittest import mock
 
@@ -21,7 +22,6 @@ import pandas as pd
 import pytest
 import tensorflow as tf
 
-import create_datasets
 import data_utils
 import predict
 import trainer
@@ -79,13 +79,15 @@ def test_e2e_local() -> None:
         checkpoint_dir = os.path.join(temp_dir, "checkpoints")
 
         # Create the dataset TFRecord files.
-        create_datasets.run(
-            raw_data_dir="test_data",
-            raw_labels_dir="test_data",
-            train_data_dir=train_data_dir,
-            eval_data_dir=eval_data_dir,
-            train_eval_split=[80, 20],
-        )
+        cmd = [
+            "python",
+            "create_datasets.py",
+            f"--raw-data-dir=test_data",
+            f"--raw-labels-dir=test_data",
+            f"--train-data-dir={train_data_dir}",
+            f"--eval-data-dir={eval_data_dir}",
+        ]
+        subprocess.run(cmd, check=True)
         assert os.listdir(train_data_dir), "no training files found"
         assert os.listdir(eval_data_dir), "no evaluation files found"
 

--- a/people-and-planet-ai/timeseries-classification/main.py
+++ b/people-and-planet-ai/timeseries-classification/main.py
@@ -78,10 +78,22 @@ def run_create_datasets() -> dict:
         ]
         result = subprocess.run(cmd, check=True, capture_output=True)
         output = result.stdout.decode("utf-8")
+
+        m = re.search(r"^job_id: (.*)$", output)
+        if m:
+            job_id = m.group(1)
+            job_url = (
+                f"https://console.cloud.google.com/dataflow/jobs/{REGION}/{job_id}?project={PROJECT}",
+            )
+        else:
+            job_id = ""
+            job_url = ""
+
         return {
             "method": "create-datasets",
             "job_name": job_name,
-            "job_id": m.group(1) if (m := re.search(r"^job_id: (.*)$", output)) else "",
+            "job_id": job_id,
+            "job_url": job_url,
         }
     except Exception as e:
         return {"error": f"{type(e).__name__}: {e}"}

--- a/people-and-planet-ai/timeseries-classification/main.py
+++ b/people-and-planet-ai/timeseries-classification/main.py
@@ -75,6 +75,7 @@ def run_create_datasets() -> dict:
             f"--project={args.get('project', PROJECT)}",
             f"--region={args.get('region', REGION)}",
             f"--temp_location={args.get('temp_location', TEMP_DIR)}",
+            f"--sdk_container_image={CONTAINER_IMAGE}",
         ]
         result = subprocess.run(cmd, check=True, capture_output=True)
         output = result.stdout.decode("utf-8")


### PR DESCRIPTION
## Description

Fixes #9891 and #9797

TensorFlow drastically increased its memory footprint, requiring to increase the available memory on Cloud Run.

Also, Dataflow has trouble pickling the main session when launching from an existing process. Launching the job from a subprocess is the recommended way to avoid pickling unwanted symbols.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved