### PR TITLE
docs(samples): Update STT samples to use new model names

### DIFF
--- a/speech/snippets/adaptation_v2_custom_class_reference.py
+++ b/speech/snippets/adaptation_v2_custom_class_reference.py
@@ -78,7 +78,7 @@ def adaptation_v2_custom_class_reference(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
-        model="latest_short",
+        model="short",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/adaptation_v2_inline_custom_class.py
+++ b/speech/snippets/adaptation_v2_inline_custom_class.py
@@ -55,7 +55,7 @@ def adaptation_v2_inline_custom_class(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
-        model="latest_short",
+        model="short",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/adaptation_v2_inline_phrase_set.py
+++ b/speech/snippets/adaptation_v2_inline_phrase_set.py
@@ -44,7 +44,7 @@ def adaptation_v2_inline_phrase_set(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
-        model="latest_short",
+        model="short",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/adaptation_v2_phrase_set_reference.py
+++ b/speech/snippets/adaptation_v2_phrase_set_reference.py
@@ -64,7 +64,7 @@ def adaptation_v2_phrase_set_reference(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         adaptation=adaptation,
         language_codes=["en-US"],
-        model="latest_short",
+        model="short",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/change_speech_v2_location.py
+++ b/speech/snippets/change_speech_v2_location.py
@@ -41,7 +41,7 @@ def change_speech_v2_location(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/create_recognizer.py
+++ b/speech/snippets/create_recognizer.py
@@ -28,7 +28,7 @@ def create_recognizer(project_id: str, recognizer_id: str) -> cloud_speech.Recog
         parent=f"projects/{project_id}/locations/global",
         recognizer_id=recognizer_id,
         recognizer=cloud_speech.Recognizer(
-            language_codes=["en-US"], model="latest_long"
+            language_codes=["en-US"], model="long"
         ),
     )
 

--- a/speech/snippets/quickstart_v2.py
+++ b/speech/snippets/quickstart_v2.py
@@ -35,7 +35,7 @@ def quickstart_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/transcribe_auto_punctuation_v2.py
+++ b/speech/snippets/transcribe_auto_punctuation_v2.py
@@ -35,7 +35,7 @@ def transcribe_auto_punctuation_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
         features=cloud_speech.RecognitionFeatures(
             enable_automatic_punctuation=True,
         ),

--- a/speech/snippets/transcribe_file_v2.py
+++ b/speech/snippets/transcribe_file_v2.py
@@ -34,7 +34,7 @@ def transcribe_file_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/transcribe_gcs_v2.py
+++ b/speech/snippets/transcribe_gcs_v2.py
@@ -39,7 +39,7 @@ def transcribe_gcs_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
     )
 
     request = cloud_speech.RecognizeRequest(

--- a/speech/snippets/transcribe_model_selection_v2_test.py
+++ b/speech/snippets/transcribe_model_selection_v2_test.py
@@ -27,7 +27,7 @@ def test_transcribe_model_selection_v2() -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
     response = transcribe_model_selection_v2.transcribe_model_selection_v2(
-        project_id, "latest_long", os.path.join(_RESOURCES, "audio.wav")
+        project_id, "long", os.path.join(_RESOURCES, "audio.wav")
     )
 
     assert re.search(

--- a/speech/snippets/transcribe_multichannel_v2.py
+++ b/speech/snippets/transcribe_multichannel_v2.py
@@ -35,7 +35,7 @@ def transcribe_multichannel_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
         features=cloud_speech.RecognitionFeatures(
             multi_channel_mode=cloud_speech.RecognitionFeatures.MultiChannelMode.SEPARATE_RECOGNITION_PER_CHANNEL,
         ),

--- a/speech/snippets/transcribe_profanity_filter_v2.py
+++ b/speech/snippets/transcribe_profanity_filter_v2.py
@@ -35,7 +35,7 @@ def transcribe_profanity_filter_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
         features=cloud_speech.RecognitionFeatures(
             profanity_filter=True,
         ),

--- a/speech/snippets/transcribe_streaming_v2.py
+++ b/speech/snippets/transcribe_streaming_v2.py
@@ -53,7 +53,7 @@ def transcribe_streaming_v2(
     recognition_config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
     )
     streaming_config = cloud_speech.StreamingRecognitionConfig(
         config=recognition_config

--- a/speech/snippets/transcribe_streaming_voice_activity_events.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_events.py
@@ -52,7 +52,7 @@ def transcribe_streaming_voice_activity_events(
     recognition_config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
     )
 
     # Sets the flag to enable voice activity events

--- a/speech/snippets/transcribe_streaming_voice_activity_timeouts.py
+++ b/speech/snippets/transcribe_streaming_voice_activity_timeouts.py
@@ -60,7 +60,7 @@ def transcribe_streaming_voice_activity_timeouts(
     recognition_config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
     )
 
     # Sets the flag to enable voice activity events and timeout

--- a/speech/snippets/transcribe_word_level_confidence_v2.py
+++ b/speech/snippets/transcribe_word_level_confidence_v2.py
@@ -35,7 +35,7 @@ def transcribe_word_level_confidence_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
         features=cloud_speech.RecognitionFeatures(
             enable_word_confidence=True,
         ),

--- a/speech/snippets/transcribe_word_time_offsets_v2.py
+++ b/speech/snippets/transcribe_word_time_offsets_v2.py
@@ -35,7 +35,7 @@ def transcribe_word_time_offsets_v2(
     config = cloud_speech.RecognitionConfig(
         auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
         language_codes=["en-US"],
-        model="latest_long",
+        model="long",
         features=cloud_speech.RecognitionFeatures(
             enable_word_time_offsets=True,
         ),


### PR DESCRIPTION
## Description

Update STT samples to use new model names:
latest_long --> long
latest_short --> short

old model names are still working and available.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved