### PR TITLE
chore(webrisk): update submit_uri API

### DIFF
--- a/auth/api-client/api_key_test.py
+++ b/auth/api-client/api_key_test.py
@@ -15,9 +15,11 @@ import os
 import re
 from time import sleep
 from unittest import mock
+from unittest.mock import MagicMock
 import uuid
 
 from _pytest.capture import CaptureFixture
+import backoff
 import google.auth.transport.requests
 from google.cloud import language_v1
 from google.cloud.api_keys_v2 import Key
@@ -38,19 +40,19 @@ SERVICE_ACCOUNT_FILE = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
 
 @pytest.fixture(scope="session")
-def api_key():
+def api_key() -> Key:
     suffix = uuid.uuid4().hex
     api_key = create_api_key.create_api_key(PROJECT, suffix)
-    sleep(5)
+    sleep(30)
     yield api_key
     delete_api_key.delete_api_key(PROJECT, get_key_id(api_key.name))
 
 
-def get_key_id(api_key_name: str):
+def get_key_id(api_key_name: str) -> str:
     return api_key_name.rsplit("/")[-1]
 
 
-def get_mock_sentiment_response():
+def get_mock_sentiment_response() -> MagicMock:
     response = mock.MagicMock(spec=language_v1.AnalyzeSentimentResponse)
     sentiment = mock.MagicMock(spec=language_v1.Sentiment)
     sentiment.score = 0.2
@@ -59,7 +61,10 @@ def get_mock_sentiment_response():
     return mock.MagicMock(return_value=response)
 
 
-def test_authenticate_with_api_key(api_key: Key, capsys: CaptureFixture):
+@backoff.on_exception(backoff.expo,
+                      Exception,
+                      max_tries=3)
+def test_authenticate_with_api_key(api_key: Key, capsys: CaptureFixture) -> None:
     with mock.patch(
         "google.cloud.language_v1.LanguageServiceClient.analyze_sentiment",
         get_mock_sentiment_response()
@@ -71,37 +76,37 @@ def test_authenticate_with_api_key(api_key: Key, capsys: CaptureFixture):
     assert re.search("Successfully authenticated using the API key", out)
 
 
-def test_lookup_api_key(api_key: Key, capsys: CaptureFixture):
+def test_lookup_api_key(api_key: Key, capsys: CaptureFixture) -> None:
     lookup_api_key.lookup_api_key(api_key.key_string)
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully retrieved the API key name: {api_key.name}", out)
 
 
-def test_restrict_api_key_android(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_android(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_android.restrict_api_key_android(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_api(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_api(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_api.restrict_api_key_api(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_http(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_http(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_http.restrict_api_key_http(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_ios(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_ios(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_ios.restrict_api_key_ios(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)
 
 
-def test_restrict_api_key_server(api_key: Key, capsys: CaptureFixture):
+def test_restrict_api_key_server(api_key: Key, capsys: CaptureFixture) -> None:
     restrict_api_key_server.restrict_api_key_server(PROJECT, get_key_id(api_key.name))
     out, _ = capsys.readouterr()
     assert re.search(f"Successfully updated the API key: {api_key.name}", out)

--- a/webrisk/snippets/submit_uri.py
+++ b/webrisk/snippets/submit_uri.py
@@ -21,6 +21,8 @@ def submit_uri(project_id: str, uri: str) -> Submission:
     """Submits a URI suspected of containing malicious content to be reviewed.
 
     Returns a google.longrunning.Operation which, once the review is complete, is updated with its result.
+    You can use the [Pub/Sub API] (https://cloud.google.com/pubsub) to receive notifications for the
+    returned Operation.
     If the result verifies the existence of malicious content, the site will be added to the
     Google's Social Engineering lists in order to protect users that could get exposed to this
     threat in the future. Only allow-listed projects can use this method during Early Access.
@@ -35,15 +37,49 @@ def submit_uri(project_id: str, uri: str) -> Submission:
     """
     webrisk_client = webrisk_v1.WebRiskServiceClient()
 
+    # Set the URI to be submitted.
     submission = webrisk_v1.Submission()
     submission.uri = uri
 
-    request = webrisk_v1.CreateSubmissionRequest()
-    request.parent = f"projects/{project_id}"
-    request.submission = submission
+    # Confidence that a URI is unsafe.
+    threat_confidence = webrisk_v1.ThreatInfo.Confidence(
+        level=webrisk_v1.ThreatInfo.Confidence.ConfidenceLevel.MEDIUM
+    )
 
-    response = webrisk_client.create_submission(request)
+    # Context about why the URI is unsafe.
+    threat_justification = webrisk_v1.ThreatInfo.ThreatJustification(
+        # Labels that explain how the URI was classified.
+        labels=[webrisk_v1.ThreatInfo.ThreatJustification.JustificationLabel.AUTOMATED_REPORT],
+        # Free-form context on why this URI is unsafe.
+        comments=["Testing submission"]
+    )
+
+    # Set the context about the submission including the type of abuse found on the URI and
+    # supporting details.
+    threat_info = webrisk_v1.ThreatInfo(
+        # The abuse type found on the URI.
+        abuse_type=webrisk_v1.types.ThreatType.SOCIAL_ENGINEERING,
+        threat_confidence=threat_confidence,
+        threat_justification=threat_justification
+    )
+
+    # Set the details about how the threat was discovered.
+    threat_discovery = webrisk_v1.ThreatDiscovery(
+        # Platform on which the threat was discovered.
+        platform=webrisk_v1.ThreatDiscovery.Platform.MACOS,
+        # CLDR region code of the countries/regions the URI poses a threat ordered
+        # from most impact to least impact. Example: "US" for United States.
+        region_codes=["US"]
+    )
+
+    request = webrisk_v1.SubmitUriRequest(
+        parent=f"projects/{project_id}",
+        submission=submission,
+        threat_info=threat_info,
+        threat_discovery=threat_discovery
+    )
+
+    response = webrisk_client.submit_uri(request).result(timeout=30)
     return response
-
 
 # [END webrisk_submit_uri]


### PR DESCRIPTION
## Description

Webrisk updated the legacy `create_submission` endpoint to `submit_uri`. The PR addressed this change and include new fields that are part of the new API.

NOTE: The GCP test project needs to be allowlisted for the tests to run successfully. Will remove the 'DO_NOT_MERGE' label when the project has the access.