### PR TITLE
fix(firestore): update query samples to use FieldFilter

### DIFF
--- a/firestore/cloud-async-client/snippets.py
+++ b/firestore/cloud-async-client/snippets.py
@@ -14,6 +14,7 @@
 import datetime
 
 from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
 
 
 async def quickstart_new_instance():
@@ -233,7 +234,7 @@ async def get_simple_query():
     db = firestore.AsyncClient()
     # [START firestore_data_query_async]
     # Note: Use of CollectionRef stream() is prefered to get()
-    docs = db.collection("cities").where("capital", "==", True).stream()
+    docs = db.collection("cities").where(filter=FieldFilter("capital", "==", True)).stream()
 
     async for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -245,7 +246,7 @@ async def array_contains_filter():
     # [START firestore_query_filter_array_contains_async]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("regions", "array_contains", "west_coast")
+    query = cities_ref.where(filter=FieldFilter("regions", "array_contains", "west_coast"))
     # [END firestore_query_filter_array_contains_async]
     docs = query.stream()
     async for doc in docs:
@@ -445,7 +446,7 @@ async def compound_query_example():
     cities_ref = db.collection("cities")
 
     # Create a query against the collection
-    query_ref = cities_ref.where("state", "==", "CA")
+    query_ref = cities_ref.where(filter=FieldFilter("state", "==", "CA"))
     # [END firestore_query_filter_eq_string_async]
 
     return query_ref
@@ -456,7 +457,7 @@ async def compound_query_simple():
     # [START firestore_query_filter_eq_boolean_async]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("capital", "==", True)
+    query = cities_ref.where(filter=FieldFilter("capital", "==", True))
     # [END firestore_query_filter_eq_boolean_async]
 
     print(query)
@@ -467,9 +468,9 @@ async def compound_query_single_clause():
     # [START firestore_query_filter_single_examples_async]
     cities_ref = db.collection("cities")
 
-    cities_ref.where("state", "==", "CA")
-    cities_ref.where("population", "<", 1000000)
-    cities_ref.where("name", ">=", "San Francisco")
+    cities_ref.where(filter=FieldFilter("state", "==", "CA"))
+    cities_ref.where(filter=FieldFilter("population", "<", 1000000))
+    cities_ref.where(filter=FieldFilter("name", ">=", "San Francisco"))
     # [END firestore_query_filter_single_examples_async]
 
 
@@ -478,9 +479,9 @@ async def compound_query_valid_multi_clause():
     # [START firestore_query_filter_compound_multi_eq_async]
     cities_ref = db.collection("cities")
 
-    denver_query = cities_ref.where("state", "==", "CO").where("name", "==", "Denver")
-    large_us_cities_query = cities_ref.where("state", "==", "CA").where(
-        "population", ">", 1000000
+    denver_query = cities_ref.where(filter=FieldFilter("state", "==", "CO")).where(filter=FieldFilter("name", "==", "Denver"))
+    large_us_cities_query = cities_ref.where(filter=FieldFilter("state", "==", "CA")).where(
+        filter=FieldFilter("population", ">", 1000000)
     )
     # [END firestore_query_filter_compound_multi_eq_async]
     print(denver_query)
@@ -491,7 +492,7 @@ async def compound_query_valid_single_field():
     db = firestore.AsyncClient()
     # [START firestore_query_filter_range_valid_async]
     cities_ref = db.collection("cities")
-    cities_ref.where("state", ">=", "CA").where("state", "<=", "IN")
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("state", "<=", "IN"))
     # [END firestore_query_filter_range_valid_async]
 
 
@@ -499,7 +500,7 @@ async def compound_query_invalid_multi_field():
     db = firestore.AsyncClient()
     # [START firestore_query_filter_range_invalid_async]
     cities_ref = db.collection("cities")
-    cities_ref.where("state", ">=", "CA").where("population", ">=", 1000000)
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("population", ">=", 1000000))
     # [END firestore_query_filter_range_invalid_async]
 
 
@@ -534,7 +535,7 @@ async def order_where_limit():
     db = firestore.AsyncClient()
     # [START firestore_query_order_limit_field_valid_async]
     cities_ref = db.collection("cities")
-    query = cities_ref.where("population", ">", 2500000).order_by("population").limit(2)
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population").limit(2)
     results = query.stream()
     # [END firestore_query_order_limit_field_valid_async]
     print([d async for d in results])
@@ -554,7 +555,7 @@ async def order_where_valid():
     db = firestore.AsyncClient()
     # [START firestore_query_order_with_filter_async]
     cities_ref = db.collection("cities")
-    query = cities_ref.where("population", ">", 2500000).order_by("population")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population")
     results = query.stream()
     # [END firestore_query_order_with_filter_async]
     print([d async for d in results])
@@ -564,7 +565,7 @@ async def order_where_invalid():
     db = firestore.AsyncClient()
     # [START firestore_query_order_field_invalid_async]
     cities_ref = db.collection("cities")
-    query = cities_ref.where("population", ">", 2500000).order_by("country")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("country")
     results = query.stream()
     # [END firestore_query_order_field_invalid_async]
     print(results)
@@ -720,7 +721,7 @@ async def collection_group_query(db):
     # [END firestore_query_collection_group_dataset_async]
 
     # [START firestore_query_collection_group_filter_eq_async]
-    museums = db.collection_group("landmarks").where("type", "==", "museum")
+    museums = db.collection_group("landmarks").where(filter=FieldFilter("type", "==", "museum"))
     docs = museums.stream()
     async for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -733,7 +734,7 @@ async def array_contains_any_queries(db):
     cities_ref = db.collection("cities")
 
     query = cities_ref.where(
-        "regions", "array_contains_any", ["west_coast", "east_coast"]
+        filter=FieldFilter("regions", "array_contains_any", ["west_coast", "east_coast"])
     )
     return query
     # [END firestore_query_filter_array_contains_any_async]
@@ -743,7 +744,7 @@ async def in_query_without_array(db):
     # [START firestore_query_filter_in_async]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("country", "in", ["USA", "Japan"])
+    query = cities_ref.where(filter=FieldFilter("country", "in", ["USA", "Japan"]))
     return query
     # [END firestore_query_filter_in_async]
 
@@ -752,7 +753,7 @@ async def in_query_with_array(db):
     # [START firestore_query_filter_in_with_array_async]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("regions", "in", [["west_coast"], ["east_coast"]])
+    query = cities_ref.where(filter=FieldFilter("regions", "in", [["west_coast"], ["east_coast"]]))
     return query
     # [END firestore_query_filter_in_with_array_async]
 

--- a/firestore/cloud-async-client/snippets.py
+++ b/firestore/cloud-async-client/snippets.py
@@ -234,7 +234,11 @@ async def get_simple_query():
     db = firestore.AsyncClient()
     # [START firestore_data_query_async]
     # Note: Use of CollectionRef stream() is prefered to get()
-    docs = db.collection("cities").where(filter=FieldFilter("capital", "==", True)).stream()
+    docs = (
+        db.collection("cities")
+        .where(filter=FieldFilter("capital", "==", True))
+        .stream()
+    )
 
     async for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -246,7 +250,9 @@ async def array_contains_filter():
     # [START firestore_query_filter_array_contains_async]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where(filter=FieldFilter("regions", "array_contains", "west_coast"))
+    query = cities_ref.where(
+        filter=FieldFilter("regions", "array_contains", "west_coast")
+    )
     # [END firestore_query_filter_array_contains_async]
     docs = query.stream()
     async for doc in docs:
@@ -479,10 +485,12 @@ async def compound_query_valid_multi_clause():
     # [START firestore_query_filter_compound_multi_eq_async]
     cities_ref = db.collection("cities")
 
-    denver_query = cities_ref.where(filter=FieldFilter("state", "==", "CO")).where(filter=FieldFilter("name", "==", "Denver"))
-    large_us_cities_query = cities_ref.where(filter=FieldFilter("state", "==", "CA")).where(
-        filter=FieldFilter("population", ">", 1000000)
+    denver_query = cities_ref.where(filter=FieldFilter("state", "==", "CO")).where(
+        filter=FieldFilter("name", "==", "Denver")
     )
+    large_us_cities_query = cities_ref.where(
+        filter=FieldFilter("state", "==", "CA")
+    ).where(filter=FieldFilter("population", ">", 1000000))
     # [END firestore_query_filter_compound_multi_eq_async]
     print(denver_query)
     print(large_us_cities_query)
@@ -492,7 +500,9 @@ async def compound_query_valid_single_field():
     db = firestore.AsyncClient()
     # [START firestore_query_filter_range_valid_async]
     cities_ref = db.collection("cities")
-    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("state", "<=", "IN"))
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(
+        filter=FieldFilter("state", "<=", "IN")
+    )
     # [END firestore_query_filter_range_valid_async]
 
 
@@ -500,7 +510,9 @@ async def compound_query_invalid_multi_field():
     db = firestore.AsyncClient()
     # [START firestore_query_filter_range_invalid_async]
     cities_ref = db.collection("cities")
-    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("population", ">=", 1000000))
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(
+        filter=FieldFilter("population", ">=", 1000000)
+    )
     # [END firestore_query_filter_range_invalid_async]
 
 
@@ -535,7 +547,11 @@ async def order_where_limit():
     db = firestore.AsyncClient()
     # [START firestore_query_order_limit_field_valid_async]
     cities_ref = db.collection("cities")
-    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population").limit(2)
+    query = (
+        cities_ref.where(filter=FieldFilter("population", ">", 2500000))
+        .order_by("population")
+        .limit(2)
+    )
     results = query.stream()
     # [END firestore_query_order_limit_field_valid_async]
     print([d async for d in results])
@@ -555,7 +571,9 @@ async def order_where_valid():
     db = firestore.AsyncClient()
     # [START firestore_query_order_with_filter_async]
     cities_ref = db.collection("cities")
-    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by(
+        "population"
+    )
     results = query.stream()
     # [END firestore_query_order_with_filter_async]
     print([d async for d in results])
@@ -565,7 +583,9 @@ async def order_where_invalid():
     db = firestore.AsyncClient()
     # [START firestore_query_order_field_invalid_async]
     cities_ref = db.collection("cities")
-    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("country")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by(
+        "country"
+    )
     results = query.stream()
     # [END firestore_query_order_field_invalid_async]
     print(results)
@@ -721,7 +741,9 @@ async def collection_group_query(db):
     # [END firestore_query_collection_group_dataset_async]
 
     # [START firestore_query_collection_group_filter_eq_async]
-    museums = db.collection_group("landmarks").where(filter=FieldFilter("type", "==", "museum"))
+    museums = db.collection_group("landmarks").where(
+        filter=FieldFilter("type", "==", "museum")
+    )
     docs = museums.stream()
     async for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -734,7 +756,9 @@ async def array_contains_any_queries(db):
     cities_ref = db.collection("cities")
 
     query = cities_ref.where(
-        filter=FieldFilter("regions", "array_contains_any", ["west_coast", "east_coast"])
+        filter=FieldFilter(
+            "regions", "array_contains_any", ["west_coast", "east_coast"]
+        )
     )
     return query
     # [END firestore_query_filter_array_contains_any_async]
@@ -753,7 +777,9 @@ async def in_query_with_array(db):
     # [START firestore_query_filter_in_with_array_async]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where(filter=FieldFilter("regions", "in", [["west_coast"], ["east_coast"]]))
+    query = cities_ref.where(
+        filter=FieldFilter("regions", "in", [["west_coast"], ["east_coast"]])
+    )
     return query
     # [END firestore_query_filter_in_with_array_async]
 

--- a/firestore/cloud-client/aggregate_query_count.py
+++ b/firestore/cloud-client/aggregate_query_count.py
@@ -21,6 +21,7 @@ See https://cloud.google.com/python/docs/reference/firestore/latest before runni
 # [START firestore_count_query]
 from google.cloud import firestore
 from google.cloud.firestore_v1 import aggregation
+from google.cloud.firestore_v1.base_query import FieldFilter
 
 
 def create_count_query(project_id: str) -> None:
@@ -32,7 +33,7 @@ def create_count_query(project_id: str) -> None:
     client = firestore.Client(project=project_id)
 
     collection_ref = client.collection("users")
-    query = collection_ref.where("born", ">", 1800)
+    query = collection_ref.where(filter=FieldFilter("born", ">", 1800))
     aggregate_query = aggregation.AggregationQuery(query)
 
     # `alias` to provides a key for accessing the aggregate query results

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -18,6 +18,7 @@ from time import sleep
 
 from google.api_core.client_options import ClientOptions
 from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
 
 
 def quickstart_new_instance():
@@ -238,7 +239,7 @@ def get_simple_query():
     db = firestore.Client()
     # [START firestore_data_query]
     # Note: Use of CollectionRef stream() is prefered to get()
-    docs = db.collection("cities").where("capital", "==", True).stream()
+    docs = db.collection("cities").where(filter=FieldFilter("capital", "==", True)).stream()
 
     for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -250,7 +251,7 @@ def array_contains_filter():
     # [START firestore_query_filter_array_contains]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("regions", "array_contains", "west_coast")
+    query = cities_ref.where(filter=FieldFilter("regions", "array_contains", "west_coast"))
     # [END firestore_query_filter_array_contains]
     docs = query.stream()
     for doc in docs:
@@ -451,7 +452,7 @@ def compound_query_example():
     cities_ref = db.collection("cities")
 
     # Create a query against the collection
-    query_ref = cities_ref.where("state", "==", "CA")
+    query_ref = cities_ref.where(filter=FieldFilter("state", "==", "CA"))
     # [END firestore_query_filter_eq_string]
 
     return query_ref
@@ -462,7 +463,7 @@ def compound_query_simple():
     # [START firestore_query_filter_eq_boolean]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("capital", "==", True)
+    query = cities_ref.where(filter=FieldFilter("capital", "==", True))
     # [END firestore_query_filter_eq_boolean]
 
     print(query)
@@ -473,9 +474,9 @@ def compound_query_single_clause():
     # [START firestore_query_filter_single_examples]
     cities_ref = db.collection("cities")
 
-    cities_ref.where("state", "==", "CA")
-    cities_ref.where("population", "<", 1000000)
-    cities_ref.where("name", ">=", "San Francisco")
+    cities_ref.where(filter=FieldFilter("state", "==", "CA"))
+    cities_ref.where(filter=FieldFilter("population", "<", 1000000))
+    cities_ref.where(filter=FieldFilter("name", ">=", "San Francisco"))
     # [END firestore_query_filter_single_examples]
 
 
@@ -484,10 +485,10 @@ def compound_query_valid_multi_clause():
     # [START firestore_query_filter_compound_multi_eq]
     cities_ref = db.collection("cities")
 
-    denver_query = cities_ref.where("state", "==", "CO").where("name", "==", "Denver")
-    large_us_cities_query = cities_ref.where("state", "==", "CA").where(
-        "population", ">", 1000000
-    )
+    denver_query = cities_ref.where(filter=FieldFilter("state", "==", "CO")).where(filter=FieldFilter("name", "==", "Denver"))
+    large_us_cities_query = cities_ref.where(filter=FieldFilter("state", "==", "CA")).where(
+        filter=FieldFilter("population", ">", 1000000
+    ))
     # [END firestore_query_filter_compound_multi_eq]
     print(denver_query)
     print(large_us_cities_query)
@@ -497,7 +498,7 @@ def compound_query_valid_single_field():
     db = firestore.Client()
     # [START firestore_query_filter_range_valid]
     cities_ref = db.collection("cities")
-    cities_ref.where("state", ">=", "CA").where("state", "<=", "IN")
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("state", "<=", "IN"))
     # [END firestore_query_filter_range_valid]
 
 
@@ -505,7 +506,7 @@ def compound_query_invalid_multi_field():
     db = firestore.Client()
     # [START firestore_query_filter_range_invalid]
     cities_ref = db.collection("cities")
-    cities_ref.where("state", ">=", "CA").where("population", ">=", 1000000)
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("population", ">=", 1000000))
     # [END firestore_query_filter_range_invalid]
 
 
@@ -540,7 +541,7 @@ def order_where_limit():
     db = firestore.Client()
     # [START firestore_query_order_limit_field_valid]
     cities_ref = db.collection("cities")
-    query = cities_ref.where("population", ">", 2500000).order_by("population").limit(2)
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population").limit(2)
     results = query.stream()
     # [END firestore_query_order_limit_field_valid]
     print(results)
@@ -560,7 +561,7 @@ def order_where_valid():
     db = firestore.Client()
     # [START firestore_query_order_with_filter]
     cities_ref = db.collection("cities")
-    query = cities_ref.where("population", ">", 2500000).order_by("population")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population")
     results = query.stream()
     # [END firestore_query_order_with_filter]
     print(results)
@@ -570,7 +571,7 @@ def order_where_invalid():
     db = firestore.Client()
     # [START firestore_query_order_field_invalid]
     cities_ref = db.collection("cities")
-    query = cities_ref.where("population", ">", 2500000).order_by("country")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("country")
     results = query.stream()
     # [END firestore_query_order_field_invalid]
     print(results)
@@ -689,7 +690,7 @@ def listen_multiple():
             print(f"{doc.id}")
         callback_done.set()
 
-    col_query = db.collection("cities").where("state", "==", "CA")
+    col_query = db.collection("cities").where(filter=FieldFilter("state", "==", "CA"))
 
     # Watch the collection query
     query_watch = col_query.on_snapshot(on_snapshot)
@@ -729,7 +730,7 @@ def listen_for_changes():
                 print(f"Removed city: {change.document.id}")
                 delete_done.set()
 
-    col_query = db.collection("cities").where("state", "==", "CA")
+    col_query = db.collection("cities").where(filter=FieldFilter("state", "==", "CA"))
 
     # Watch the collection query
     query_watch = col_query.on_snapshot(on_snapshot)
@@ -853,7 +854,7 @@ def collection_group_query(db):
     # [END firestore_query_collection_group_dataset]
 
     # [START firestore_query_collection_group_filter_eq]
-    museums = db.collection_group("landmarks").where("type", "==", "museum")
+    museums = db.collection_group("landmarks").where(filter=FieldFilter("type", "==", "museum"))
     docs = museums.stream()
     for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -866,8 +867,8 @@ def array_contains_any_queries(db):
     cities_ref = db.collection("cities")
 
     query = cities_ref.where(
-        "regions", "array_contains_any", ["west_coast", "east_coast"]
-    )
+        filter=FieldFilter("regions", "array_contains_any", ["west_coast", "east_coast"]
+    ))
     return query
     # [END firestore_query_filter_array_contains_any]
 
@@ -876,7 +877,7 @@ def in_query_without_array(db):
     # [START firestore_query_filter_in]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("country", "in", ["USA", "Japan"])
+    query = cities_ref.where(filter=FieldFilter("country", "in", ["USA", "Japan"]))
     return query
     # [END firestore_query_filter_in]
 
@@ -885,7 +886,7 @@ def in_query_with_array(db):
     # [START firestore_query_filter_in_with_array]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where("regions", "in", [["west_coast"], ["east_coast"]])
+    query = cities_ref.where(filter=FieldFilter("regions", "in", [["west_coast"], ["east_coast"]]))
     return query
     # [END firestore_query_filter_in_with_array]
 

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -239,7 +239,11 @@ def get_simple_query():
     db = firestore.Client()
     # [START firestore_data_query]
     # Note: Use of CollectionRef stream() is prefered to get()
-    docs = db.collection("cities").where(filter=FieldFilter("capital", "==", True)).stream()
+    docs = (
+        db.collection("cities")
+        .where(filter=FieldFilter("capital", "==", True))
+        .stream()
+    )
 
     for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -251,7 +255,9 @@ def array_contains_filter():
     # [START firestore_query_filter_array_contains]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where(filter=FieldFilter("regions", "array_contains", "west_coast"))
+    query = cities_ref.where(
+        filter=FieldFilter("regions", "array_contains", "west_coast")
+    )
     # [END firestore_query_filter_array_contains]
     docs = query.stream()
     for doc in docs:
@@ -485,10 +491,12 @@ def compound_query_valid_multi_clause():
     # [START firestore_query_filter_compound_multi_eq]
     cities_ref = db.collection("cities")
 
-    denver_query = cities_ref.where(filter=FieldFilter("state", "==", "CO")).where(filter=FieldFilter("name", "==", "Denver"))
-    large_us_cities_query = cities_ref.where(filter=FieldFilter("state", "==", "CA")).where(
-        filter=FieldFilter("population", ">", 1000000)
+    denver_query = cities_ref.where(filter=FieldFilter("state", "==", "CO")).where(
+        filter=FieldFilter("name", "==", "Denver")
     )
+    large_us_cities_query = cities_ref.where(
+        filter=FieldFilter("state", "==", "CA")
+    ).where(filter=FieldFilter("population", ">", 1000000))
     # [END firestore_query_filter_compound_multi_eq]
     print(denver_query)
     print(large_us_cities_query)
@@ -498,7 +506,9 @@ def compound_query_valid_single_field():
     db = firestore.Client()
     # [START firestore_query_filter_range_valid]
     cities_ref = db.collection("cities")
-    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("state", "<=", "IN"))
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(
+        filter=FieldFilter("state", "<=", "IN")
+    )
     # [END firestore_query_filter_range_valid]
 
 
