### PR TITLE
bug fix in create_instance when spot is False

### DIFF
--- a/compute/client_library/snippets/instances/custom_machine_types/extra_mem_no_helper.py
+++ b/compute/client_library/snippets/instances/custom_machine_types/extra_mem_no_helper.py
@@ -233,13 +233,15 @@ def create_instance(
         instance.scheduling = compute_v1.Scheduling()
         instance.scheduling.preemptible = True
 
+    instance.scheduling = compute_v1.Scheduling()
     if spot:
         # Set the Spot VM setting
-        instance.scheduling = compute_v1.Scheduling()
         instance.scheduling.provisioning_model = (
             compute_v1.Scheduling.ProvisioningModel.SPOT.name
         )
         instance.scheduling.instance_termination_action = instance_termination_action
+    else:
+        instance.scheduling.on_host_maintenance = "TERMINATE"
 
     if custom_hostname is not None:
         # Set the custom hostname for the instance


### PR DESCRIPTION
Setting the on_host_maintenance = "TERMINATE" to avoid: "Instances with guest accelerators do not support live migration."

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved