### PR TITLE
chore: remove return val from transcribe_streaming

### DIFF
--- a/speech/snippets/transcribe_streaming.py
+++ b/speech/snippets/transcribe_streaming.py
@@ -69,7 +69,6 @@ def transcribe_streaming(stream_file: str) -> speech.RecognitionConfig:
                 print(f"Confidence: {alternative.confidence}")
                 print(f"Transcript: {alternative.transcript}")
 
-    return response
     # [END speech_python_migration_streaming_response]
 
 

--- a/speech/snippets/transcribe_streaming_test.py
+++ b/speech/snippets/transcribe_streaming_test.py
@@ -25,10 +25,9 @@ RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 @Retry()
 def test_transcribe_streaming(capsys: pytest.CaptureFixture) -> None:
-    response = transcribe_streaming.transcribe_streaming(
+    transcribe_streaming.transcribe_streaming(
         os.path.join(RESOURCES, "audio.raw")
     )
-    out, err = capsys.readouterr()
+    out, _ = capsys.readouterr()
 
     assert re.search(r"how old is the Brooklyn Bridge", out, re.DOTALL | re.I)
-    assert response is not None


### PR DESCRIPTION
## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved