### PR TITLE
Use yaml.safe_load() in readme-gen instead of yaml.load().

### DIFF
--- a/scripts/readme-gen/readme_gen.py
+++ b/scripts/readme-gen/readme_gen.py
@@ -51,7 +51,7 @@ def main():
     jinja_env.globals['get_help'] = get_help
 
     with io.open(source, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
 
     # This allows get_help to execute in the right directory.
     os.chdir(root)


### PR DESCRIPTION
Recommendation from https://pyyaml.org/wiki/PyYAMLDocumentation. Also generating README.rst using `nox` fails if safe_load isn't used.