### PR TITLE
fix(dlp, testing): add unique string to dlp infotype tests

### DIFF
--- a/dlp/snippets/inspect_content.py
+++ b/dlp/snippets/inspect_content.py
@@ -335,9 +335,7 @@ def inspect_column_values_w_custom_hotwords(
     headers = [{"name": val} for val in table_header]
     rows = []
     for row in table_rows:
-        rows.append(
-            {"values": [{"string_value": cell_val} for cell_val in row]}
-        )
+        rows.append({"values": [{"string_value": cell_val} for cell_val in row]})
     table = {"headers": headers, "rows": rows}
 
     # Construct the `item` for table to be inspected.
@@ -396,6 +394,7 @@ def inspect_column_values_w_custom_hotwords(
             print("Likelihood: {}".format(finding.likelihood))
     else:
         print("No findings.")
+
 
 # [END dlp_inspect_column_values_w_custom_hotwords]
 
@@ -1122,6 +1121,7 @@ def inspect_image_file(
     else:
         print("No findings.")
 
+
 # [END dlp_inspect_image_file]
 
 
@@ -1698,7 +1698,7 @@ if __name__ == "__main__":
     parser_table_hotword = subparsers.add_parser(
         "table_w_custom_hotword",
         help="Inspect a table and exclude column values when matched "
-             "with custom hot-word.",
+        "with custom hot-word.",
     )
     parser_table_hotword.add_argument(
         "--project",
@@ -1708,23 +1708,23 @@ if __name__ == "__main__":
     parser_table_hotword.add_argument(
         "--table_header",
         help="List of strings representing table field names."
-             "Example include '['Fake_Email_Address', 'Real_Email_Address]'. "
-             "The method can be used to exclude matches from entire column"
-             '"Fake_Email_Address".',
+        "Example include '['Fake_Email_Address', 'Real_Email_Address]'. "
+        "The method can be used to exclude matches from entire column"
+        '"Fake_Email_Address".',
     )
     parser_table_hotword.add_argument(
         "--table_rows",
         help="List of rows representing table values."
-             'Example: '
-             '"[["example1@example.org", "test1@example.com],'
-             '["example2@example.org", "test2@example.com]]"',
+        "Example: "
+        '"[["example1@example.org", "test1@example.com],'
+        '["example2@example.org", "test2@example.com]]"',
     )
     parser_table_hotword.add_argument(
         "--info_types",
         action="append",
         help="Strings representing info types to look for. A full list of "
-             "info categories and types is available from the API. Examples "
-             'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
+        "info categories and types is available from the API. Examples "
+        'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". ',
     )
     parser_table_hotword.add_argument(
         "custom_hotword",
@@ -2104,11 +2104,13 @@ if __name__ == "__main__":
         help="The Google Cloud project id to use as a parent resource.",
         default=default_project,
     )
-    parser_image_default_infotypes.add_argument("filename", help="The path to the file to inspect.")
+    parser_image_default_infotypes.add_argument(
+        "filename", help="The path to the file to inspect."
+    )
     parser_image_default_infotypes.add_argument(
         "--include_quote",
         help="A Boolean for whether to display a quote of the detected"
-             "information in the results.",
+        "information in the results.",
         default=True,
     )
 

--- a/dlp/snippets/inspect_content_test.py
+++ b/dlp/snippets/inspect_content_test.py
@@ -232,8 +232,8 @@ def test_inspect_column_values_w_custom_hotwords(capsys):
         "rows": [
             ["111-11-1111", "222-22-2222"],
             ["987-23-1234", "333-33-3333"],
-            ["678-12-0909", "444-44-4444"]
-        ]
+            ["678-12-0909", "444-44-4444"],
+        ],
     }
     inspect_content.inspect_column_values_w_custom_hotwords(
         GCLOUD_PROJECT,

--- a/dlp/snippets/stored_infotype_test.py
+++ b/dlp/snippets/stored_infotype_test.py
@@ -29,7 +29,7 @@ UNIQUE_STRING = str(uuid.uuid4()).split("-")[0]
 TEST_BUCKET_NAME = GCLOUD_PROJECT + "-dlp-python-client-test" + UNIQUE_STRING
 RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "resources")
 RESOURCE_FILE_NAMES = ["term_list.txt"]
-STORED_INFO_TYPE_ID = "github-usernames"
+STORED_INFO_TYPE_ID = "github-usernames" + UNIQUE_STRING
 
 DLP_CLIENT = google.cloud.dlp_v2.DlpServiceClient()
 


### PR DESCRIPTION
These tests compete for the same resource when there are multiple concurrent test runs.

This leads to flaky tests as seen on #10222


## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved