### PR TITLE
refactor: update typehints for servicedirectory samples

### DIFF
--- a/servicedirectory/noxfile_config.py
+++ b/servicedirectory/noxfile_config.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default TEST_CONFIG_OVERRIDE for python repos.
+
+# You can copy this file into your directory, then it will be imported from
+# the noxfile.py.
+
+# The source of truth:
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/noxfile_config.py
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    "ignored_versions": ["2.7", "3.6"],
+    # Old samples are opted out of enforcing Python type hints
+    # All new samples should feature them
+    "enforce_type_hints": True,
+    # An envvar key for determining the project id to use. Change it
+    # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
+    # build specific Cloud project. You can also use your own string
+    # to use your own Cloud project.
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    # If you need to use a specific version of pip,
+    # change pip_version_override to the string representation
+    # of the version number, for example, "20.2.4"
+    "pip_version_override": None,
+    # A dictionary you want to inject into your test. Don't put any
+    # secrets here. These values will override predefined values.
+    "envs": {},
+}

--- a/servicedirectory/quickstart.py
+++ b/servicedirectory/quickstart.py
@@ -16,19 +16,33 @@
 
 # [START servicedirectory_quickstart]
 from google.cloud import servicedirectory_v1
+from google.cloud.servicedirectory_v1.services.registration_service.pagers import (
+    ListNamespacesPager,
+)
 
 
-def list_namespaces(project_id, location_id):
-    """Lists all namespaces in the given location."""
+def list_namespaces(project_id: str, location: str) -> ListNamespacesPager:
+    """Lists all namespaces in the given location.
+
+    Args:
+        project_id: The Google Cloud project id.
+        location: The location which contains the namespaces to list.
+
+    Returns:
+        All namespaces in the given location.
+    """
 
     client = servicedirectory_v1.RegistrationServiceClient()
 
     response = client.list_namespaces(
-        parent=f'projects/{project_id}/locations/{location_id}')
+        parent=f"projects/{project_id}/locations/{location}"
+    )
 
-    print(f'Listed namespaces in {location_id}.')
+    print(f"Listed namespaces in {location}.")
     for namespace in response:
-        print(f'Namespace: {namespace.name}')
+        print(f"Namespace: {namespace.name}")
 
     return response
+
+
 # [END servicedirectory_quickstart]

--- a/servicedirectory/quickstart_test.py
+++ b/servicedirectory/quickstart_test.py
@@ -18,31 +18,33 @@ from os import environ
 import uuid
 
 import backoff
-from google.api_core.exceptions import (InternalServerError, ServiceUnavailable)
+from google.api_core.exceptions import InternalServerError, ServiceUnavailable
 from google.cloud import servicedirectory_v1
 
+from google.cloud.servicedirectory_v1 import Namespace, RegistrationServiceClient
 import pytest
 
 import quickstart
 
-PROJECT_ID = environ['GOOGLE_CLOUD_PROJECT']
-LOCATION_ID = 'us-east1'
-NAMESPACE_ID = f'test-namespace-{uuid.uuid4().hex}'
+PROJECT_ID = environ["GOOGLE_CLOUD_PROJECT"]
+LOCATION = "us-east1"
+NAMESPACE_ID = f"test-namespace-{uuid.uuid4().hex}"
 
 
-@pytest.fixture(scope='module')
-def client():
+@pytest.fixture(scope="module")
+def client() -> RegistrationServiceClient:
     return servicedirectory_v1.RegistrationServiceClient()
 
 
-@pytest.fixture(scope='module')
-def namespace(client):
+@pytest.fixture(scope="module")
+def namespace(client: RegistrationServiceClient) -> Namespace:
     namespace = servicedirectory_v1.Namespace(
-        name=client.namespace_path(PROJECT_ID, LOCATION_ID, NAMESPACE_ID))
+        name=client.namespace_path(PROJECT_ID, LOCATION, NAMESPACE_ID)
+    )
 
     try:
         client.create_namespace(
-            parent=f'projects/{PROJECT_ID}/locations/{LOCATION_ID}',
+            parent=f"projects/{PROJECT_ID}/locations/{LOCATION}",
             namespace=namespace,
             namespace_id=NAMESPACE_ID,
         )
@@ -52,7 +54,11 @@ def namespace(client):
         client.delete_namespace(name=namespace.name)
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_list_namespace(namespace):
-    google_cloud_namespaces = quickstart.list_namespaces(PROJECT_ID, LOCATION_ID).namespaces
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_list_namespace(namespace: Namespace) -> None:
+    google_cloud_namespaces = quickstart.list_namespaces(
+        PROJECT_ID, LOCATION
+    ).namespaces
     assert namespace.name in [_namespace.name for _namespace in google_cloud_namespaces]

--- a/servicedirectory/snippets.py
+++ b/servicedirectory/snippets.py
@@ -15,137 +15,245 @@
 # limitations under the License.
 
 from google.cloud import servicedirectory_v1
+from google.cloud.servicedirectory_v1 import (
+    Endpoint,
+    Namespace,
+    ResolveServiceResponse,
+    Service,
+)
 
 
 # [START servicedirectory_create_namespace]
-def create_namespace(project_id, location_id, namespace_id):
-    """Creates a namespace in the given location."""
+def create_namespace(project_id: str, location: str, namespace_id: str) -> Namespace:
+    """Creates a namespace in the given location.
+
+    Args:
+        project_id: Your Google Cloud project id.
+        location: The Google Cloud region containing the new namespace.
+        namespace_id: A unique id for the namespace.
+
+    Returns:
+        The created namespace.
+    """
 
     client = servicedirectory_v1.RegistrationServiceClient()
 
     namespace = servicedirectory_v1.Namespace(
-        name=client.namespace_path(project_id, location_id, namespace_id))
+        name=client.namespace_path(project_id, location, namespace_id)
+    )
 
     response = client.create_namespace(
-        parent=f'projects/{project_id}/locations/{location_id}',
+        parent=f"projects/{project_id}/locations/{location}",
         namespace=namespace,
         namespace_id=namespace_id,
     )
 
-    print(f'Created namespace {response.name}.')
+    print(f"Created namespace {response.name}.")
 
     return response
+
+
 # [END servicedirectory_create_namespace]
 
 
 # [START servicedirectory_delete_namespace]
-def delete_namespace(project_id, location_id, namespace_id):
-    """Deletes a namespace in the given location."""
+def delete_namespace(project_id: str, location: str, namespace_id: str) -> None:
+    """Deletes a namespace in the given location.
+
+    Args:
+        project_id: Your Google Cloud project id.
+        location: The Google Cloud region containing the namespace to delete.
+        namespace_id: The id for the namespace to delete.
+    """
 
     client = servicedirectory_v1.RegistrationServiceClient()
 
-    namespace_name = client.namespace_path(project_id, location_id, namespace_id)
+    namespace_name = client.namespace_path(project_id, location, namespace_id)
 
     client.delete_namespace(name=namespace_name)
 
-    print(f'Deleted namespace {namespace_name}.')
+    print(f"Deleted namespace {namespace_name}.")
+
+
 # [END servicedirectory_delete_namespace]
 
 
 # [START servicedirectory_create_service]
-def create_service(project_id, location_id, namespace_id, service_id):
-    """Creates a service in the given namespace."""
+def create_service(
+    project_id: str, location: str, namespace_id: str, service_id: str
+) -> Service:
+    """Creates a service in the given namespace.
+
+    Args:
+        project_id: Your Google Cloud project id.
+        location: The Google Cloud region containing the namespace.
+        namespace_id: The id of the parent namespace.
+        service_id: The id of the service you are creating. Service names must be unique within a namespace and follow
+            conventions for DNS labels.
+
+    Returns:
+        The created service.
+    """
 
     client = servicedirectory_v1.RegistrationServiceClient()
 
     service = servicedirectory_v1.Service(
-        name=client.service_path(project_id, location_id, namespace_id,
-                                 service_id))
+        name=client.service_path(project_id, location, namespace_id, service_id)
+    )
 
     response = client.create_service(
-        parent=client.namespace_path(project_id, location_id, namespace_id),
+        parent=client.namespace_path(project_id, location, namespace_id),
         service=service,
         service_id=service_id,
     )
 
-    print(f'Created service {response.name}.')
+    print(f"Created service {response.name}.")
 
     return response
+
+
 # [END servicedirectory_create_service]
 
 
 # [START servicedirectory_delete_service]
-def delete_service(project_id, location_id, namespace_id, service_id):
-    """Deletes a service in the given namespace."""
+def delete_service(
+    project_id: str, location: str, namespace_id: str, service_id: str
+) -> None:
+    """Deletes a service in the given namespace.
+
+    Args:
+        project_id: Your Google Cloud project id.
+        location: The Google Cloud region containing the namespace.
+        namespace_id: The id of the parent namespace.
+        service_id: The id of the service to delete.
+    """
 
     client = servicedirectory_v1.RegistrationServiceClient()
 
-    service_name = client.service_path(project_id, location_id, namespace_id,
-                                       service_id)
+    service_name = client.service_path(project_id, location, namespace_id, service_id)
 
     client.delete_service(name=service_name)
 
-    print(f'Deleted service {service_name}.')
+    print(f"Deleted service {service_name}.")
+
+
 # [END servicedirectory_delete_service]
 
 
 # [START servicedirectory_resolve_service]
-def resolve_service(project_id, location_id, namespace_id, service_id):
-    """Resolves a service in the given namespace."""
+def resolve_service(
+    project_id: str, location: str, namespace_id: str, service_id: str
+) -> ResolveServiceResponse:
+    """Resolves a service in the given namespace.
+
+    Args:
+        project_id: Your Google Cloud project id.
+        location: The Google Cloud region containing the namespace.
+        namespace_id: The id of the parent namespace.
+        service_id: The id of the service to resolve.
+
+    Returns:
+        The resolved service response, which returns all properties of the service, all endpoints, and all annotations.
+    """
 
     client = servicedirectory_v1.LookupServiceClient()
 
     request = servicedirectory_v1.ResolveServiceRequest(
         name=servicedirectory_v1.RegistrationServiceClient().service_path(
-            project_id, location_id, namespace_id, service_id))
+            project_id, location, namespace_id, service_id
+        )
+    )
 
     response = client.resolve_service(request=request)
 
-    print('Endpoints found:')
+    print("Endpoints found:")
     for endpoint in response.service.endpoints:
-        print(f'{endpoint.name} -- {endpoint.address}:{endpoint.port}')
+        print(f"{endpoint.name} -- {endpoint.address}:{endpoint.port}")
 
     return response
+
+
 # [END servicedirectory_resolve_service]
 
 
 # [START servicedirectory_create_endpoint]
-def create_endpoint(project_id, location_id, namespace_id, service_id,
-                    endpoint_id, address, port):
-    """Creates a endpoint in the given service."""
+def create_endpoint(
+    project_id: str,
+    location: str,
+    namespace_id: str,
+    service_id: str,
+    endpoint_id: str,
+    address: str,
+    port: str,
+) -> Endpoint:
+    """Creates a endpoint in the given service.
+
+    An endpoint consists of a unique name, an optional IP address and a port, and key-value annotations.
+
+    Args:
+        project_id: Your Google Cloud project id.
+        location: The Google Cloud region containing the namespace.
+        namespace_id: The id of the parent namespace.
+        service_id: The id of the parent service.
+        endpoint_id: A name for the endpoint you are creating.
+        address: IP address for the endpoint.
+        port: Port number for the endpoint.
+
+    Returns:
+        The created endpoint.
+    """
 
     client = servicedirectory_v1.RegistrationServiceClient()
 
     endpoint = servicedirectory_v1.Endpoint(
-        name=client.endpoint_path(project_id, location_id, namespace_id,
-                                  service_id, endpoint_id),
+        name=client.endpoint_path(
+            project_id, location, namespace_id, service_id, endpoint_id
+        ),
         address=address,
-        port=port)
+        port=port,
+    )
 
     response = client.create_endpoint(
-        parent=client.service_path(project_id, location_id, namespace_id,
-                                   service_id),
+        parent=client.service_path(project_id, location, namespace_id, service_id),
         endpoint=endpoint,
         endpoint_id=endpoint_id,
     )
 
-    print(f'Created endpoint {response.name}.')
+    print(f"Created endpoint {response.name}.")
 
     return response
+
+
 # [END servicedirectory_create_endpoint]
 
 
 # [START servicedirectory_delete_endpoint]
-def delete_endpoint(project_id, location_id, namespace_id, service_id,
-                    endpoint_id):
-    """Deletes a endpoin in the given service."""
+def delete_endpoint(
+    project_id: str,
+    location: str,
+    namespace_id: str,
+    service_id: str,
+    endpoint_id: str,
+) -> None:
+    """Deletes a endpoint in the given service.
+
+    Args:
+        project_id: Your Google Cloud project id.
+        location: The Google Cloud region containing the namespace.
+        namespace_id: The id of the parent namespace.
+        service_id: The id of the parent service.
+        endpoint_id: The id of the endpoint to delete.
+    """
 
     client = servicedirectory_v1.RegistrationServiceClient()
 
-    endpoint_name = client.endpoint_path(project_id, location_id, namespace_id,
-                                         service_id, endpoint_id)
+    endpoint_name = client.endpoint_path(
+        project_id, location, namespace_id, service_id, endpoint_id
+    )
 
     client.delete_endpoint(name=endpoint_name)
 
-    print(f'Deleted endpoint {endpoint_name}.')
+    print(f"Deleted endpoint {endpoint_name}.")
+
+
 # [END servicedirectory_delete_endpoint]

--- a/servicedirectory/snippets_test.py
+++ b/servicedirectory/snippets_test.py
@@ -17,24 +17,24 @@
 from os import environ
 import uuid
 
+from _pytest.capture import CaptureFixture
 import backoff
-from google.api_core.exceptions import (InternalServerError, NotFound,
-                                        ServiceUnavailable)
+from google.api_core.exceptions import InternalServerError, NotFound, ServiceUnavailable
 from google.cloud import servicedirectory_v1
 
 import quickstart
 import snippets
 
-PROJECT_ID = environ['GOOGLE_CLOUD_PROJECT']
-LOCATION_ID = 'us-east1'
-NAMESPACE_ID = f'test-namespace-{uuid.uuid4().hex}'
-SERVICE_ID = f'test-service-{uuid.uuid4().hex}'
-ENDPOINT_ID = f'test-endpoint-{uuid.uuid4().hex}'
-ADDRESS = '1.2.3.4'
+PROJECT_ID = environ["GOOGLE_CLOUD_PROJECT"]
+LOCATION_ID = "us-east1"
+NAMESPACE_ID = f"test-namespace-{uuid.uuid4().hex}"
+SERVICE_ID = f"test-service-{uuid.uuid4().hex}"
+ENDPOINT_ID = f"test-endpoint-{uuid.uuid4().hex}"
+ADDRESS = "1.2.3.4"
 PORT = 443
 
 
-def teardown_module():
+def teardown_module() -> None:
     client = servicedirectory_v1.RegistrationServiceClient()
     namespace_name = client.namespace_path(PROJECT_ID, LOCATION_ID, NAMESPACE_ID)
     all_namespaces = quickstart.list_namespaces(PROJECT_ID, LOCATION_ID).namespaces
@@ -49,57 +49,75 @@ def teardown_module():
             break
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_create_namespace():
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_create_namespace() -> None:
     response = snippets.create_namespace(PROJECT_ID, LOCATION_ID, NAMESPACE_ID)
 
     assert NAMESPACE_ID in response.name
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_create_service():
-    response = snippets.create_service(PROJECT_ID, LOCATION_ID, NAMESPACE_ID,
-                                       SERVICE_ID)
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_create_service() -> None:
+    response = snippets.create_service(
+        PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID
+    )
 
     assert SERVICE_ID in response.name
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_create_endpoint():
-    response = snippets.create_endpoint(PROJECT_ID, LOCATION_ID, NAMESPACE_ID,
-                                        SERVICE_ID, ENDPOINT_ID, ADDRESS, PORT)
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_create_endpoint() -> None:
+    response = snippets.create_endpoint(
+        PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, ENDPOINT_ID, ADDRESS, PORT
+    )
 
     assert ENDPOINT_ID in response.name
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_resolve_service():
-    response = snippets.resolve_service(PROJECT_ID, LOCATION_ID, NAMESPACE_ID,
-                                        SERVICE_ID)
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_resolve_service() -> None:
+    response = snippets.resolve_service(
+        PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID
+    )
 
     assert len(response.service.endpoints) == 1
     assert ENDPOINT_ID in response.service.endpoints[0].name
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_delete_endpoint(capsys):
-    snippets.delete_endpoint(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID,
-                             ENDPOINT_ID)
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_delete_endpoint(capsys: CaptureFixture) -> None:
+    snippets.delete_endpoint(
+        PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID, ENDPOINT_ID
+    )
 
     out, _ = capsys.readouterr()
     assert ENDPOINT_ID in out
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_delete_service(capsys):
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_delete_service(capsys: CaptureFixture) -> None:
     snippets.delete_service(PROJECT_ID, LOCATION_ID, NAMESPACE_ID, SERVICE_ID)
 
     out, _ = capsys.readouterr()
     assert SERVICE_ID in out
 
 
-@backoff.on_exception(backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5)
-def test_delete_namespace(capsys):
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable), max_tries=5
+)
+def test_delete_namespace(capsys: CaptureFixture) -> None:
     snippets.delete_namespace(PROJECT_ID, LOCATION_ID, NAMESPACE_ID)
 
     out, _ = capsys.readouterr()


### PR DESCRIPTION
## Description

b/280879439 : Update typehints for service directory samples.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved