### PR TITLE
Chore: update sync-repo-settings.yaml

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -39,7 +39,7 @@ branchProtectionRules:
   # Defaults to `false`
   requiresCodeOwnerReviews: true
   # Require up to date branches
-  requiresStrictStatusChecks: true
+  requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - "Kokoro CI - Lint"


### PR DESCRIPTION
Removing requirement to have branches up-to-date with main, to accelerate merging PRs. Merge conflicts will still be checked. 

This has been reviewed with Python leads, and we can revert it at any time if needed.