### PR TITLE
chore: handle auth flakiness

### DIFF
--- a/auth/api-client/api_key_test.py
+++ b/auth/api-client/api_key_test.py
@@ -15,9 +15,11 @@ import os
 import re
 from time import sleep
 from unittest import mock
+from unittest.mock import MagicMock
 import uuid
 
 from _pytest.capture import CaptureFixture
+import backoff
 import google.auth.transport.requests
 from google.cloud import language_v1
 from google.cloud.api_keys_v2 import Key
@@ -38,19 +40,19 @@ SERVICE_ACCOUNT_FILE = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
 
 @pytest.fixture(scope="session")
-def api_key():
+def api_key() -> Key:
     suffix = uuid.uuid4().hex
     api_key = create_api_key.create_api_key(PROJECT, suffix)
-    sleep(5)
+    sleep(30)
     yield api_key
     delete_api_key.delete_api_key(PROJECT, get_key_id(api_key.name))
 
 
-def get_key_id(api_key_name: str):
+def get_key_id(api_key_name: str) -> str:
     return api_key_name.rsplit("/")[-1]
 
 
-def get_mock_sentiment_response():
+def get_mock_sentiment_response() -> MagicMock:
     response = mock.MagicMock(spec=language_v1.AnalyzeSentimentResponse)
     sentiment = mock.MagicMock(spec=language_v1.Sentiment)
     sentiment.score = 0.2
@@ -59,7 +61,10 @@ def get_mock_sentiment_response():
     return mock.MagicMock(return_value=response)
 
 
-def test_authenticate_with_api_key(api_key: Key, capsys: CaptureFixture):
+@backoff.on_exception(backoff.expo,
+                      Exception,
+                      max_tries=3)
+def test_authenticate_with_api_key(api_key: Key, capsys: CaptureFixture) -> None:
     with mock.patch(
         "google.cloud.language_v1.LanguageServiceClient.analyze_sentiment",
         get_mock_sentiment_response()
@@ -71,37 +76,37 @@ def test_authenticate_with_api_key(api_key: Key, capsys: CaptureFixture):
     assert re.search("Successfully authenticated using the API key", out)
 
 
-def test_lookup_api_key(api_key: Key, capsys: CaptureFixture):
+def test_lookup_api_key(api_key: Key, capsys: CaptureFixture) -> None:
     lookup_api_key.lookup_api_key(api_key.key_string)
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully retrieved the API key name: {api_key.name}", out)
 
 
-def test_restrict_api_key_android(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_android(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_android.restrict_api_key_android(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_api(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_api(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_api.restrict_api_key_api(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_http(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_http(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_http.restrict_api_key_http(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_ios(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_ios(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_ios.restrict_api_key_ios(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_server(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_server(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_server.restrict_api_key_server(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)


### PR DESCRIPTION
Fixes #8787 

Increase the wait time to 30 seconds before using the key to run tests. Re-added backoff.