### PR TITLE
fixit: clean up appengine/flexible_python37_and_earlier/extending_run…

### DIFF
--- a/appengine/flexible_python37_and_earlier/extending_runtime/main.py
+++ b/appengine/flexible_python37_and_earlier/extending_runtime/main.py
@@ -23,24 +23,34 @@ app = Flask(__name__)
 
 
 # [START example]
-@app.route('/')
+@app.route("/")
 def fortune():
-    output = subprocess.check_output('/usr/games/fortune')
-    return output, 200, {'Content-Type': 'text/plain; charset=utf-8'}
+    """Runs the 'fortune' command and serves the output.
+
+    Returns:
+        The output of the 'fortune' command.
+    """
+    output = subprocess.check_output("/usr/games/fortune")
+    return output, 200, {"Content-Type": "text/plain; charset=utf-8"}
 # [END example]
 
 
 @app.errorhandler(500)
 def server_error(e):
-    logging.exception('An error occurred during a request.')
-    return """
-    An internal error occurred: <pre>{}</pre>
-    See logs for full stacktrace.
-    """.format(e), 500
+    """Serves a formatted message on-error.
+
+    Returns:
+        The error message and a code 500 status.
+    """
+    logging.exception("An error occurred during a request.")
+    return (
+        f"An internal error occurred: <pre>{e}</pre><br>See logs for full stacktrace.",
+        500,
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # This is used when running locally. Gunicorn is used to run the
     # application on Google App Engine. See CMD in Dockerfile.
-    app.run(host='127.0.0.1', port=8080, debug=True)
+    app.run(host="127.0.0.1", port=8080, debug=True)
 # [END app]

--- a/appengine/flexible_python37_and_earlier/extending_runtime/main_test.py
+++ b/appengine/flexible_python37_and_earlier/extending_runtime/main_test.py
@@ -20,12 +20,13 @@ import main
 
 
 @pytest.mark.skipif(
-    not os.path.exists('/usr/games/fortune'),
-    reason='Fortune executable is not installed.')
+    not os.path.exists("/usr/games/fortune"),
+    reason="Fortune executable is not installed.",
+)
 def test_index():
     main.app.testing = True
     client = main.app.test_client()
 
-    r = client.get('/')
+    r = client.get("/")
     assert r.status_code == 200
     assert len(r.data)


### PR DESCRIPTION
…time

## Description

Fixes #280880611

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved