### PR TITLE
fixit: clean up appengine/flexible_python37_and_earlier/disk

### DIFF
--- a/appengine/flexible_python37_and_earlier/disk/main.py
+++ b/appengine/flexible_python37_and_earlier/disk/main.py
@@ -23,7 +23,14 @@ app = Flask(__name__)
 
 
 def is_ipv6(addr):
-    """Checks if a given address is an IPv6 address."""
+    """Checks if a given address is an IPv6 address.
+
+    Args:
+        addr: An IP address object.
+
+    Returns:
+        True if addr is an IPv6 address, or False otherwise.
+    """
     try:
         socket.inet_pton(socket.AF_INET6, addr)
         return True
@@ -32,43 +39,54 @@ def is_ipv6(addr):
 
 
 # [START example]
-@app.route('/')
+@app.route("/")
 def index():
-    instance_id = os.environ.get('GAE_INSTANCE', '1')
+    """Serves the content of a file that was stored on disk.
+
+    The instance's external address is first stored on the disk as a tmp
+    file, and subsequently read. That value is then formatted and served
+    on the endpoint.
+
+    Returns:
+        A formatted string with the GAE instance ID and the content of the
+        seen.txt file.
+    """
+    instance_id = os.environ.get("GAE_INSTANCE", "1")
 
     user_ip = request.remote_addr
 
     # Keep only the first two octets of the IP address.
     if is_ipv6(user_ip):
-        user_ip = ':'.join(user_ip.split(':')[:2])
+        user_ip = ":".join(user_ip.split(":")[:2])
     else:
-        user_ip = '.'.join(user_ip.split('.')[:2])
+        user_ip = ".".join(user_ip.split(".")[:2])
 
-    with open('/tmp/seen.txt', 'a') as f:
-        f.write(f'{user_ip}\n')
+    with open("/tmp/seen.txt", "a") as f:
+        f.write(f"{user_ip}\n")
 
-    with open('/tmp/seen.txt') as f:
+    with open("/tmp/seen.txt") as f:
         seen = f.read()
 
-    output = """
-Instance: {}
-Seen:
-{}""".format(instance_id, seen)
-
-    return output, 200, {'Content-Type': 'text/plain; charset=utf-8'}
+    output = f"Instance: {instance_id}\nSeen:{seen}"
+    return output, 200, {"Content-Type": "text/plain; charset=utf-8"}
 # [END example]
 
 
 @app.errorhandler(500)
 def server_error(e):
-    logging.exception('An error occurred during a request.')
-    return """
-    An internal error occurred: <pre>{}</pre>
-    See logs for full stacktrace.
-    """.format(e), 500
+    """Serves a formatted message on-error.
+
+    Returns:
+        The error message and a code 500 status.
+    """
+    logging.exception("An error occurred during a request.")
+    return (
+        f"An internal error occurred: <pre>{e}</pre><br>See logs for full stacktrace.",
+        500,
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # This is used when running locally. Gunicorn is used to run the
     # application on Google App Engine. See entrypoint in app.yaml.
-    app.run(host='127.0.0.1', port=8080, debug=True)
+    app.run(host="127.0.0.1", port=8080, debug=True)

--- a/appengine/flexible_python37_and_earlier/disk/main_test.py
+++ b/appengine/flexible_python37_and_earlier/disk/main_test.py
@@ -19,6 +19,6 @@ def test_index():
     main.app.testing = True
     client = main.app.test_client()
 
-    r = client.get('/', environ_base={'REMOTE_ADDR': '127.0.0.1'})
+    r = client.get("/", environ_base={"REMOTE_ADDR": "127.0.0.1"})
     assert r.status_code == 200
-    assert '127.0' in r.data.decode('utf-8')
+    assert "127.0" in r.data.decode("utf-8")


### PR DESCRIPTION
## Description

Fixes #280880345

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved