### PR TITLE
fix: add ServiceUnavailable to retry

### DIFF
--- a/asset/snippets/conftest.py
+++ b/asset/snippets/conftest.py
@@ -18,8 +18,7 @@ import os
 import uuid
 
 import backoff
-from google.api_core.exceptions import InternalServerError
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import InternalServerError, NotFound, ServiceUnavailable
 from google.cloud import pubsub_v1
 import pytest
 
@@ -63,7 +62,9 @@ def test_feed(test_topic):
     feed_id = f"feed-{uuid.uuid4().hex}"
     asset_name = f"assets-{uuid.uuid4().hex}"
 
-    @backoff.on_exception(backoff.expo, InternalServerError, max_time=60)
+    @backoff.on_exception(
+        backoff.expo, (InternalServerError, ServiceUnavailable), max_time=60
+    )
     def create_feed():
         return quickstart_createfeed.create_feed(
             PROJECT,


### PR DESCRIPTION
## Description

I think that this might fix 10406 if the serviceunavailable error is actually flaky - otherwise, lmk if there's a better way to do this

Fixes #10406 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved