### PR TITLE
chore: update dependency update schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "prConcurrentLimit": 0,
   "rebaseWhen": "never",
   "masterIssue": true,
@@ -9,9 +7,19 @@
     "fileMatch": ["pyproject.toml"]
   },
   "pip_requirements": {
-    "fileMatch": ["requirements-test.txt", "requirements-composer.txt", "constraints.txt", "constraints-test.txt"]
+    "fileMatch": [
+      "requirements-test.txt",
+      "requirements-composer.txt",
+      "constraints.txt",
+      "constraints-test.txt"
+    ]
   },
-  "ignorePaths" : ["composer/**/constraints.txt", "composer/blog/**/constraints.txt", "composer/airflow_1_samples/requirements.txt", "appengine/standard"],
+  "ignorePaths": [
+    "composer/**/constraints.txt",
+    "composer/blog/**/constraints.txt",
+    "composer/airflow_1_samples/requirements.txt",
+    "appengine/standard"
+  ],
   "packageRules": [
     {
       "packagePatterns": ["pytest"],
@@ -21,6 +29,14 @@
       "packagePatterns": ["pytest"],
       "updateTypes": ["patch"],
       "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "extends": ["schedule:monthly"]
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "extends": ["schedule:quarterly"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -38,5 +38,8 @@
       "matchUpdateTypes": ["patch"],
       "extends": ["schedule:quarterly"]
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "schedule": ["at any time"]
+  }
 }


### PR DESCRIPTION
Update Renovate config so that minor PRs are submitted monthly, and patch PRs are submitted quarterly. Schedule can be updated at any time.