### PR TITLE
fix: broken tests due to str(enum) changes in Python 3.11

### DIFF
--- a/video/transcoder/get_job_state.py
+++ b/video/transcoder/get_job_state.py
@@ -42,7 +42,7 @@ def get_job_state(project_id, location, job_id):
     name = f"projects/{project_id}/locations/{location}/jobs/{job_id}"
     response = client.get_job(name=name)
 
-    print(f"Job state: {str(response.state)}")
+    print(f"Job state: {str(response.state.name)}")
     return response
 
 

--- a/video/transcoder/job_test.py
+++ b/video/transcoder/job_test.py
@@ -89,8 +89,8 @@ output_uri_for_periodic_spritesheet = (
 output_uri_for_concat = f"gs://{output_bucket_name}/test-output-concat/"
 
 preset = "preset/web-hd"
-job_succeeded_state = "ProcessingState.SUCCEEDED"
-job_running_state = "ProcessingState.RUNNING"
+job_succeeded_state = "SUCCEEDED"
+job_running_state = "RUNNING"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description
There was a breaking change in python 3.11. See 
* https://github.com/python/cpython/issues/94763
* https://github.com/python/cpython/issues/100458
* https://docs.python.org/3/whatsnew/3.11.html#enum

```
Changed Enum.__format__() (the default for format(), str.format() and f-strings) to always produce the same result as Enum.__str__(): for enums inheriting from ReprEnum it will be the member’s value; for all other enums it will be the enum and member name (e.g. Color.RED)
```

Fixes #10241

## Checklist
- [X] Please **merge** this PR for me once it is approved