### PR TITLE
docs(samples): Improve output in create_migration_workflow.py sample

### DIFF
--- a/bigquery-migration/snippets/create_migration_workflow.py
+++ b/bigquery-migration/snippets/create_migration_workflow.py
@@ -67,7 +67,7 @@ def create_migration_workflow(
     print("Created workflow:")
     print(response.display_name)
     print("Current state:")
-    print(response.State(response.state))
+    print(response.State(response.state).Name)
 
 
 # [END bigquery_migration_create_workflow]


### PR DESCRIPTION
After casting response.state from a number type to Enum type cannot make it readable. Better to use name of Enum instead.

Copy from https://github.com/googleapis/python-bigquery-migration/pull/181

