### PR TITLE
refactor: typehints and return for webrisk samples

### DIFF
--- a/webrisk/snippets/compute_threatlist_diff.py
+++ b/webrisk/snippets/compute_threatlist_diff.py
@@ -14,6 +14,7 @@
 
 # [START webrisk_compute_threatlist_diff]
 from google.cloud import webrisk_v1
+from google.cloud.webrisk_v1 import ComputeThreatListDiffResponse
 
 
 def compute_threatlist_diff(
@@ -22,7 +23,7 @@ def compute_threatlist_diff(
     max_diff_entries: int,
     max_database_entries: int,
     compression_type: webrisk_v1.CompressionType,
-) -> None:
+) -> ComputeThreatListDiffResponse:
     """Gets the most recent threat list diffs. These diffs should be applied to a local database of
     hashes to keep it up-to-date.
 
@@ -50,6 +51,10 @@ def compute_threatlist_diff(
 
         compression_type: The compression type supported by the client.
             compression_type = webrisk_v1.CompressionType.RAW
+
+    Returns:
+        The response which contains the diff between local and remote threat lists. In addition to the threat list,
+        the response also contains the version token and the recommended time for next diff.
     """
 
     webrisk_client = webrisk_v1.WebRiskServiceClient()
@@ -70,12 +75,12 @@ def compute_threatlist_diff(
     # https://cloud.google.com/web-risk/docs/reference/rpc/google.cloud.webrisk.v1#computethreatlistdiffresponse
     # Type of response: DIFF/ RESET/ RESPONSE_TYPE_UNSPECIFIED
     print(response.response_type)
-
     # New version token to be used the next time when querying.
     print(response.new_version_token)
-
     # Recommended next diff timestamp.
     print(response.recommended_next_diff)
 
-    print("Obtained threat list diff.")
+    return response
+
+
 # [END webrisk_compute_threatlist_diff]

--- a/webrisk/snippets/compute_threatlist_diff.py
+++ b/webrisk/snippets/compute_threatlist_diff.py
@@ -24,9 +24,9 @@ def compute_threatlist_diff(
     max_database_entries: int,
     compression_type: webrisk_v1.CompressionType,
 ) -> ComputeThreatListDiffResponse:
-    """Gets the most recent threat list diffs. These diffs should be applied to a local database of
-    hashes to keep it up-to-date.
-
+    """Gets the most recent threat list diffs. 
+    
+    These diffs should be applied to a local database of hashes to keep it up-to-date. 
     If the local database is empty or excessively out-of-date,
     a complete snapshot of the database will be returned. This Method only updates a
     single ThreatList at a time. To update multiple ThreatList databases, this method needs to be

--- a/webrisk/snippets/compute_threatlist_diff.py
+++ b/webrisk/snippets/compute_threatlist_diff.py
@@ -24,9 +24,9 @@ def compute_threatlist_diff(
     max_database_entries: int,
     compression_type: webrisk_v1.CompressionType,
 ) -> ComputeThreatListDiffResponse:
-    """Gets the most recent threat list diffs. 
-    
-    These diffs should be applied to a local database of hashes to keep it up-to-date. 
+    """Gets the most recent threat list diffs.
+
+    These diffs should be applied to a local database of hashes to keep it up-to-date.
     If the local database is empty or excessively out-of-date,
     a complete snapshot of the database will be returned. This Method only updates a
     single ThreatList at a time. To update multiple ThreatList databases, this method needs to be

--- a/webrisk/snippets/search_hashes.py
+++ b/webrisk/snippets/search_hashes.py
@@ -16,7 +16,7 @@
 from google.cloud import webrisk_v1
 
 
-def search_hashes(hash_prefix: bytes, threat_type: webrisk_v1.ThreatType) -> None:
+def search_hashes(hash_prefix: bytes, threat_type: webrisk_v1.ThreatType) -> list:
     """Gets the full hashes that match the requested hash prefix.
 
     This is used after a hash prefix is looked up in a threatList and there is a match.
@@ -37,6 +37,9 @@ def search_hashes(hash_prefix: bytes, threat_type: webrisk_v1.ThreatType) -> Non
             For the list on threat types, see:
             https://cloud.google.com/web-risk/docs/reference/rpc/google.cloud.webrisk.v1#threattype
             threat_type = [webrisk_v1.ThreatType.MALWARE, webrisk_v1.ThreatType.SOCIAL_ENGINEERING]
+
+    Returns:
+        A hash list that contain all hashes that matches the given hash prefix.
     """
     webrisk_client = webrisk_v1.WebRiskServiceClient()
 
@@ -51,9 +54,10 @@ def search_hashes(hash_prefix: bytes, threat_type: webrisk_v1.ThreatType) -> Non
     # specified in threat_hash.expire_time
     # For more information on response type, see:
     # https://cloud.google.com/web-risk/docs/reference/rpc/google.cloud.webrisk.v1#threathash
+    hash_list = []
     for threat_hash in response.threats:
-        print(threat_hash.hash)
+        hash_list.append(threat_hash.hash)
+    return hash_list
 
-    print("Completed searching threat hashes.")
 
 # [END webrisk_search_hash]

--- a/webrisk/snippets/search_uri.py
+++ b/webrisk/snippets/search_uri.py
@@ -14,9 +14,12 @@
 
 # [START webrisk_search_uri]
 from google.cloud import webrisk_v1
+from google.cloud.webrisk_v1 import SearchUrisResponse
 
 
-def search_uri(uri: str, threat_type: webrisk_v1.ThreatType.MALWARE) -> None:
+def search_uri(
+    uri: str, threat_type: webrisk_v1.ThreatType.MALWARE
+) -> SearchUrisResponse:
     """Checks whether a URI is on a given threatList.
 
     Multiple threatLists may be searched in a single query. The response will list all
@@ -26,9 +29,11 @@ def search_uri(uri: str, threat_type: webrisk_v1.ThreatType.MALWARE) -> None:
     Args:
         uri: The URI to be checked for matches
             Example: "http://testsafebrowsing.appspot.com/s/malware.html"
-
         threat_type: The ThreatLists to search in. Multiple ThreatLists may be specified.
             Example: threat_type = webrisk_v1.ThreatType.MALWARE
+
+    Returns:
+        SearchUrisResponse that contains a threat_type if the URI is present in the threatList.
     """
     webrisk_client = webrisk_v1.WebRiskServiceClient()
 
@@ -39,7 +44,9 @@ def search_uri(uri: str, threat_type: webrisk_v1.ThreatType.MALWARE) -> None:
     response = webrisk_client.search_uris(request)
     if response.threat.threat_types:
         print(f"The URI has the following threat: {response}")
-        return
+    else:
+        print("The URL is safe!")
+    return response
 
-    print("The URL is safe!")
+
 # [END webrisk_search_uri]

--- a/webrisk/snippets/submit_uri.py
+++ b/webrisk/snippets/submit_uri.py
@@ -14,9 +14,10 @@
 
 # [START webrisk_submit_uri]
 from google.cloud import webrisk_v1
+from google.cloud.webrisk_v1 import Submission
 
 
-def submit_uri(project_id: str, uri: str) -> None:
+def submit_uri(project_id: str, uri: str) -> Submission:
     """Submits a URI suspected of containing malicious content to be reviewed.
 
     Returns a google.longrunning.Operation which, once the review is complete, is updated with its result.
@@ -28,6 +29,9 @@ def submit_uri(project_id: str, uri: str) -> None:
          project_id: The name of the project that is making the submission.
          uri: The URI that is being reported for malicious content to be analyzed.
              uri = "http://testsafebrowsing.appspot.com/s/malware.html"
+
+    Returns:
+        Submission response that contains the URI submitted.
     """
     webrisk_client = webrisk_v1.WebRiskServiceClient()
 
@@ -39,6 +43,7 @@ def submit_uri(project_id: str, uri: str) -> None:
     request.submission = submission
 
     response = webrisk_client.create_submission(request)
-    print(f"Submission response: {response}")
+    return response
+
 
 # [END webrisk_submit_uri]

--- a/webrisk/snippets/test_basic_samples.py
+++ b/webrisk/snippets/test_basic_samples.py
@@ -27,7 +27,7 @@ from .submit_uri import submit_uri
 PROJECT = google.auth.default()[1]
 
 
-def test_search_uri_with_threat(capsys: CaptureFixture) -> None:
+def test_search_uri_with_threat() -> None:
     response = search_uri(
         "http://testsafebrowsing.appspot.com/s/malware.html",
         webrisk_v1.ThreatType.MALWARE,
@@ -35,7 +35,7 @@ def test_search_uri_with_threat(capsys: CaptureFixture) -> None:
     assert response.threat.threat_types
 
 
-def test_search_uri_without_threat(capsys: CaptureFixture) -> None:
+def test_search_uri_without_threat() -> None:
     response = search_uri(
         "http://testsafebrowsing.appspot.com/malware.html",
         webrisk_v1.ThreatType.MALWARE,
@@ -43,13 +43,13 @@ def test_search_uri_without_threat(capsys: CaptureFixture) -> None:
     assert not response.threat.threat_types
 
 
-def test_submit_uri(capsys: CaptureFixture) -> None:
+def test_submit_uri() -> None:
     malware_uri = "http://testsafebrowsing.appspot.com/s/malware.html"
     response = submit_uri(PROJECT, malware_uri)
     assert response.uri == malware_uri
 
 
-def test_search_hashes(capsys: CaptureFixture) -> None:
+def test_search_hashes() -> None:
     uri = "http://example.com"
     sha256 = hashlib.sha256()
     sha256.update(base64.urlsafe_b64encode(bytes(uri, "utf-8")))
@@ -59,7 +59,7 @@ def test_search_hashes(capsys: CaptureFixture) -> None:
     search_hashes(hex_string, webrisk_v1.ThreatType.MALWARE)
 
 
-def test_compute_threatdiff_list(capsys: CaptureFixture) -> None:
+def test_compute_threatdiff_list() -> None:
     response = compute_threatlist_diff(
         webrisk_v1.ThreatType.MALWARE, b"", 1024, 1024, webrisk_v1.CompressionType.RAW
     )

--- a/webrisk/snippets/test_basic_samples.py
+++ b/webrisk/snippets/test_basic_samples.py
@@ -13,9 +13,7 @@
 #  limitations under the License.
 import base64
 import hashlib
-import re
 
-from _pytest.capture import CaptureFixture
 import google
 from google.cloud import webrisk_v1
 

--- a/webrisk/snippets/test_basic_samples.py
+++ b/webrisk/snippets/test_basic_samples.py
@@ -28,18 +28,25 @@ PROJECT = google.auth.default()[1]
 
 
 def test_search_uri_with_threat(capsys: CaptureFixture) -> None:
-    search_uri("http://testsafebrowsing.appspot.com/s/malware.html", webrisk_v1.ThreatType.MALWARE)
-    assert re.search("The URI has the following threat: ", capsys.readouterr().out)
+    response = search_uri(
+        "http://testsafebrowsing.appspot.com/s/malware.html",
+        webrisk_v1.ThreatType.MALWARE,
+    )
+    assert response.threat.threat_types
 
 
 def test_search_uri_without_threat(capsys: CaptureFixture) -> None:
-    search_uri("http://testsafebrowsing.appspot.com/malware.html", webrisk_v1.ThreatType.MALWARE)
-    assert re.search("The URL is safe!", capsys.readouterr().out)
+    response = search_uri(
+        "http://testsafebrowsing.appspot.com/malware.html",
+        webrisk_v1.ThreatType.MALWARE,
+    )
+    assert not response.threat.threat_types
 
 
 def test_submit_uri(capsys: CaptureFixture) -> None:
-    submit_uri(PROJECT, "http://testsafebrowsing.appspot.com/s/malware.html")
-    assert re.search("Submission response: ", capsys.readouterr().out)
+    malware_uri = "http://testsafebrowsing.appspot.com/s/malware.html"
+    response = submit_uri(PROJECT, malware_uri)
+    assert response.uri == malware_uri
 
 
 def test_search_hashes(capsys: CaptureFixture) -> None:
@@ -48,10 +55,12 @@ def test_search_hashes(capsys: CaptureFixture) -> None:
     sha256.update(base64.urlsafe_b64encode(bytes(uri, "utf-8")))
     hex_string = sha256.digest()
 
+    # The hash list may or may not be empty. Hence, no assertion is required as long as the code runs to completion.
     search_hashes(hex_string, webrisk_v1.ThreatType.MALWARE)
-    assert re.search("Completed searching threat hashes.", capsys.readouterr().out)
 
 
 def test_compute_threatdiff_list(capsys: CaptureFixture) -> None:
-    compute_threatlist_diff(webrisk_v1.ThreatType.MALWARE, b'', 1024, 1024, webrisk_v1.CompressionType.RAW)
-    assert re.search("Obtained threat list diff.", capsys.readouterr().out)
+    response = compute_threatlist_diff(
+        webrisk_v1.ThreatType.MALWARE, b"", 1024, 1024, webrisk_v1.CompressionType.RAW
+    )
+    assert response.response_type


### PR DESCRIPTION
## Description

b/280881593 : Fix typehints and return responses from samples to tests.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved