### PR TITLE
chore: Add requirements-dev.txt exception to header-checker-lint.yml

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -9,8 +9,9 @@ allowedLicenses:
 
 ignoreFiles:
   - "**/requirements.txt"
-  - "**/requirements-test.txt"
   - "**/requirements-composer.txt"
+  - "**/requirements-dev.txt"
+  - "**/requirements-test.txt"
   - "**/__init__.py"
   - "**/constraints.txt"
   - "**/constraints-test.txt"


### PR DESCRIPTION
`requirements-dev.txt` exists in some samples, and should also be ignored in license header checks.