@@ -506,7 +516,9 @@ def compound_query_invalid_multi_field():
     db = firestore.Client()
     # [START firestore_query_filter_range_invalid]
     cities_ref = db.collection("cities")
-    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(filter=FieldFilter("population", ">=", 1000000))
+    cities_ref.where(filter=FieldFilter("state", ">=", "CA")).where(
+        filter=FieldFilter("population", ">=", 1000000)
+    )
     # [END firestore_query_filter_range_invalid]
 
 
@@ -541,7 +553,11 @@ def order_where_limit():
     db = firestore.Client()
     # [START firestore_query_order_limit_field_valid]
     cities_ref = db.collection("cities")
-    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population").limit(2)
+    query = (
+        cities_ref.where(filter=FieldFilter("population", ">", 2500000))
+        .order_by("population")
+        .limit(2)
+    )
     results = query.stream()
     # [END firestore_query_order_limit_field_valid]
     print(results)
@@ -561,7 +577,9 @@ def order_where_valid():
     db = firestore.Client()
     # [START firestore_query_order_with_filter]
     cities_ref = db.collection("cities")
-    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("population")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by(
+        "population"
+    )
     results = query.stream()
     # [END firestore_query_order_with_filter]
     print(results)
@@ -571,7 +589,9 @@ def order_where_invalid():
     db = firestore.Client()
     # [START firestore_query_order_field_invalid]
     cities_ref = db.collection("cities")
-    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by("country")
+    query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by(
+        "country"
+    )
     results = query.stream()
     # [END firestore_query_order_field_invalid]
     print(results)
@@ -854,7 +874,9 @@ def collection_group_query(db):
     # [END firestore_query_collection_group_dataset]
 
     # [START firestore_query_collection_group_filter_eq]
-    museums = db.collection_group("landmarks").where(filter=FieldFilter("type", "==", "museum"))
+    museums = db.collection_group("landmarks").where(
+        filter=FieldFilter("type", "==", "museum")
+    )
     docs = museums.stream()
     for doc in docs:
         print(f"{doc.id} => {doc.to_dict()}")
@@ -867,8 +889,10 @@ def array_contains_any_queries(db):
     cities_ref = db.collection("cities")
 
     query = cities_ref.where(
-        filter=FieldFilter("regions", "array_contains_any", ["west_coast", "east_coast"]
-    ))
+        filter=FieldFilter(
+            "regions", "array_contains_any", ["west_coast", "east_coast"]
+        )
+    )
     return query
     # [END firestore_query_filter_array_contains_any]
 
@@ -886,7 +910,9 @@ def in_query_with_array(db):
     # [START firestore_query_filter_in_with_array]
     cities_ref = db.collection("cities")
 
-    query = cities_ref.where(filter=FieldFilter("regions", "in", [["west_coast"], ["east_coast"]]))
+    query = cities_ref.where(
+        filter=FieldFilter("regions", "in", [["west_coast"], ["east_coast"]])
+    )
     return query
     # [END firestore_query_filter_in_with_array]
 

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -487,8 +487,8 @@ def compound_query_valid_multi_clause():
 
     denver_query = cities_ref.where(filter=FieldFilter("state", "==", "CO")).where(filter=FieldFilter("name", "==", "Denver"))
     large_us_cities_query = cities_ref.where(filter=FieldFilter("state", "==", "CA")).where(
-        filter=FieldFilter("population", ">", 1000000
-    ))
+        filter=FieldFilter("population", ">", 1000000)
+    )
     # [END firestore_query_filter_compound_multi_eq]
     print(denver_query)
     print(large_us_cities_query)


### PR DESCRIPTION
## Description
Update the samples which currently show the following warnings:
```
UserWarning: Detected filter using positional arguments. Prefer using the 'filter' keyword argument instead.
    cities_ref.where("state", ">=", "CA").where("state", "<=", "IN")
```

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved