### PR TITLE
refactor: update healthcare v1 samples

### DIFF
--- a/healthcare/api-client/v1/fhir/README.rst
+++ b/healthcare/api-client/v1/fhir/README.rst
@@ -214,25 +214,70 @@ To run this sample:
     positional arguments:
       {create-resource-from-file,create-patient,create-encounter,create-observation,delete-resource,get-resource,list-resource-history,execute-bundle,get-resource-history,delete-resource-purge,update-resource,patch-resource,search-resources-get,search-resources-post,get-patient-everything,create-structure-definition,create-implementation-guide,enable-implementation-guide,validate-resource,validate-resource-profile-url}
         create-resource-from-file
-                            Creates a new FHIR resource in a FHIR store using a
+                            Creates a new FHIR resource in a FHIR store from a
                             JSON resource file. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#create for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. resource_type: A valid FHIR resource type.
+                            See https://www.hl7.org/fhir/resourcelist.html.
+                            resource_file: The path to a JSON file containing a
+                            FHIR resource. Returns: A dict representing the
+                            created FHIR resource.
         create-patient      Creates a new Patient resource in a FHIR store. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
-        create-encounter    Creates a new Encounter resource in a FHIR store based
-                            on a Patient. See
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#create for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store that holds the Patient resource. Returns: A
+                            dict representing the created Patient resource.
+        create-encounter    Creates a new Encounter resource in a FHIR store that
+                            references a Patient resource. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#create for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. patient_id: The "logical id" of the
+                            referenced Patient resource. The ID is assigned by the
+                            server. Returns: A dict representing the created
+                            Encounter resource.
         create-observation  Creates a new Observation resource in a FHIR store
-                            based on an Encounter. See
+                            that references an Encounter and Patient resource. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#create for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. patient_id: The "logical id" of the
+                            referenced Patient resource. The ID is assigned by the
+                            server. encounter_id: The "logical id" of the
+                            referenced Encounter resource. The ID is assigned by
+                            the server. Returns: A dict representing the created
+                            Observation resource.
         delete-resource     Deletes a FHIR resource. Regardless of whether the
                             operation succeeds or fails, the server returns a 200
                             OK HTTP status code. To check that the resource was
@@ -240,39 +285,128 @@ To run this sample:
                             and see if it exists. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
-        get-resource        Gets a FHIR resource. See
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#delete for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. resource_type: The type of the FHIR
+                            resource. resource_id: The "logical id" of the FHIR
+                            resource you want to delete. The ID is assigned by the
+                            server. Returns: An empty dict.
+        get-resource        Gets the contents of a FHIR resource. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#read for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. resource_type: The type of FHIR resource.
+                            resource_id: The "logical id" of the resource you want
+                            to get the contents of. The ID is assigned by the
+                            server. Returns: A dict representing the FHIR
+                            resource.
         list-resource-history
                             Gets the history of a resource. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#history for the Python API
+                            reference. Args: project_id: The project ID or project
+                            number of the Cloud project you want to use. location:
+                            The name of the parent dataset's location. dataset_id:
+                            The name of the parent dataset. fhir_store_id: The
+                            name of the FHIR store. resource_type: The type of
+                            FHIR resource. resource_id: The "logical id" of the
+                            resource whose history you want to list. The ID is
+                            assigned by the server. Returns: A dict representing
+                            the FHIR resource.
         execute-bundle      Executes the operations in the given bundle. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
                             running the sample.
         get-resource-history
-                            Gets a version resource. See
+                            Gets the contents of a version (current or historical)
+                            of a FHIR resource by version ID. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#vread for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. resource_type: The type of FHIR resource.
+                            resource_id: The "logical id" of the resource whose
+                            details you want to view at a particular version. The
+                            ID is assigned by the server. version_id: The ID of
+                            the version. Changes whenever the FHIR resource is
+                            modified. Returns: A dict representing the FHIR
+                            resource at the specified version.
         delete-resource-purge
-                            Deletes versions of a resource (excluding current
-                            version). See
+                            Deletes all versions of a FHIR resource (excluding the
+                            current version). See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
-        update-resource     Updates an existing resource. See
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#Resource_purge for the Python API
+                            reference. Args: project_id: The project ID or project
+                            number of the Cloud project you want to use. location:
+                            The name of the parent dataset's location. dataset_id:
+                            The name of the parent dataset. fhir_store_id: The
+                            name of the FHIR store. resource_type: The type of the
+                            FHIR resource. resource_id: The "logical id" of the
+                            resource. The ID is assigned by the server. Returns:
+                            An empty dict.
+        update-resource     Updates the entire contents of a FHIR resource.
+                            Creates a new current version if the resource already
+                            exists, or creates a new resource with an initial
+                            version if no resource already exists with the
+                            provided ID. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
-        patch-resource      Updates part of an existing resource. See
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#update for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. resource_type: The type of the FHIR
+                            resource. resource_id: The "logical id" of the
+                            resource. The ID is assigned by the server. Returns: A
+                            dict representing the updated FHIR resource.
+        patch-resource      Updates part of an existing FHIR resource by applying
+                            the operations specified in a [JSON
+                            Patch](http://jsonpatch.com/) document. See
                             https://github.com/GoogleCloudPlatform/python-docs-
                             samples/tree/main/healthcare/api-client/v1/fhir before
-                            running the sample.
+                            running the sample. See
+                            https://googleapis.github.io/google-api-python-client/
+                            docs/dyn/healthcare_v1.projects.locations.datasets.fhi
+                            rStores.fhir.html#patch for the Python API reference.
+                            Args: project_id: The project ID or project number of
+                            the Cloud project you want to use. location: The name
+                            of the parent dataset's location. dataset_id: The name
+                            of the parent dataset. fhir_store_id: The name of the
+                            FHIR store. resource_type: The type of the FHIR
+                            resource. resource_id: The "logical id" of the
+                            resource. The ID is assigned by the server. Returns: A
+                            dict representing the patched FHIR resource.
         search-resources-get
                             Uses the searchResources GET method to search for
                             resources in the given FHIR store. See

--- a/healthcare/api-client/v1/fhir/fhir_resources.py
+++ b/healthcare/api-client/v1/fhir/fhir_resources.py
@@ -16,61 +16,79 @@ import argparse
 import json
 import os
 
+# [START healthcare_create_resource_from_file]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
 
+
+# [END healthcare_create_resource_from_file]
 # [START healthcare_create_resource_from_file]
 def create_resource_from_file(
-    project_id, location, dataset_id, fhir_store_id, resource_type, resource_file
-):
-    """Creates a new FHIR resource in a FHIR store using a JSON resource file.
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_file: str,
+) -> Dict[str, Any]:
+    """Creates a new FHIR resource in a FHIR store from a JSON resource file.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#create
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: A valid FHIR resource type. See
+        https://www.hl7.org/fhir/resourcelist.html.
+      resource_file: The path to a JSON file containing a FHIR resource.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      A dict representing the created FHIR resource.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_file = 'Patient.json'  # replace with the FHIR resource file
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    fhir_store_path = "{}/datasets/{}/fhirStores/{}/fhir/{}".format(
-        url, dataset_id, fhir_store_id, resource_type
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
+    fhir_store_name = f"{fhir_store_parent}/fhirStores/{fhir_store_id}"
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
+    # Load the local FHIR resource JSON file.
     with open(resource_file) as resource:
-        resource_content = json.load(resource)
+        resource_body = json.load(resource)
 
-    response = session.post(fhir_store_path, headers=headers, json=resource_content)
-    response.raise_for_status()
-
-    response_resource = response.json()
-
-    print("Created FHIR resource with ID {}".format(response_resource["id"]))
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .create(parent=fhir_store_name, type=resource_type, body=resource_body)
+    )
+    # Sets required application/fhir+json header on the googleapiclient.http.HttpRequest.
+    request.headers["content-type"] = "application/fhir+json;charset=utf-8"
+    response = request.execute()
+    print(f"Created {resource_type} resource with ID {response['id']}")
 
     return response
 
@@ -79,61 +97,77 @@ def create_resource_from_file(
 
 
 # [START healthcare_create_resource]
-def create_patient(project_id, location, dataset_id, fhir_store_id):
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+
+# [END healthcare_create_resource]
+# [START healthcare_create_resource]
+def create_patient(
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+) -> Dict[str, Any]:
     """Creates a new Patient resource in a FHIR store.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#create
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store that holds the Patient resource.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      A dict representing the created Patient resource.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    fhir_store_path = "{}/datasets/{}/fhirStores/{}/fhir/Patient".format(
-        url, dataset_id, fhir_store_id
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
+    fhir_store_name = f"{fhir_store_parent}/fhirStores/{fhir_store_id}"
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
-    body = {
+    patient_body = {
         "name": [{"use": "official", "family": "Smith", "given": ["Darcy"]}],
         "gender": "female",
         "birthDate": "1970-01-01",
         "resourceType": "Patient",
     }
 
-    response = session.post(fhir_store_path, headers=headers, json=body)
-    response.raise_for_status()
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .create(parent=fhir_store_name, type="Patient", body=patient_body)
+    )
+    # Sets required application/fhir+json header on the googleapiclient.http.HttpRequest.
+    request.headers["content-type"] = "application/fhir+json;charset=utf-8"
+    response = request.execute()
 
-    resource = response.json()
-
-    print("Created Patient resource with ID {}".format(resource["id"]))
-
+    print(f"Created Patient resource with ID {response['id']}")
     return response
 
 
@@ -141,55 +175,63 @@ def create_patient(project_id, location, dataset_id, fhir_store_id):
 
 
 # [START healthcare_create_encounter]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+# [END healthcare_create_encounter]
+
+
+# [START healthcare_create_encounter]
 def create_encounter(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    patient_id,
-):
-    """Creates a new Encounter resource in a FHIR store based on a Patient.
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    patient_id: str,
+) -> Dict[str, Any]:
+    """Creates a new Encounter resource in a FHIR store that references a Patient resource.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#create
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      patient_id: The "logical id" of the referenced Patient resource. The ID is
+        assigned by the server.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      A dict representing the created Encounter resource.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store'  # replace with the FHIR store ID
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
     # patient_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the associated Patient resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    fhir_store_path = "{}/datasets/{}/fhirStores/{}/fhir/Encounter".format(
-        url, dataset_id, fhir_store_id
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
+    fhir_store_name = f"{fhir_store_parent}/fhirStores/{fhir_store_id}"
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
-    body = {
+    encounter_body = {
         "status": "finished",
         "class": {
             "system": "http://hl7.org/fhir/v3/ActCode",
@@ -198,20 +240,28 @@ def create_encounter(
         },
         "reason": [
             {
-                "text": "The patient had an abnormal heart rate. She was"
-                " concerned about this."
+                "text": (
+                    "The patient had an abnormal heart rate. She was"
+                    " concerned about this."
+                )
             }
         ],
         "subject": {"reference": f"Patient/{patient_id}"},
         "resourceType": "Encounter",
     }
 
-    response = session.post(fhir_store_path, headers=headers, json=body)
-    response.raise_for_status()
-
-    resource = response.json()
-
-    print("Created Encounter resource with ID {}".format(resource["id"]))
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .create(parent=fhir_store_name, type="Encounter", body=encounter_body)
+    )
+    # Sets required application/fhir+json header on the googleapiclient.http.HttpRequest.
+    request.headers["content-type"] = "application/fhir+json;charset=utf-8"
+    response = request.execute()
+    print(f"Created Encounter resource with ID {response['id']}")
 
     return response
 
@@ -220,59 +270,69 @@ def create_encounter(
 
 
 # [START healthcare_create_observation]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+# [END healthcare_create_observation]
+
+
+# [START healthcare_create_observation]
 def create_observation(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    patient_id,
-    encounter_id,
-):
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    patient_id: str,
+    encounter_id: str,
+) -> Dict[str, Any]:
+    """Creates a new Observation resource in a FHIR store that references an Encounter and Patient resource.
+
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#create
+    for the Python API reference.
+
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      patient_id: The "logical id" of the referenced Patient resource. The ID is
+        assigned by the server.
+      encounter_id: The "logical id" of the referenced Encounter resource. The ID
+        is assigned by the server.
+
+    Returns:
+      A dict representing the created Observation resource.
     """
-    Creates a new Observation resource in a FHIR store based on
-    an Encounter.
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
-
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
-
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
-
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
     # patient_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the associated Patient resource's ID
     # encounter_id = 'a7602f-ffba-470a-a5c1-103f993c6  # replace with the associated Encounter resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    fhir_store_path = "{}/datasets/{}/fhirStores/{}/fhir/Observation".format(
-        url, dataset_id, fhir_store_id
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
+    )
+    fhir_observation_path = (
+        f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/Observation"
     )
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
-    body = {
+    observation_body = {
         "resourceType": "Observation",
         "code": {
             "coding": [
@@ -290,12 +350,22 @@ def create_observation(
         "context": {"reference": f"Encounter/{encounter_id}"},
     }
 
-    response = session.post(fhir_store_path, headers=headers, json=body)
-    response.raise_for_status()
-
-    resource = response.json()
-
-    print("Created Observation resource with ID {}".format(resource["id"]))
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .create(
+            parent=fhir_observation_path,
+            type="Observation",
+            body=observation_body,
+        )
+    )
+    # Sets required application/fhir+json header on the googleapiclient.http.HttpRequest.
+    request.headers["content-type"] = "application/fhir+json;charset=utf-8"
+    response = request.execute()
+    print(f"Created Observation resource with ID {response['id']}")
 
     return response
 
@@ -305,59 +375,70 @@ def create_observation(
 
 # [START healthcare_delete_resource]
 def delete_resource(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    resource_type,
-    resource_id,
-):
-    """
-    Deletes a FHIR resource.
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_id: str,
+) -> dict:
+    """Deletes a FHIR resource.
 
     Regardless of whether the operation succeeds or
     fails, the server returns a 200 OK HTTP status code. To check that the
     resource was successfully deleted, search for or get the resource and
     see if it exists.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#delete
+    for the Python API reference.
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: The type of the FHIR resource.
+      resource_id: The "logical id" of the FHIR resource you want to delete. The
+        ID is assigned by the server.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Returns:
+      An empty dict.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
-
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
-    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the FHIR resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}/{}".format(
-        url, dataset_id, fhir_store_id, resource_type, resource_id
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
+    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
+    fhir_resource_path = f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/{resource_type}/{resource_id}"
 
-    response = session.delete(resource_path)
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .delete(name=fhir_resource_path)
+    )
+    response = request.execute()
     print(f"Deleted {resource_type} resource with ID {resource_id}.")
 
     return response
@@ -367,201 +448,240 @@ def delete_resource(
 
 
 # [START healthcare_get_resource]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+
+# [END healthcare_get_resource]
+# [START healthcare_get_resource]
 def get_resource(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    resource_type,
-    resource_id,
-):
-    """Gets a FHIR resource.
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_id: str,
+) -> Dict[str, Any]:
+    """Gets the contents of a FHIR resource.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#read
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: The type of FHIR resource.
+      resource_id: The "logical id" of the resource you want to get the contents
+        of. The ID is assigned by the server.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      A dict representing the FHIR resource.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
-    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the FHIR resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
+    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
+    )
+    fhir_resource_path = f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/{resource_type}/{resource_id}"
 
-    resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}/{}".format(
-        url, dataset_id, fhir_store_id, resource_type, resource_id
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .read(name=fhir_resource_path)
+    )
+    response = request.execute()
+    print(
+        f"Got contents of {resource_type} resource with ID {resource_id}:\n",
+        json.dumps(response, indent=2),
     )
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
-    response = session.get(resource_path, headers=headers)
-    response.raise_for_status()
-
-    resource = response.json()
-
-    print("Got {} resource:".format(resource["resourceType"]))
-    print(json.dumps(resource, indent=2))
-
-    return resource
+    return response
 
 
 # [END healthcare_get_resource]
 
 
 # [START healthcare_list_resource_history]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+
+# [END healthcare_list_resource_history]
+# [START healthcare_list_resource_history]
 def list_resource_history(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    resource_type,
-    resource_id,
-):
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_id: str,
+) -> Dict[str, Any]:
     """Gets the history of a resource.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#history
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: The type of FHIR resource.
+      resource_id: The "logical id" of the resource whose history you want to
+        list. The ID is assigned by the server.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      A dict representing the FHIR resource.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
-    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the FHIR resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}/{}".format(
-        url, dataset_id, fhir_store_id, resource_type, resource_id
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
+    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
+    fhir_resource_path = f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/{resource_type}/{resource_id}"
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
-    response = session.get(resource_path + "/_history", headers=headers)
-    response.raise_for_status()
-
-    resource = response.json()
-
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .history(name=fhir_resource_path)
+    )
+    response = request.execute()
     print(
-        "History for {} resource:".format(
-            resource["entry"][0]["resource"]["resourceType"]
-        )
+        f"History for {resource_type} resource with ID {resource_id}:\n"
+        f" {json.dumps(response, indent=2)}"
     )
