### PR TITLE
chore(cleanup): retire media translate samples

### DIFF
--- a/media-translation/README.md
+++ b/media-translation/README.md
@@ -1,0 +1,6 @@
+# Media Translation API deprication
+
+Media Translation API is [deprecated] and will no longer be available on Google Cloud after July 1, 2024.
+All API code samples under this folder are no longer maintained and will be removed after July 1, 2024.
+
+[deprecated]: https://cloud.google.com/translate/media/docs/deprecations

--- a/media-translation/snippets/README.md
+++ b/media-translation/snippets/README.md
@@ -1,0 +1,6 @@
+# Media Translation API deprication
+
+Media Translation API is [deprecated] and will no longer be available on Google Cloud after July 1, 2024.
+All API code samples under this folder are no longer maintained and will be removed after July 1, 2024.
+
+[deprecated]: https://cloud.google.com/translate/media/docs/deprecations

--- a/media-translation/snippets/translate_from_file_test.py
+++ b/media-translation/snippets/translate_from_file_test.py
@@ -15,11 +15,13 @@
 import os
 import re
 
+import pytest
+
 import translate_from_file
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
-
+@pytest.mark.skip(reason="skip test for deprecated code sample")
 def test_translate_streaming(capsys):
     translate_from_file.translate_from_file(os.path.join(RESOURCES, "audio.raw"))
     out, err = capsys.readouterr()

--- a/media-translation/snippets/translate_from_file_test.py
+++ b/media-translation/snippets/translate_from_file_test.py
@@ -21,6 +21,7 @@ import translate_from_file
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
+
 @pytest.mark.skip(reason="skip test for deprecated code sample")
 def test_translate_streaming(capsys):
     translate_from_file.translate_from_file(os.path.join(RESOURCES, "audio.raw"))


### PR DESCRIPTION
### Description

Adds README.md with the deprecation message 
Disables tests.

Fixes #10370 
