### PR TITLE
docs(samples): Add & update samples for STT v2

### DIFF
--- a/speech/snippets/adaptation_v2_custom_class_reference.py
+++ b/speech/snippets/adaptation_v2_custom_class_reference.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-# [START speech_adaptation_v2_custom_class_reference]
+import argparse
 
+# [START speech_adaptation_v2_custom_class_reference]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
 def adaptation_v2_custom_class_reference(
     project_id: str,
-    recognizer_id: str,
     phrase_set_id: str,
     custom_class_id: str,
     audio_file: str,
@@ -30,7 +30,6 @@ def adaptation_v2_custom_class_reference(
 
     Args:
         project_id: The GCP project ID.
-        recognizer_id: The ID of the recognizer to use.
         phrase_set_id: The ID of the phrase set to use.
         custom_class_id: The ID of the custom class to use.
         audio_file: The audio file to transcribe.
@@ -40,18 +39,6 @@ def adaptation_v2_custom_class_reference(
     """
     # Instantiates a client
     client = SpeechClient()
-
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_short"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -88,11 +75,16 @@ def adaptation_v2_custom_class_reference(
         ]
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, adaptation=adaptation
+        auto_decoding_config={},
+        adaptation=adaptation,
+        language_codes=["en-US"],
+        model="latest_short",
     )
 
     request = cloud_speech.RecognizeRequest(
-        recognizer=recognizer.name, config=config, content=content
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        content=content,
     )
 
     # Transcribes the audio into text
@@ -108,4 +100,14 @@ def adaptation_v2_custom_class_reference(
 
 
 if __name__ == "__main__":
-    adaptation_v2_custom_class_reference()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("phrase_set_id", help="ID for the phrase set to create")
+    parser.add_argument("custom_class_id", help="ID for the custom class to create")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    adaptation_v2_custom_class_reference(
+        args.project_id, args.phrase_set_id, args.custom_class_id, args.audio_file
+    )

--- a/speech/snippets/adaptation_v2_custom_class_reference.py
+++ b/speech/snippets/adaptation_v2_custom_class_reference.py
@@ -75,7 +75,7 @@ def adaptation_v2_custom_class_reference(
         ]
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
         model="latest_short",

--- a/speech/snippets/adaptation_v2_custom_class_reference_test.py
+++ b/speech/snippets/adaptation_v2_custom_class_reference_test.py
@@ -25,12 +25,6 @@ import adaptation_v2_custom_class_reference
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
-
-
 def delete_phrase_set(name: str) -> None:
     client = SpeechClient()
     request = cloud_speech.DeletePhraseSetRequest(name=name)
@@ -47,13 +41,11 @@ def delete_custom_class(name: str) -> None:
 def test_adaptation_v2_custom_class_reference() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     phrase_set_id = "phrase-set-" + str(uuid4())
     custom_class_id = "custom-class-" + str(uuid4())
     response = (
         adaptation_v2_custom_class_reference.adaptation_v2_custom_class_reference(
             project_id,
-            recognizer_id,
             phrase_set_id,
             custom_class_id,
             os.path.join(RESOURCES, "fair.wav"),
@@ -64,10 +56,6 @@ def test_adaptation_v2_custom_class_reference() -> None:
         r"the word is fare",
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )
 
     delete_phrase_set(

--- a/speech/snippets/adaptation_v2_custom_class_reference_test.py
+++ b/speech/snippets/adaptation_v2_custom_class_reference_test.py
@@ -22,7 +22,7 @@ from google.cloud.speech_v2.types import cloud_speech
 
 import adaptation_v2_custom_class_reference
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 def delete_phrase_set(name: str) -> None:
@@ -48,7 +48,7 @@ def test_adaptation_v2_custom_class_reference() -> None:
             project_id,
             phrase_set_id,
             custom_class_id,
-            os.path.join(RESOURCES, "fair.wav"),
+            os.path.join(_RESOURCES, "fair.wav"),
         )
     )
 

--- a/speech/snippets/adaptation_v2_inline_custom_class.py
+++ b/speech/snippets/adaptation_v2_inline_custom_class.py
@@ -13,22 +13,21 @@
 # limitations under the License.
 
 
-# [START speech_adaptation_v2_inline_custom_class]
+import argparse
 
+# [START speech_adaptation_v2_inline_custom_class]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
 def adaptation_v2_inline_custom_class(
     project_id: str,
-    recognizer_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
     """Transcribe audio file using inline custom class
 
     Args:
         project_id: The GCP project ID.
-        recognizer_id: The ID of the recognizer.
         audio_file: The audio file to transcribe.
 
     Returns:
@@ -36,18 +35,6 @@ def adaptation_v2_inline_custom_class(
     """
     # Instantiates a client
     client = SpeechClient()
-
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_short"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -65,11 +52,16 @@ def adaptation_v2_inline_custom_class(
         custom_classes=[custom_class],
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, adaptation=adaptation
+        auto_decoding_config={},
+        adaptation=adaptation,
+        language_codes=["en-US"],
+        model="latest_short",
     )
 
     request = cloud_speech.RecognizeRequest(
-        recognizer=recognizer.name, config=config, content=content
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        content=content,
     )
 
     # Transcribes the audio into text
@@ -85,4 +77,10 @@ def adaptation_v2_inline_custom_class(
 
 
 if __name__ == "__main__":
-    adaptation_v2_inline_custom_class()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    adaptation_v2_inline_custom_class(args.project_id, args.audio_file)

--- a/speech/snippets/adaptation_v2_inline_custom_class.py
+++ b/speech/snippets/adaptation_v2_inline_custom_class.py
@@ -52,7 +52,7 @@ def adaptation_v2_inline_custom_class(
         custom_classes=[custom_class],
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
         model="latest_short",

--- a/speech/snippets/adaptation_v2_inline_custom_class_test.py
+++ b/speech/snippets/adaptation_v2_inline_custom_class_test.py
@@ -14,38 +14,24 @@
 
 import os
 import re
-from uuid import uuid4
 
 from google.api_core.retry import Retry
-from google.cloud.speech_v2 import SpeechClient
-from google.cloud.speech_v2.types import cloud_speech
 
 import adaptation_v2_inline_custom_class
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
-
-
 @Retry()
 def test_adaptation_v2_inline_custom_class() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     response = adaptation_v2_inline_custom_class.adaptation_v2_inline_custom_class(
-        project_id, recognizer_id, os.path.join(RESOURCES, "fair.wav")
+        project_id, os.path.join(RESOURCES, "fair.wav")
     )
 
     assert re.search(
         r"the word",
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )

--- a/speech/snippets/adaptation_v2_inline_custom_class_test.py
+++ b/speech/snippets/adaptation_v2_inline_custom_class_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import adaptation_v2_inline_custom_class
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_adaptation_v2_inline_custom_class() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = adaptation_v2_inline_custom_class.adaptation_v2_inline_custom_class(
-        project_id, os.path.join(RESOURCES, "fair.wav")
+        project_id, os.path.join(_RESOURCES, "fair.wav")
     )
 
     assert re.search(

--- a/speech/snippets/adaptation_v2_inline_phrase_set.py
+++ b/speech/snippets/adaptation_v2_inline_phrase_set.py
@@ -13,31 +13,19 @@
 # limitations under the License.
 
 
-# [START speech_adaptation_v2_inline_phrase_set]
+import argparse
 
+# [START speech_adaptation_v2_inline_phrase_set]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
 def adaptation_v2_inline_phrase_set(
     project_id: str,
-    recognizer_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
     # Instantiates a client
     client = SpeechClient()
-
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_short"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -53,11 +41,16 @@ def adaptation_v2_inline_phrase_set(
         ]
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, adaptation=adaptation
+        auto_decoding_config={},
+        adaptation=adaptation,
+        language_codes=["en-US"],
+        model="latest_short",
     )
 
     request = cloud_speech.RecognizeRequest(
-        recognizer=recognizer.name, config=config, content=content
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        content=content,
     )
 
     # Transcribes the audio into text
@@ -73,4 +66,13 @@ def adaptation_v2_inline_phrase_set(
 
 
 if __name__ == "__main__":
-    adaptation_v2_inline_phrase_set()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    adaptation_v2_inline_phrase_set(
+        args.project_id,
+        args.audio_file,
+    )

--- a/speech/snippets/adaptation_v2_inline_phrase_set.py
+++ b/speech/snippets/adaptation_v2_inline_phrase_set.py
@@ -41,7 +41,7 @@ def adaptation_v2_inline_phrase_set(
         ]
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
         model="latest_short",

--- a/speech/snippets/adaptation_v2_inline_phrase_set_test.py
+++ b/speech/snippets/adaptation_v2_inline_phrase_set_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import adaptation_v2_inline_phrase_set
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_adaptation_v2_inline_phrase_set() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = adaptation_v2_inline_phrase_set.adaptation_v2_inline_phrase_set(
-        project_id, os.path.join(RESOURCES, "fair.wav")
+        project_id, os.path.join(_RESOURCES, "fair.wav")
     )
 
     assert re.search(

--- a/speech/snippets/adaptation_v2_inline_phrase_set_test.py
+++ b/speech/snippets/adaptation_v2_inline_phrase_set_test.py
@@ -14,38 +14,24 @@
 
 import os
 import re
-from uuid import uuid4
 
 from google.api_core.retry import Retry
-from google.cloud.speech_v2 import SpeechClient
-from google.cloud.speech_v2.types import cloud_speech
 
 import adaptation_v2_inline_phrase_set
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
-
-
 @Retry()
 def test_adaptation_v2_inline_phrase_set() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     response = adaptation_v2_inline_phrase_set.adaptation_v2_inline_phrase_set(
-        project_id, recognizer_id, os.path.join(RESOURCES, "fair.wav")
+        project_id, os.path.join(RESOURCES, "fair.wav")
     )
 
     assert re.search(
         r"the word is fare",
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )

--- a/speech/snippets/adaptation_v2_phrase_set_reference.py
+++ b/speech/snippets/adaptation_v2_phrase_set_reference.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 
-# [START speech_adaptation_v2_phrase_set_reference]
+import argparse
 
+# [START speech_adaptation_v2_phrase_set_reference]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
 def adaptation_v2_phrase_set_reference(
     project_id: str,
-    recognizer_id: str,
     phrase_set_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
@@ -29,7 +29,6 @@ def adaptation_v2_phrase_set_reference(
 
     Args:
         project_id: The GCP project ID.
-        recognizer_id: The ID of the recognizer to use.
         phrase_set_id: The ID of the PhraseSet to use.
         audio_file: The path to the audio file to transcribe.
 
@@ -38,18 +37,6 @@ def adaptation_v2_phrase_set_reference(
     """
     # Instantiates a client
     client = SpeechClient()
-
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_short"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -74,11 +61,16 @@ def adaptation_v2_phrase_set_reference(
         ]
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, adaptation=adaptation
+        auto_decoding_config={},
+        adaptation=adaptation,
+        language_codes=["en-US"],
+        model="latest_short",
     )
 
     request = cloud_speech.RecognizeRequest(
-        recognizer=recognizer.name, config=config, content=content
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        content=content,
     )
 
     # Transcribes the audio into text
@@ -94,4 +86,15 @@ def adaptation_v2_phrase_set_reference(
 
 
 if __name__ == "__main__":
-    adaptation_v2_phrase_set_reference()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("phrase_set_id", help="ID for the phrase set to create")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    adaptation_v2_phrase_set_reference(
+        args.project_id,
+        args.phrase_set_id,
+        args.audio_file,
+    )

--- a/speech/snippets/adaptation_v2_phrase_set_reference.py
+++ b/speech/snippets/adaptation_v2_phrase_set_reference.py
@@ -61,7 +61,7 @@ def adaptation_v2_phrase_set_reference(
         ]
     )
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
         model="latest_short",

--- a/speech/snippets/adaptation_v2_phrase_set_reference_test.py
+++ b/speech/snippets/adaptation_v2_phrase_set_reference_test.py
@@ -25,12 +25,6 @@ import adaptation_v2_phrase_set_reference
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
-
-
 def delete_phrase_set(name: str) -> None:
     client = SpeechClient()
     request = cloud_speech.DeletePhraseSetRequest(name=name)
@@ -41,20 +35,15 @@ def delete_phrase_set(name: str) -> None:
 def test_adaptation_v2_phrase_set_reference() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     phrase_set_id = "phrase-set-" + str(uuid4())
     response = adaptation_v2_phrase_set_reference.adaptation_v2_phrase_set_reference(
-        project_id, recognizer_id, phrase_set_id, os.path.join(RESOURCES, "fair.wav")
+        project_id, phrase_set_id, os.path.join(RESOURCES, "fair.wav")
     )
 
     assert re.search(
         r"the word is fare",
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )
 
     delete_phrase_set(

--- a/speech/snippets/adaptation_v2_phrase_set_reference_test.py
+++ b/speech/snippets/adaptation_v2_phrase_set_reference_test.py
@@ -22,7 +22,7 @@ from google.cloud.speech_v2.types import cloud_speech
 
 import adaptation_v2_phrase_set_reference
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 def delete_phrase_set(name: str) -> None:
@@ -37,7 +37,7 @@ def test_adaptation_v2_phrase_set_reference() -> None:
 
     phrase_set_id = "phrase-set-" + str(uuid4())
     response = adaptation_v2_phrase_set_reference.adaptation_v2_phrase_set_reference(
-        project_id, phrase_set_id, os.path.join(RESOURCES, "fair.wav")
+        project_id, phrase_set_id, os.path.join(_RESOURCES, "fair.wav")
     )
 
     assert re.search(

--- a/speech/snippets/change_speech_v2_location.py
+++ b/speech/snippets/change_speech_v2_location.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,18 +15,24 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_change_speech_v2_location]
+from google.api_core.client_options import ClientOptions
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def change_speech_v2_location(
     project_id: str,
+    location: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
-    """Transcribe an audio file."""
-    # Instantiates a client
-    client = SpeechClient()
+    """Transcribe an audio file in a specific region."""
+    # Instantiates a client to a regionalized Speech endpoint.
+    client = SpeechClient(
+        client_options=ClientOptions(
+            api_endpoint=f"{location}-speech.googleapis.com",
+        )
+    )
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -37,7 +43,7 @@ def quickstart_v2(
     )
 
     request = cloud_speech.RecognizeRequest(
-        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        recognizer=f"projects/{project_id}/locations/{location}/recognizers/_",
         config=config,
         content=content,
     )
@@ -51,7 +57,7 @@ def quickstart_v2(
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_change_speech_v2_location]
 
 
 if __name__ == "__main__":
@@ -59,6 +65,7 @@ if __name__ == "__main__":
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("location", help="The GCP region to which to connect")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    change_speech_v2_location(args.project_id, args.location, args.audio_file)

--- a/speech/snippets/change_speech_v2_location.py
+++ b/speech/snippets/change_speech_v2_location.py
@@ -39,7 +39,9 @@ def change_speech_v2_location(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="latest_long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/change_speech_v2_location_test.py
+++ b/speech/snippets/change_speech_v2_location_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import change_speech_v2_location
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_change_speech_v2_location() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = change_speech_v2_location.change_speech_v2_location(
-        project_id, "us-central1", os.path.join(RESOURCES, "audio.wav")
+        project_id, "us-central1", os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/change_speech_v2_location_test.py
+++ b/speech/snippets/change_speech_v2_location_test.py
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,18 +15,19 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import change_speech_v2_location
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_change_speech_v2_location() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+    response = change_speech_v2_location.change_speech_v2_location(
+        project_id, "us-central1", os.path.join(RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/create_recognizer.py
+++ b/speech/snippets/create_recognizer.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import argparse
+
 # [START speech_create_recognizer]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
@@ -41,4 +43,10 @@ def create_recognizer(project_id: str, recognizer_id: str) -> cloud_speech.Recog
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("recognizer_id", help="ID for the recognizer to create")
+    args = parser.parse_args()
     create_recognizer()

--- a/speech/snippets/quickstart_v2.py
+++ b/speech/snippets/quickstart_v2.py
@@ -33,7 +33,9 @@ def quickstart_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="latest_long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/quickstart_v2_test.py
+++ b/speech/snippets/quickstart_v2_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import quickstart_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_quickstart_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = quickstart_v2.quickstart_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_auto_punctuation_v2.py
+++ b/speech/snippets/transcribe_auto_punctuation_v2.py
@@ -33,7 +33,7 @@ def transcribe_auto_punctuation_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
         model="latest_long",
         features=cloud_speech.RecognitionFeatures(

--- a/speech/snippets/transcribe_auto_punctuation_v2.py
+++ b/speech/snippets/transcribe_auto_punctuation_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_transcribe_auto_punctuation_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def transcribe_auto_punctuation_v2(
     project_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
@@ -33,7 +33,12 @@ def quickstart_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config={},
+        language_codes=["en-US"],
+        model="latest_long",
+        features=cloud_speech.RecognitionFeatures(
+            enable_automatic_punctuation=True,
+        ),
     )
 
     request = cloud_speech.RecognizeRequest(
@@ -51,7 +56,7 @@ def quickstart_v2(
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_transcribe_auto_punctuation_v2]
 
 
 if __name__ == "__main__":
@@ -61,4 +66,4 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="GCP Project ID")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    transcribe_auto_punctuation_v2(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_auto_punctuation_v2_test.py
+++ b/speech/snippets/transcribe_auto_punctuation_v2_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import transcribe_auto_punctuation_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_transcribe_auto_punctuation_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_auto_punctuation_v2.transcribe_auto_punctuation_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_auto_punctuation_v2_test.py
+++ b/speech/snippets/transcribe_auto_punctuation_v2_test.py
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,22 +15,23 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import transcribe_auto_punctuation_v2
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_transcribe_auto_punctuation_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
+    response = transcribe_auto_punctuation_v2.transcribe_auto_punctuation_v2(
         project_id, os.path.join(RESOURCES, "audio.wav")
     )
 
     assert re.search(
-        r"how old is the Brooklyn Bridge",
+        r"How old is the Brooklyn Bridge?",
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
     )

--- a/speech/snippets/transcribe_chirp.py
+++ b/speech/snippets/transcribe_chirp.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,29 +15,34 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_transcribe_chirp]
+from google.api_core.client_options import ClientOptions
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def transcribe_chirp(
     project_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
-    """Transcribe an audio file."""
+    """Transcribe an audio file using Chirp."""
     # Instantiates a client
-    client = SpeechClient()
+    client = SpeechClient(
+        client_options=ClientOptions(
+            api_endpoint="us-central1-speech.googleapis.com",
+        )
+    )
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config={}, language_codes=["en-US"], model="chirp"
     )
 
     request = cloud_speech.RecognizeRequest(
-        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        recognizer=f"projects/{project_id}/locations/us-central1/recognizers/_",
         config=config,
         content=content,
     )
@@ -51,7 +56,7 @@ def quickstart_v2(
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_transcribe_chirp]
 
 
 if __name__ == "__main__":
@@ -61,4 +66,4 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="GCP Project ID")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    transcribe_chirp(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_chirp.py
+++ b/speech/snippets/transcribe_chirp.py
@@ -38,7 +38,9 @@ def transcribe_chirp(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="chirp"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="chirp",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/transcribe_chirp_test.py
+++ b/speech/snippets/transcribe_chirp_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import transcribe_chirp
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_transcribe_chirp() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_chirp.transcribe_chirp(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_chirp_test.py
+++ b/speech/snippets/transcribe_chirp_test.py
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,17 +15,18 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import transcribe_chirp
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_transcribe_chirp() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
+    response = transcribe_chirp.transcribe_chirp(
         project_id, os.path.join(RESOURCES, "audio.wav")
     )
 

--- a/speech/snippets/transcribe_file_v2.py
+++ b/speech/snippets/transcribe_file_v2.py
@@ -13,40 +13,32 @@
 # limitations under the License.
 
 
-# [START speech_transcribe_file_v2]
+import argparse
 
+# [START speech_transcribe_file_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
 def transcribe_file_v2(
     project_id: str,
-    recognizer_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
     # Instantiates a client
     client = SpeechClient()
 
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_long"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
-
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
         content = f.read()
 
-    config = cloud_speech.RecognitionConfig(auto_decoding_config={})
+    config = cloud_speech.RecognitionConfig(
+        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+    )
 
     request = cloud_speech.RecognizeRequest(
-        recognizer=recognizer.name, config=config, content=content
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        content=content,
     )
 
     # Transcribes the audio into text
@@ -62,4 +54,10 @@ def transcribe_file_v2(
 
 
 if __name__ == "__main__":
-    transcribe_file_v2()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    transcribe_file_v2(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_file_v2.py
+++ b/speech/snippets/transcribe_file_v2.py
@@ -32,7 +32,9 @@ def transcribe_file_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="latest_long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/transcribe_file_v2_test.py
+++ b/speech/snippets/transcribe_file_v2_test.py
@@ -19,14 +19,14 @@ import pytest
 
 import transcribe_file_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_file_v2.transcribe_file_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_gcs_v2.py
+++ b/speech/snippets/transcribe_gcs_v2.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import argparse
+
 # [START speech_transcribe_gcs_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
@@ -20,14 +22,12 @@ from google.cloud.speech_v2.types import cloud_speech
 
 def transcribe_gcs_v2(
     project_id: str,
-    recognizer_id: str,
     gcs_uri: str,
 ) -> cloud_speech.RecognizeResponse:
     """Transcribes audio from a Google Cloud Storage URI.
 
     Args:
         project_id: The GCP project ID.
-        recognizer_id: The ID of the recognizer.
         gcs_uri: The Google Cloud Storage URI.
 
     Returns:
@@ -36,22 +36,14 @@ def transcribe_gcs_v2(
     # Instantiates a client
     client = SpeechClient()
 
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_long"
-        ),
+    config = cloud_speech.RecognitionConfig(
+        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
     )
 
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
-
-    config = cloud_speech.RecognitionConfig(auto_decoding_config={})
-
     request = cloud_speech.RecognizeRequest(
-        recognizer=recognizer.name, config=config, uri=gcs_uri
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        uri=gcs_uri,
     )
 
     # Transcribes the audio into text
@@ -67,4 +59,10 @@ def transcribe_gcs_v2(
 
 
 if __name__ == "__main__":
-    transcribe_gcs_v2()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("gcs_uri", help="URI to GCS file")
+    args = parser.parse_args()
+    transcribe_gcs_v2(args.project_id, args.gcs_uri)

--- a/speech/snippets/transcribe_gcs_v2.py
+++ b/speech/snippets/transcribe_gcs_v2.py
@@ -37,7 +37,9 @@ def transcribe_gcs_v2(
     client = SpeechClient()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="latest_long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/transcribe_gcs_v2_test.py
+++ b/speech/snippets/transcribe_gcs_v2_test.py
@@ -14,37 +14,23 @@
 
 import os
 import re
-from uuid import uuid4
 
 from google.api_core.retry import Retry
-from google.cloud.speech_v2 import SpeechClient
-from google.cloud.speech_v2.types import cloud_speech
 import pytest
 
 import transcribe_gcs_v2
-
-
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
 
 
 @Retry()
 def test_transcribe_gcs_v2(capsys: pytest.CaptureFixture) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     response = transcribe_gcs_v2.transcribe_gcs_v2(
-        project_id, recognizer_id, "gs://cloud-samples-data/speech/audio.flac"
+        project_id, "gs://cloud-samples-data/speech/audio.flac"
     )
 
     assert re.search(
         r"how old is the Brooklyn Bridge",
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )

--- a/speech/snippets/transcribe_gcs_v2_test.py
+++ b/speech/snippets/transcribe_gcs_v2_test.py
@@ -21,13 +21,14 @@ import pytest
 import transcribe_gcs_v2
 
 
+_TEST_AUDIO_FILE_PATH = "gs://cloud-samples-data/speech/audio.flac"
+
+
 @Retry()
 def test_transcribe_gcs_v2(capsys: pytest.CaptureFixture) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_gcs_v2.transcribe_gcs_v2(
-        project_id, "gs://cloud-samples-data/speech/audio.flac"
-    )
+    response = transcribe_gcs_v2.transcribe_gcs_v2(project_id, _TEST_AUDIO_FILE_PATH)
 
     assert re.search(
         r"how old is the Brooklyn Bridge",

--- a/speech/snippets/transcribe_model_selection_v2.py
+++ b/speech/snippets/transcribe_model_selection_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_transcribe_model_selection_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def transcribe_model_selection_v2(
     project_id: str,
+    model: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
     """Transcribe an audio file."""
@@ -33,7 +34,7 @@ def quickstart_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config={}, language_codes=["en-US"], model=model
     )
 
     request = cloud_speech.RecognizeRequest(
@@ -51,7 +52,7 @@ def quickstart_v2(
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_transcribe_model_selection_v2]
 
 
 if __name__ == "__main__":
@@ -59,6 +60,7 @@ if __name__ == "__main__":
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("model", help="Speech-to-Text model with which to transcribe")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    transcribe_model_selection_v2(args.project_id, args.model, args.audio_file)

--- a/speech/snippets/transcribe_model_selection_v2.py
+++ b/speech/snippets/transcribe_model_selection_v2.py
@@ -34,7 +34,9 @@ def transcribe_model_selection_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model=model
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model=model,
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/transcribe_model_selection_v2_test.py
+++ b/speech/snippets/transcribe_model_selection_v2_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import transcribe_model_selection_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_transcribe_model_selection_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_model_selection_v2.transcribe_model_selection_v2(
-        project_id, "latest_long", os.path.join(RESOURCES, "audio.wav")
+        project_id, "latest_long", os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_model_selection_v2_test.py
+++ b/speech/snippets/transcribe_model_selection_v2_test.py
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,18 +15,19 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import transcribe_model_selection_v2
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_transcribe_model_selection_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+    response = transcribe_model_selection_v2.transcribe_model_selection_v2(
+        project_id, "latest_long", os.path.join(RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_multichannel_v2.py
+++ b/speech/snippets/transcribe_multichannel_v2.py
@@ -33,7 +33,7 @@ def transcribe_multichannel_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
         model="latest_long",
         features=cloud_speech.RecognitionFeatures(

--- a/speech/snippets/transcribe_multichannel_v2.py
+++ b/speech/snippets/transcribe_multichannel_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,16 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_transcribe_multichannel_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def transcribe_multichannel_v2(
     project_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
-    """Transcribe an audio file."""
+    """Transcribe a multi-channel audio file."""
     # Instantiates a client
     client = SpeechClient()
 
@@ -33,7 +33,12 @@ def quickstart_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config={},
+        language_codes=["en-US"],
+        model="latest_long",
+        features=cloud_speech.RecognitionFeatures(
+            multi_channel_mode=cloud_speech.RecognitionFeatures.MultiChannelMode.SEPARATE_RECOGNITION_PER_CHANNEL,
+        ),
     )
 
     request = cloud_speech.RecognizeRequest(
@@ -47,11 +52,12 @@ def quickstart_v2(
 
     for result in response.results:
         print(f"Transcript: {result.alternatives[0].transcript}")
+        print(f"Channel tag: {result.channel_tag}")
 
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_transcribe_multichannel_v2]
 
 
 if __name__ == "__main__":
@@ -61,4 +67,4 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="GCP Project ID")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    transcribe_multichannel_v2(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_multichannel_v2_test.py
+++ b/speech/snippets/transcribe_multichannel_v2_test.py
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,22 +15,31 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import transcribe_multichannel_v2
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_transcribe_multichannel_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+    response = transcribe_multichannel_v2.transcribe_multichannel_v2(
+        project_id, os.path.join(RESOURCES, "two_channel_16k.wav")
     )
 
     assert re.search(
-        r"how old is the Brooklyn Bridge",
+        r"saving account",
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
     )
+    assert response.results[0].channel_tag == 1
+
+    assert re.search(
+        r"debit card number",
+        response.results[1].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )
+    assert response.results[1].channel_tag == 2

--- a/speech/snippets/transcribe_multichannel_v2_test.py
+++ b/speech/snippets/transcribe_multichannel_v2_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import transcribe_multichannel_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_transcribe_multichannel_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_multichannel_v2.transcribe_multichannel_v2(
-        project_id, os.path.join(RESOURCES, "two_channel_16k.wav")
+        project_id, os.path.join(_RESOURCES, "two_channel_16k.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_profanity_filter_v2.py
+++ b/speech/snippets/transcribe_profanity_filter_v2.py
@@ -33,7 +33,7 @@ def transcribe_profanity_filter_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
         model="latest_long",
         features=cloud_speech.RecognitionFeatures(

--- a/speech/snippets/transcribe_profanity_filter_v2.py
+++ b/speech/snippets/transcribe_profanity_filter_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_transcribe_profanity_filter_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def transcribe_profanity_filter_v2(
     project_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
@@ -33,7 +33,12 @@ def quickstart_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config={},
+        language_codes=["en-US"],
+        model="latest_long",
+        features=cloud_speech.RecognitionFeatures(
+            profanity_filter=True,
+        ),
     )
 
     request = cloud_speech.RecognizeRequest(
@@ -51,7 +56,7 @@ def quickstart_v2(
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_transcribe_profanity_filter_v2]
 
 
 if __name__ == "__main__":
@@ -61,4 +66,4 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="GCP Project ID")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    transcribe_profanity_filter_v2(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_profanity_filter_v2_test.py
+++ b/speech/snippets/transcribe_profanity_filter_v2_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import transcribe_profanity_filter_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_transcribe_profanity_filter_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_profanity_filter_v2.transcribe_profanity_filter_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_profanity_filter_v2_test.py
+++ b/speech/snippets/transcribe_profanity_filter_v2_test.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,17 +15,18 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import transcribe_profanity_filter_v2
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_transcribe_profanity_filter_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
+    response = transcribe_profanity_filter_v2.transcribe_profanity_filter_v2(
         project_id, os.path.join(RESOURCES, "audio.wav")
     )
 

--- a/speech/snippets/transcribe_streaming_v2.py
+++ b/speech/snippets/transcribe_streaming_v2.py
@@ -13,22 +13,21 @@
 # limitations under the License.
 
 
-# [START speech_transcribe_streaming_v2]
+import argparse
 
+# [START speech_transcribe_streaming_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
 def transcribe_streaming_v2(
     project_id: str,
-    recognizer_id: str,
     audio_file: str,
 ) -> cloud_speech.StreamingRecognizeResponse:
     """Transcribes audio from audio file stream.
 
     Args:
         project_id: The GCP project ID.
-        recognizer_id: The ID of the recognizer to use.
         audio_file: The path to the audio file to transcribe.
 
     Returns:
@@ -36,18 +35,6 @@ def transcribe_streaming_v2(
     """
     # Instantiates a client
     client = SpeechClient()
-
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_long"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -63,12 +50,15 @@ def transcribe_streaming_v2(
         cloud_speech.StreamingRecognizeRequest(audio=audio) for audio in stream
     )
 
-    recognition_config = cloud_speech.RecognitionConfig(auto_decoding_config={})
+    recognition_config = cloud_speech.RecognitionConfig(
+        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+    )
     streaming_config = cloud_speech.StreamingRecognitionConfig(
         config=recognition_config
     )
     config_request = cloud_speech.StreamingRecognizeRequest(
-        recognizer=recognizer.name, streaming_config=streaming_config
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        streaming_config=streaming_config,
     )
 
     def requests(config: cloud_speech.RecognitionConfig, audio: list) -> list:
@@ -92,4 +82,10 @@ def transcribe_streaming_v2(
 
 
 if __name__ == "__main__":
-    transcribe_streaming_v2()
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    transcribe_streaming_v2(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_streaming_v2.py
+++ b/speech/snippets/transcribe_streaming_v2.py
@@ -51,7 +51,9 @@ def transcribe_streaming_v2(
     )
 
     recognition_config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="latest_long",
     )
     streaming_config = cloud_speech.StreamingRecognitionConfig(
         config=recognition_config

--- a/speech/snippets/transcribe_streaming_v2_test.py
+++ b/speech/snippets/transcribe_streaming_v2_test.py
@@ -20,7 +20,7 @@ import pytest
 
 import transcribe_streaming_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -28,7 +28,7 @@ def test_transcribe_streaming_v2(capsys: pytest.CaptureFixture) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     responses = transcribe_streaming_v2.transcribe_streaming_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     transcript = ""

--- a/speech/snippets/transcribe_streaming_v2_test.py
+++ b/speech/snippets/transcribe_streaming_v2_test.py
@@ -14,11 +14,8 @@
 
 import os
 import re
-from uuid import uuid4
 
 from google.api_core.retry import Retry
-from google.cloud.speech_v2 import SpeechClient
-from google.cloud.speech_v2.types import cloud_speech
 import pytest
 
 import transcribe_streaming_v2
@@ -26,19 +23,12 @@ import transcribe_streaming_v2
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
-
-
 @Retry()
 def test_transcribe_streaming_v2(capsys: pytest.CaptureFixture) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     responses = transcribe_streaming_v2.transcribe_streaming_v2(
-        project_id, recognizer_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(RESOURCES, "audio.wav")
     )
 
     transcript = ""
@@ -50,8 +40,4 @@ def test_transcribe_streaming_v2(capsys: pytest.CaptureFixture) -> None:
         r"how old is the Brooklyn Bridge",
         transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )

--- a/speech/snippets/transcribe_streaming_voice_activity_events.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_events.py
@@ -50,7 +50,9 @@ def transcribe_streaming_voice_activity_events(
     )
 
     recognition_config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="latest_long",
     )
 
     # Sets the flag to enable voice activity events

--- a/speech/snippets/transcribe_streaming_voice_activity_events.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_events.py
@@ -16,19 +16,17 @@
 import argparse
 
 # [START speech_transcribe_streaming_voice_activity_events]
-
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
 def transcribe_streaming_voice_activity_events(
-    project_id: str, recognizer_id: str, audio_file: str
+    project_id: str, audio_file: str
 ) -> cloud_speech.StreamingRecognizeResponse:
     """Transcribes audio from a file into text.
 
     Args:
         project_id: The GCP project ID to use.
-        recognizer_id: The ID of the recognizer to use.
         audio_file: The path to the audio file to transcribe.
 
     Returns:
@@ -36,18 +34,6 @@ def transcribe_streaming_voice_activity_events(
     """
     # Instantiates a client
     client = SpeechClient()
-
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_long"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -63,7 +49,9 @@ def transcribe_streaming_voice_activity_events(
         cloud_speech.StreamingRecognizeRequest(audio=audio) for audio in stream
     )
 
-    recognition_config = cloud_speech.RecognitionConfig(auto_decoding_config={})
+    recognition_config = cloud_speech.RecognitionConfig(
+        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+    )
 
     # Sets the flag to enable voice activity events
     streaming_features = cloud_speech.StreamingRecognitionFeatures(
@@ -74,7 +62,8 @@ def transcribe_streaming_voice_activity_events(
     )
 
     config_request = cloud_speech.StreamingRecognizeRequest(
-        recognizer=recognizer.name, streaming_config=streaming_config
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        streaming_config=streaming_config,
     )
 
     def requests(config: cloud_speech.RecognitionConfig, audio: list) -> list:
@@ -111,10 +100,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("project_id", help="project to create recognizer in")
-    parser.add_argument("recognizer_id", help="name of recognizer to create")
-    parser.add_argument("audio_file", help="audio file to stream")
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    transcribe_streaming_voice_activity_events(
-        args.project_id, args.recognizer_id, args.audio_file
-    )
+    transcribe_streaming_voice_activity_events(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_streaming_voice_activity_events_test.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_events_test.py
@@ -21,7 +21,7 @@ import pytest
 
 import transcribe_streaming_voice_activity_events
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -31,7 +31,7 @@ def test_transcribe_streaming_voice_activity_events(
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     responses = transcribe_streaming_voice_activity_events.transcribe_streaming_voice_activity_events(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     transcript = ""

--- a/speech/snippets/transcribe_streaming_voice_activity_events_test.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_events_test.py
@@ -14,10 +14,8 @@
 
 import os
 import re
-from uuid import uuid4
 
 from google.api_core.retry import Retry
-from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 import pytest
 
@@ -26,21 +24,14 @@ import transcribe_streaming_voice_activity_events
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
-
-
 @Retry()
 def test_transcribe_streaming_voice_activity_events(
     capsys: pytest.CaptureFixture,
 ) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     responses = transcribe_streaming_voice_activity_events.transcribe_streaming_voice_activity_events(
-        project_id, recognizer_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(RESOURCES, "audio.wav")
     )
 
     transcript = ""
@@ -57,8 +48,4 @@ def test_transcribe_streaming_voice_activity_events(
         r"how old is the Brooklyn Bridge",
         transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )

--- a/speech/snippets/transcribe_streaming_voice_activity_timeouts.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_timeouts.py
@@ -25,7 +25,6 @@ from google.protobuf import duration_pb2  # type: ignore
 
 def transcribe_streaming_voice_activity_timeouts(
     project_id: str,
-    recognizer_id: str,
     speech_start_timeout: int,
     speech_end_timeout: int,
     audio_file: str,
@@ -34,7 +33,6 @@ def transcribe_streaming_voice_activity_timeouts(
 
     Args:
         project_id: The GCP project ID to use.
-        recognizer_id: The ID of the recognizer to use.
         speech_start_timeout: The timeout in seconds for speech start.
         speech_end_timeout: The timeout in seconds for speech end.
         audio_file: The audio file to transcribe.
@@ -44,18 +42,6 @@ def transcribe_streaming_voice_activity_timeouts(
     """
     # Instantiates a client
     client = SpeechClient()
-
-    request = cloud_speech.CreateRecognizerRequest(
-        parent=f"projects/{project_id}/locations/global",
-        recognizer_id=recognizer_id,
-        recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_long"
-        ),
-    )
-
-    # Creates a Recognizer
-    operation = client.create_recognizer(request=request)
-    recognizer = operation.result()
 
     # Reads a file as bytes
     with open(audio_file, "rb") as f:
@@ -71,7 +57,9 @@ def transcribe_streaming_voice_activity_timeouts(
         cloud_speech.StreamingRecognizeRequest(audio=audio) for audio in stream
     )
 
-    recognition_config = cloud_speech.RecognitionConfig(auto_decoding_config={})
+    recognition_config = cloud_speech.RecognitionConfig(
+        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+    )
 
     # Sets the flag to enable voice activity events and timeout
     speech_start_timeout = duration_pb2.Duration(seconds=speech_start_timeout)
@@ -91,7 +79,8 @@ def transcribe_streaming_voice_activity_timeouts(
     )
 
     config_request = cloud_speech.StreamingRecognizeRequest(
-        recognizer=recognizer.name, streaming_config=streaming_config
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        streaming_config=streaming_config,
     )
 
     def requests(config: cloud_speech.RecognitionConfig, audio: list) -> list:
@@ -131,17 +120,15 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("project_id", help="project to create recognizer in")
-    parser.add_argument("recognizer_id", help="name of recognizer to create")
+    parser.add_argument("project_id", help="GCP Project ID")
     parser.add_argument(
-        "speech_start_timeout", help="timeout in seconds for speech start"
+        "speech_start_timeout", help="Timeout in seconds for speech start"
     )
-    parser.add_argument("speech_end_timeout", help="timeout in seconds for speech end")
-    parser.add_argument("audio_file", help="audio file to stream")
+    parser.add_argument("speech_end_timeout", help="Timeout in seconds for speech end")
+    parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
     transcribe_streaming_voice_activity_timeouts(
         args.project_id,
-        args.recognizer_id,
         args.speech_start_timeout,
         args.speech_end_timeout,
         args.audio_file,

--- a/speech/snippets/transcribe_streaming_voice_activity_timeouts.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_timeouts.py
@@ -58,7 +58,9 @@ def transcribe_streaming_voice_activity_timeouts(
     )
 
     recognition_config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="latest_long",
     )
 
     # Sets the flag to enable voice activity events and timeout

--- a/speech/snippets/transcribe_streaming_voice_activity_timeouts_test.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_timeouts_test.py
@@ -22,7 +22,7 @@ import pytest
 
 import transcribe_streaming_voice_activity_timeouts
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @flaky(max_runs=3, min_passes=1)
@@ -33,7 +33,7 @@ def test_transcribe_silence_padding_timeouts(capsys: pytest.CaptureFixture) -> N
         project_id,
         1,
         5,
-        os.path.join(RESOURCES, "audio_silence_padding.wav"),
+        os.path.join(_RESOURCES, "audio_silence_padding.wav"),
     )
 
     # This assert doesn't seem deterministic. We should consider removing or changing.
@@ -50,7 +50,7 @@ def test_transcribe_streaming_voice_activity_timeouts(
         project_id,
         5,
         1,
-        os.path.join(RESOURCES, "audio_silence_padding.wav"),
+        os.path.join(_RESOURCES, "audio_silence_padding.wav"),
     )
     transcript = ""
     for response in responses:

--- a/speech/snippets/transcribe_streaming_voice_activity_timeouts_test.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_timeouts_test.py
@@ -14,11 +14,9 @@
 
 import os
 import re
-from uuid import uuid4
 
 from flaky import flaky
 
-from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 import pytest
 
@@ -27,20 +25,12 @@ import transcribe_streaming_voice_activity_timeouts
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def delete_recognizer(name: str) -> None:
-    client = SpeechClient()
-    request = cloud_speech.DeleteRecognizerRequest(name=name)
-    client.delete_recognizer(request=request)
-
-
 @flaky(max_runs=3, min_passes=1)
 def test_transcribe_silence_padding_timeouts(capsys: pytest.CaptureFixture) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     responses = transcribe_streaming_voice_activity_timeouts.transcribe_streaming_voice_activity_timeouts(
         project_id,
-        recognizer_id,
         1,
         5,
         os.path.join(RESOURCES, "audio_silence_padding.wav"),
@@ -49,10 +39,6 @@ def test_transcribe_silence_padding_timeouts(capsys: pytest.CaptureFixture) -> N
     # This assert doesn't seem deterministic. We should consider removing or changing.
     assert len(responses) == 0
 
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
-    )
-
 
 @flaky(max_runs=3, min_passes=1)
 def test_transcribe_streaming_voice_activity_timeouts(
@@ -60,10 +46,8 @@ def test_transcribe_streaming_voice_activity_timeouts(
 ) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    recognizer_id = "recognizer-" + str(uuid4())
     responses = transcribe_streaming_voice_activity_timeouts.transcribe_streaming_voice_activity_timeouts(
         project_id,
-        recognizer_id,
         5,
         1,
         os.path.join(RESOURCES, "audio_silence_padding.wav"),
@@ -87,8 +71,4 @@ def test_transcribe_streaming_voice_activity_timeouts(
         r"how old is the Brooklyn Bridge",
         transcript,
         re.DOTALL | re.I,
-    )
-
-    delete_recognizer(
-        f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
     )

--- a/speech/snippets/transcribe_word_level_confidence_v2.py
+++ b/speech/snippets/transcribe_word_level_confidence_v2.py
@@ -33,7 +33,7 @@ def transcribe_word_level_confidence_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
         model="latest_long",
         features=cloud_speech.RecognitionFeatures(

--- a/speech/snippets/transcribe_word_level_confidence_v2.py
+++ b/speech/snippets/transcribe_word_level_confidence_v2.py
@@ -15,12 +15,12 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_transcribe_word_level_confidence_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def transcribe_word_level_confidence_v2(
     project_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
@@ -33,7 +33,12 @@ def quickstart_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config={},
+        language_codes=["en-US"],
+        model="latest_long",
+        features=cloud_speech.RecognitionFeatures(
+            enable_word_confidence=True,
+        ),
     )
 
     request = cloud_speech.RecognizeRequest(
@@ -51,7 +56,7 @@ def quickstart_v2(
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_transcribe_word_level_confidence_v2]
 
 
 if __name__ == "__main__":
@@ -61,4 +66,4 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="GCP Project ID")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    transcribe_word_level_confidence_v2(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_word_level_confidence_v2_test.py
+++ b/speech/snippets/transcribe_word_level_confidence_v2_test.py
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,17 +15,18 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import transcribe_word_level_confidence_v2
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_transcribe_word_level_confidence_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
+    response = transcribe_word_level_confidence_v2.transcribe_word_level_confidence_v2(
         project_id, os.path.join(RESOURCES, "audio.wav")
     )
 
@@ -34,3 +35,4 @@ def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
     )
+    assert response.results[0].alternatives[0].words[0].confidence > 0

--- a/speech/snippets/transcribe_word_level_confidence_v2_test.py
+++ b/speech/snippets/transcribe_word_level_confidence_v2_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import transcribe_word_level_confidence_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_transcribe_word_level_confidence_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_word_level_confidence_v2.transcribe_word_level_confidence_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_word_time_offsets_v2.py
+++ b/speech/snippets/transcribe_word_time_offsets_v2.py
@@ -33,7 +33,7 @@ def transcribe_word_time_offsets_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={},
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
         model="latest_long",
         features=cloud_speech.RecognitionFeatures(

--- a/speech/snippets/transcribe_word_time_offsets_v2.py
+++ b/speech/snippets/transcribe_word_time_offsets_v2.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
 
 import argparse
 
-# [START speech_quickstart_v2]
+# [START speech_transcribe_word_time_offsets_v2]
 from google.cloud.speech_v2 import SpeechClient
 from google.cloud.speech_v2.types import cloud_speech
 
 
-def quickstart_v2(
+def transcribe_word_time_offsets_v2(
     project_id: str,
     audio_file: str,
 ) -> cloud_speech.RecognizeResponse:
@@ -33,7 +33,12 @@ def quickstart_v2(
         content = f.read()
 
     config = cloud_speech.RecognitionConfig(
-        auto_decoding_config={}, language_codes=["en-US"], model="latest_long"
+        auto_decoding_config={},
+        language_codes=["en-US"],
+        model="latest_long",
+        features=cloud_speech.RecognitionFeatures(
+            enable_word_time_offsets=True,
+        ),
     )
 
     request = cloud_speech.RecognizeRequest(
@@ -51,7 +56,7 @@ def quickstart_v2(
     return response
 
 
-# [END speech_quickstart_v2]
+# [END speech_transcribe_word_time_offsets_v2]
 
 
 if __name__ == "__main__":
@@ -61,4 +66,4 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="GCP Project ID")
     parser.add_argument("audio_file", help="Audio file to stream")
     args = parser.parse_args()
-    quickstart_v2(args.project_id, args.audio_file)
+    transcribe_word_time_offsets_v2(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_word_time_offsets_v2_test.py
+++ b/speech/snippets/transcribe_word_time_offsets_v2_test.py
@@ -1,10 +1,10 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,17 +15,18 @@
 import os
 import re
 
-import pytest
+from google.api_core.retry import Retry
 
-import transcribe_file_v2
+import transcribe_word_time_offsets_v2
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
-def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
+@Retry()
+def test_transcribe_word_time_offsets_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    response = transcribe_file_v2.transcribe_file_v2(
+    response = transcribe_word_time_offsets_v2.transcribe_word_time_offsets_v2(
         project_id, os.path.join(RESOURCES, "audio.wav")
     )
 
@@ -34,3 +35,4 @@ def test_transcribe_file_v2(capsys: pytest.CaptureFixture) -> None:
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
     )
+    assert response.results[0].alternatives[0].words[0].end_offset.total_seconds() > 0

--- a/speech/snippets/transcribe_word_time_offsets_v2_test.py
+++ b/speech/snippets/transcribe_word_time_offsets_v2_test.py
@@ -19,7 +19,7 @@ from google.api_core.retry import Retry
 
 import transcribe_word_time_offsets_v2
 
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
@@ -27,7 +27,7 @@ def test_transcribe_word_time_offsets_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_word_time_offsets_v2.transcribe_word_time_offsets_v2(
-        project_id, os.path.join(RESOURCES, "audio.wav")
+        project_id, os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(


### PR DESCRIPTION
## Description

Added samples for:
* Changing STT endpoint location
* Automatic punctuation
* Profanity filter
* Selecting a model
* Multi-channel
* Word level confidence
* Word time offsets
* Chirp

Updated existing samples:
* Added commandline args
* Removed recognizer creation where not needed

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved