### PR TITLE
Minor Python fix

### DIFF
--- a/cloud-sql/postgres/sqlalchemy/connect_tcp.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_tcp.py
@@ -22,7 +22,7 @@ import ssl
 import sqlalchemy
 
 
-def connect_tcp_socket() -> sqlalchemy.engine.base.Engine:
+def connect_tcp_socket(self) -> sqlalchemy.engine.base.Engine:
     """Initializes a TCP connection pool for a Cloud SQL instance of Postgres."""
     # Note: Saving credentials in environment variables is convenient, but not
     # secure - consider a more secure solution such as


### PR DESCRIPTION
## Description

When following this Python code sample from the Cloud Functions GCP documentation [1], I observed this error message when it was running on Cloud Functions [2].

This situation seems to occur when Python sends, automatically and by default, the self argument to the function even though the function was not expecting any parameter as input when invoked. To fix this issue, adding 'self' to the function 'connect_tcp_socket()' should fix the issue (e.g. cloud_tcp_docket(self)).    


[1]
https://cloud.google.com/sql/docs/postgres/connect-functions#private-ip:~:text=SQL%20Auth%20Proxy.-,Connect%20with%20TCP,-Connect%20using%20the

[2]
TypeError: connect_tcp_socket() takes 0 positional arguments but 1 was
given"