### PR TITLE
Remove torus blunderbuss

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -18,18 +18,6 @@
 assign_issues_by:
   # DEE teams
   - labels:
-      - "api: appengine"
-      - "api: cloudbuild"
-      - "api: cloudscheduler"
-      - "api: cloudtasks"
-      - "api: containeranalysis"
-      - "api: eventarc"
-      - "api: functions"
-      - "api: run"
-      - "api: workflows"
-    to:
-      - GoogleCloudPlatform/torus-dpe
-  - labels:
       - "api: batch"
       - "api: compute"
       - "api: cloudkms"
@@ -167,18 +155,6 @@ assign_issues_by:
 ###
 assign_prs_by:
   # DEE teams
-  - labels:
-      - "api: appengine"
-      - "api: cloudbuild"
-      - "api: cloudscheduler"
-      - "api: cloudtasks"
-      - "api: containeranalysis"
-      - "api: eventarc"
-      - "api: functions"
-      - "api: run"
-      - "api: workflows"
-    to:
-      - GoogleCloudPlatform/torus-dpe
   - labels:
       - "api: batch"
       - "api: compute"


### PR DESCRIPTION
This PR will remove blunderbuss configuration that auto assigns issues and PRs to the torus-dpe team.

Reasoning: automatic assignment does not align with current team triage processes