-    print(json.dumps(resource, indent=2))
-
-    return resource
+    return response
 
 
 # [END healthcare_list_resource_history]
 
 
 # [START healthcare_get_resource_history]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+
+# [END healthcare_get_resource_history]
+# [START healthcare_get_resource_history]
 def get_resource_history(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    resource_type,
-    resource_id,
-    version_id,
-):
-    """Gets a version resource.
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_id: str,
+    version_id: str,
+) -> Dict[str, Any]:
+    """Gets the contents of a version (current or historical) of a FHIR resource by version ID.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#vread
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: The type of FHIR resource.
+      resource_id: The "logical id" of the resource whose details you want to view
+        at a particular version. The ID is assigned by the server.
+      version_id: The ID of the version. Changes whenever the FHIR resource is
+        modified.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      A dict representing the FHIR resource at the specified version.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
-    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the FHIR resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}/{}".format(
-        url, dataset_id, fhir_store_id, resource_type, resource_id
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
+    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'
+    # version_id = 'MTY4NDQ1MDc3MDU2ODgyNzAwMA'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
-    resource_path += f"/_history/{version_id}"
+    fhir_resource_path = f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/{resource_type}/{resource_id}/_history/{version_id}"
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .vread(name=fhir_resource_path)
+    )
+    response = request.execute()
+    print(
+        f"Got contents of {resource_type} resource with ID {resource_id} at"
+        f" version {version_id}:\n {json.dumps(response, indent=2)}"
+    )
 
-    response = session.get(resource_path, headers=headers)
-    response.raise_for_status()
-
-    resource = response.json()
-
-    print(f"Got history for {resource_type} resource:")
-    print(json.dumps(resource, indent=2))
-
-    return resource
+    return response
 
 
 # [END healthcare_get_resource_history]
@@ -569,65 +689,70 @@ def get_resource_history(
 
 # [START healthcare_delete_resource_purge]
 def delete_resource_purge(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    resource_type,
-    resource_id,
-):
-    """Deletes versions of a resource (excluding current version).
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_id: str,
+) -> dict:
+    """Deletes all versions of a FHIR resource (excluding the current version).
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#Resource_purge
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: The type of the FHIR resource.
+      resource_id: The "logical id" of the resource. The ID is assigned by the
+        server.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      An empty dict.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
-    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the FHIR resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}/{}".format(
-        url, dataset_id, fhir_store_id, resource_type, resource_id
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
+    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
-    resource_path += "/$purge"
+    fhir_resource_path = f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/{resource_type}/{resource_id}"
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
-    response = session.delete(resource_path, headers=headers)
-    response.raise_for_status()
-
-    if response.status_code < 400:
-        print(
-            "Deleted versions of {} resource "
-            "(excluding current version).".format(resource_type)
-        )
-
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .Resource_purge(name=fhir_resource_path)
+    )
+    response = request.execute()
+    print(
+        f"Deleted all versions of {resource_type} resource with ID"
+        f" {resource_id} (excluding current version)."
+    )
     return response
 
 
@@ -635,143 +760,187 @@ def delete_resource_purge(
 
 
 # [START healthcare_update_resource]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+
+# [END healthcare_update_resource]
+# [START healthcare_update_resource]
 def update_resource(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    resource_type,
-    resource_id,
-):
-    """Updates an existing resource.
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_id: str,
+) -> Dict[str, Any]:
+    """Updates the entire contents of a FHIR resource.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    Creates a new current version if the resource already exists, or creates
+    a new resource with an initial version if no resource already exists with
+    the provided ID.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#update
+    for the Python API reference.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: The type of the FHIR resource.
+      resource_id: The "logical id" of the resource. The ID is assigned by the
+        server.
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    Returns:
+      A dict representing the updated FHIR resource.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    api_version = "v1"
+    service_name = "healthcare"
+
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
-    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the FHIR resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
-
-    resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}/{}".format(
-        url, dataset_id, fhir_store_id, resource_type, resource_id
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
+    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
     )
+    fhir_resource_path = f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/{resource_type}/{resource_id}"
 
-    # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
-
-    # The body shown works with a Patient resource and is not guaranteed
+    # The following sample body works with a Patient resource and isn't guaranteed
     # to work with other types of FHIR resources. If necessary,
     # supply a new body with data that corresponds to the resource you
     # are updating.
-    body = {"resourceType": resource_type, "active": True, "id": resource_id}
+    patient_body = {
+        "resourceType": resource_type,
+        "active": True,
+        "id": resource_id,
+    }
 
-    response = session.put(resource_path, headers=headers, json=body)
-    response.raise_for_status()
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .update(name=fhir_resource_path, body=patient_body)
+    )
+    # Sets required application/fhir+json header on the googleapiclient.http.HttpRequest.
+    request.headers["content-type"] = "application/fhir+json;charset=utf-8"
+    response = request.execute()
 
-    resource = response.json()
+    print(
+        f"Updated {resource_type} resource with ID {resource_id}:\n"
+        f" {json.dumps(response, indent=2)}"
+    )
 
-    print("Updated {} resource:".format(resource["resourceType"]))
-    print(json.dumps(resource, indent=2))
-
-    return resource
+    return response
 
 
 # [END healthcare_update_resource]
 
 
 # [START healthcare_patch_resource]
+# Imports the types Dict and Any for runtime type hints.
+from typing import Any, Dict  # noqa: E402
+
+
+# [END healthcare_patch_resource]
+# [START healthcare_patch_resource]
 def patch_resource(
-    project_id,
-    location,
-    dataset_id,
-    fhir_store_id,
-    resource_type,
-    resource_id,
-):
-    """Updates part of an existing resource.
+    project_id: str,
+    location: str,
+    dataset_id: str,
+    fhir_store_id: str,
+    resource_type: str,
+    resource_id: str,
+) -> Dict[str, Any]:
+    """Updates part of an existing FHIR resource by applying the operations specified in a [JSON Patch](http://jsonpatch.com/) document.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    See
+    https://googleapis.github.io/google-api-python-client/docs/dyn/healthcare_v1.projects.locations.datasets.fhirStores.fhir.html#patch
+    for the Python API reference.
 
-    # Imports the google.auth.transport.requests transport
-    from google.auth.transport import requests
+    Args:
+      project_id: The project ID or project number of the Cloud project you want
+        to use.
+      location: The name of the parent dataset's location.
+      dataset_id: The name of the parent dataset.
+      fhir_store_id: The name of the FHIR store.
+      resource_type: The type of the FHIR resource.
+      resource_id: The "logical id" of the resource. The ID is assigned by the
+        server.
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    Returns:
+      A dict representing the patched FHIR resource.
+    """
+    # Imports the Google API Discovery Service.
+    from googleapiclient import discovery
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
-    # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    api_version = "v1"
+    service_name = "healthcare"
 
-    # URL to the Cloud Healthcare API endpoint and version
-    base_url = "https://healthcare.googleapis.com/v1"
+    # Returns an authorized API client by discovering the Healthcare API
+    # and using GOOGLE_APPLICATION_CREDENTIALS environment variable.
+    client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
-    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the FHIR resource's ID
-    url = f"{base_url}/projects/{project_id}/locations/{location}"
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
+    # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'
+    fhir_store_parent = (
+        f"projects/{project_id}/locations/{location}/datasets/{dataset_id}"
+    )
+    fhir_resource_path = f"{fhir_store_parent}/fhirStores/{fhir_store_id}/fhir/{resource_type}/{resource_id}"
 
-    resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}/{}".format(
-        url, dataset_id, fhir_store_id, resource_type, resource_id
+    # The following sample body works with a Patient resource and isn't guaranteed
+    # to work with other types of FHIR resources. If necessary,
+    # supply a new body with data that corresponds to the resource you
+    # are updating.
+    patient_body = [{"op": "replace", "path": "/active", "value": False}]
+
+    request = (
+        client.projects()
+        .locations()
+        .datasets()
+        .fhirStores()
+        .fhir()
+        .patch(name=fhir_resource_path, body=patient_body)
     )
 
     # Sets required application/json-patch+json header.
     # See https://tools.ietf.org/html/rfc6902 for more information.
-    headers = {"Content-Type": "application/json-patch+json"}
+    request.headers["content-type"] = "application/json-patch+json"
 
-    # The body shown works with a Patient resource and is not guaranteed
-    # to work with other types of FHIR resources. If necessary,
-    # supply a new body with data that corresponds to the resource you
-    # are patching.
-    body = json.dumps([{"op": "replace", "path": "/active", "value": False}])
+    response = request.execute()
 
-    response = session.patch(resource_path, headers=headers, data=body)
-    response.raise_for_status()
+    print(
+        f"Patched {resource_type} resource with ID {resource_id}:\n"
+        f" {json.dumps(response, indent=2)}"
+    )
 
-    resource = response.json()
-
-    print("Patched {} resource:".format(resource["resourceType"]))
-    print(json.dumps(resource, indent=2))
-
-    return resource
+    return response
 
 
 # [END healthcare_patch_resource]
@@ -785,39 +954,32 @@ def search_resources_get(
     fhir_store_id,
     resource_type,
 ):
+    """Uses the searchResources GET method to search for resources in the given FHIR store.
+
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
     """
-    Uses the searchResources GET method to search for resources in the given FHIR store.
-
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
-
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
     resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}".format(
@@ -844,41 +1006,35 @@ def search_resources_get(
 
 # [START healthcare_search_resources_post]
 def search_resources_post(project_id, location, dataset_id, fhir_store_id):
+    """Searches for resources in the given FHIR store.
+
+    Uses the _search POST method and a query string containing the information to
+    search for. In this sample, the search criteria is 'family:exact=Smith' on a
+    Patient resource.
+
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
     """
-    Searches for resources in the given FHIR store. Uses the
-    _search POST method and a query string containing the
-    information to search for. In this sample, the search criteria is
-    'family:exact=Smith' on a Patient resource.
-
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
-
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
     fhir_store_path = "{}/datasets/{}/fhirStores/{}/fhir".format(
@@ -888,7 +1044,7 @@ def search_resources_post(project_id, location, dataset_id, fhir_store_id):
     resource_path = f"{fhir_store_path}/Patient/_search?family:exact=Smith"
 
     # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    headers = {"content-type": "application/fhir+json;charset=utf-8"}
 
     response = session.post(resource_path, headers=headers)
     response.raise_for_status()
@@ -918,35 +1074,30 @@ def get_patient_everything(
 ):
     """Gets all the resources in the patient compartment.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    """
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
     # resource_id = 'b682d-0e-4843-a4a9-78c9ac64'  # replace with the Patient resource's ID
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
@@ -956,7 +1107,7 @@ def get_patient_everything(
     resource_path += "/$everything"
 
     # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    headers = {"content-type": "application/fhir+json;charset=utf-8"}
 
     response = session.get(resource_path, headers=headers)
     response.raise_for_status()
@@ -981,35 +1132,30 @@ def execute_bundle(
 ):
     """Executes the operations in the given bundle.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    """
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
     # bundle = 'bundle.json'  # replace with the bundle file
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
@@ -1017,7 +1163,7 @@ def execute_bundle(
         url, dataset_id, fhir_store_id
     )
 
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    headers = {"content-type": "application/fhir+json;charset=utf-8"}
 
     with open(bundle) as bundle_file:
         bundle_file_content = bundle_file.read()
@@ -1040,40 +1186,34 @@ def execute_bundle(
 def create_implementation_guide(
     project_id, location, dataset_id, fhir_store_id, implementation_guide_file
 ):
+    """Creates a new ImplementationGuide resource in a FHIR store from an
 
-    """
-    Creates a new ImplementationGuide resource in a FHIR store from an
     ImplementationGuide JSON file.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    """
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
     # implementation_guide_definition_file = 'ImplementationGuide-hl7.fhir.us.core.json'  # replace with the ImplementationGuide resource file
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
@@ -1082,7 +1222,7 @@ def create_implementation_guide(
     )
 
     # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    headers = {"content-type": "application/fhir+json;charset=utf-8"}
 
     with open(implementation_guide_file) as implementation_guide:
         implementation_guide_content = json.load(implementation_guide)
@@ -1110,13 +1250,14 @@ def enable_implementation_guide(
     fhir_store_id,
     implementation_guide_url,
 ):
+    """Patches an existing FHIR store to enable an ImplementationGuide resource
 
-    """
-    Patches an existing FHIR store to enable an ImplementationGuide resource
     that exists in the FHIR store.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    """
     # Imports the Google API Discovery Service.
     from googleapiclient import discovery
 
@@ -1127,7 +1268,7 @@ def enable_implementation_guide(
     client = discovery.build(service_name, api_version)
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
+    # project_id = 'my-project'
     # location = 'us-central1'  # replace with the dataset's location
     # dataset_id = 'my-dataset'  # replace with your dataset ID
     # fhir_store_id = 'my-fhir-store'  # replace with the FHIR store's ID
@@ -1140,9 +1281,7 @@ def enable_implementation_guide(
     fhir_store_name = f"{fhir_store_parent}/fhirStores/{fhir_store_id}"
 
     validation_config = {
-        "validationConfig": {
-            "enabledImplementationGuides": [implementation_guide_url]
-        }
+        "validationConfig": {"enabledImplementationGuides": [implementation_guide_url]}
     }
 
     request = (
@@ -1151,7 +1290,9 @@ def enable_implementation_guide(
         .datasets()
         .fhirStores()
         .patch(
-            name=fhir_store_name, updateMask="validationConfig", body=validation_config
+            name=fhir_store_name,
+            updateMask="validationConfig",
+            body=validation_config,
         )
     )
 
@@ -1172,40 +1313,34 @@ def enable_implementation_guide(
 def create_structure_definition(
     project_id, location, dataset_id, fhir_store_id, structure_definition_file
 ):
+    """Creates a new StructureDefinition resource in a FHIR store from a
 
-    """
-    Creates a new StructureDefinition resource in a FHIR store from a
     StructureDefinition JSON file.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    """
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
     # structure_definition_file = 'StructureDefinition-us-core-patient.json'  # replace with the StructureDefinition resource file
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
@@ -1214,7 +1349,7 @@ def create_structure_definition(
     )
 
     # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    headers = {"content-type": "application/fhir+json;charset=utf-8"}
 
     with open(structure_definition_file) as structure_definition:
         structure_definition_content = json.load(structure_definition)
@@ -1243,37 +1378,33 @@ def validate_resource(
     resource_type,
 ):
     """Validates an input FHIR resource's conformance to the base profile
+
     configured on the FHIR store.
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    """
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
     resource_path = "{}/datasets/{}/fhirStores/{}/fhir/{}".format(
@@ -1294,7 +1425,7 @@ def validate_resource(
     }
 
     # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    headers = {"content-type": "application/fhir+json;charset=utf-8"}
 
     response = session.post(resource_path, headers=headers, json=body)
     response.raise_for_status()
@@ -1313,40 +1444,36 @@ def validate_resource(
 def validate_resource_profile_url(
     project_id, location, dataset_id, fhir_store_id, resource_type, profile_url
 ):
-    """Validates an input FHIR resource's conformance to a profile URL. The
-    profile StructureDefinition resource must exist in the FHIR store before
+    """Validates an input FHIR resource's conformance to a profile URL.
+
+    The profile StructureDefinition resource must exist in the FHIR store before
     performing validation against the URL.
 
-    See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
-    before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
+    See
+    https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/fhir
+    before running the sample.
+    """
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Construct the Google credentials object by getting the default credentials from the current environment.
+    from google.auth import default
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    credentials, _ = default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
 
     # TODO(developer): Uncomment these lines and replace with your values.
-    # project_id = 'my-project'  # replace with your GCP project ID
-    # location = 'us-central1'  # replace with the parent dataset's location
-    # dataset_id = 'my-dataset'  # replace with the parent dataset's ID
-    # fhir_store_id = 'my-fhir-store' # replace with the FHIR store ID
-    # resource_type = 'Patient'  # replace with the FHIR resource type
+    # project_id = 'my-project'
+    # location = 'us-central1'
+    # dataset_id = 'my-dataset'
+    # fhir_store_id = 'my-fhir-store'
+    # resource_type = 'Patient'
     # profile_url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'  # replace with the profile URL
     url = f"{base_url}/projects/{project_id}/locations/{location}"
 
@@ -1369,7 +1496,7 @@ def validate_resource_profile_url(
     }
 
     # Sets required application/fhir+json header on the request
-    headers = {"Content-Type": "application/fhir+json;charset=utf-8"}
+    headers = {"content-type": "application/fhir+json;charset=utf-8"}
 
     response = session.post(resource_path, headers=headers, json=body, params=params)
     response.raise_for_status()
@@ -1422,15 +1549,19 @@ def parse_command_line_args():
     parser.add_argument(
         "--patient_id",
         default=None,
-        help="Identifier for a Patient resource. Can be used as a reference "
-        "for an Encounter/Observation",
+        help=(
+            "Identifier for a Patient resource. Can be used as a reference "
+            "for an Encounter/Observation"
+        ),
     )
 
     parser.add_argument(
         "--encounter_id",
         default=None,
-        help="Identifier for an Encounter resource. Can be used as a "
-        "reference for an Observation",
+        help=(
+            "Identifier for an Encounter resource. Can be used as a "
+            "reference for an Observation"
+        ),
     )
 
     parser.add_argument(
@@ -1440,7 +1571,9 @@ def parse_command_line_args():
     )
 
     parser.add_argument(
-        "--uri_prefix", default=None, help="Prefix of gs:// URIs for import and export"
+        "--uri_prefix",
+        default=None,
+        help="Prefix of gs:// URIs for import and export",
     )
 
     parser.add_argument("--version_id", default=None, help="Version of a FHIR resource")
@@ -1466,7 +1599,10 @@ def parse_command_line_args():
     parser.add_argument(
         "--implementation_guide_url",
         default=None,
-        help="the URL defined in the 'url' property of the ImplementationGuide resource",
+        help=(
+            "the URL defined in the 'url' property of the ImplementationGuide"
+            " resource"
+        ),
     )
 
     command = parser.add_subparsers(dest="command")
@@ -1499,7 +1635,8 @@ def parse_command_line_args():
     )
     command.add_parser("validate-resource", help=validate_resource.__doc__)
     command.add_parser(
-        "validate-resource-profile-url", help=validate_resource_profile_url.__doc__
+        "validate-resource-profile-url",
+        help=validate_resource_profile_url.__doc__,
     )
 
     return parser.parse_args()

--- a/healthcare/api-client/v1/fhir/resources/Patient.json
+++ b/healthcare/api-client/v1/fhir/resources/Patient.json
@@ -1,2 +1,1 @@
 {"birthDate":"1970-01-01","gender":"female","id":"b5525e54-cf0a-4412-96fe-c44596231d92","name":[{"family":"Smith","given":["Darcy"],"use":"official"}],"resourceType":"Patient"}
-{"active":false,"id":"d9c75b09-4dcc-44ea-ad66-cc4ec6bac945","resourceType":"Patient"}


### PR DESCRIPTION
## Description

These updates primarily concern cleanups, but also the Healthcare API has always and will continue to use the google-api-python-client instead of the GAPIC libraries. Previously there wasn't a reliable way to set custom HTTP accept and content-type headers and we had to use the requests library. The samples are being updated to now solely use the https://github.com/googleapis/google-api-python-client/ for credentials/requests.

Updates to first 11 FHIR resource samples through `patch_resource()`:

- Remove all uses of google.auth.transport.requests transport in favor of the discovery-based APIs.
- Add type hints
- Add docstrings.
- Set content-type on the HttpObject from the google-api-python-client instead of the requests object.
- Use ADC for auth in the discovery service.

Other samples will have the same updates added, but in the meantime have been updated to use ADC instead of a service account file.

Part of b/280881103 fix.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] Please **merge** this PR for me once it is approved