### PR TITLE
docs(samples): More STT v2 samples

### DIFF
--- a/speech/snippets/create_recognizer_test.py
+++ b/speech/snippets/create_recognizer_test.py
@@ -31,10 +31,19 @@ def delete_recognizer(name: str) -> None:
 
 
 @Retry()
-def test_create_recognizer(capsys: pytest.CaptureFixture) -> None:
+def test_create_recognizer(
+    capsys: pytest.CaptureFixture, request: pytest.FixtureRequest
+) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+    recognizer_id = "recognizer-" + str(uuid4())
 
-    recognizer = create_recognizer.create_recognizer(
-        project_id, "recognizer-" + str(uuid4())
-    )
-    delete_recognizer(recognizer.name)
+    def cleanup():
+        delete_recognizer(
+            f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
+        )
+
+    request.addfinalizer(cleanup)
+
+    recognizer = create_recognizer.create_recognizer(project_id, recognizer_id)
+
+    assert recognizer_id in recognizer.name

--- a/speech/snippets/enable_cmek_test.py
+++ b/speech/snippets/enable_cmek_test.py
@@ -1,10 +1,10 @@
-# Copyright 2017 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,19 +13,19 @@
 # limitations under the License.
 
 import os
-import re
 
 from google.api_core.retry import Retry
-import pytest
 
-import transcribe_streaming
-
-RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+import enable_cmek
 
 
 @Retry()
-def test_transcribe_streaming(capsys: pytest.CaptureFixture) -> None:
-    transcribe_streaming.transcribe_streaming(os.path.join(RESOURCES, "audio.raw"))
-    out, _ = capsys.readouterr()
+def test_enable_cmek() -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    assert re.search(r"how old is the Brooklyn Bridge", out, re.DOTALL | re.I)
+    response = enable_cmek.enable_cmek(
+        project_id,
+        "",
+    )
+
+    assert response.kms_key_name == ""

--- a/speech/snippets/transcribe_batch_dynamic_batching_v2.py
+++ b/speech/snippets/transcribe_batch_dynamic_batching_v2.py
@@ -27,7 +27,7 @@ def transcribe_batch_dynamic_batching_v2(
     """Transcribes audio from a Google Cloud Storage URI.
 
     Args:
-        project_id: The GCP project ID.
+        project_id: The Google Cloud project ID.
         gcs_uri: The Google Cloud Storage URI.
 
     Returns:

--- a/speech/snippets/transcribe_batch_dynamic_batching_v2.py
+++ b/speech/snippets/transcribe_batch_dynamic_batching_v2.py
@@ -1,0 +1,79 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_batch_dynamic_batching_v2]
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+
+def transcribe_batch_dynamic_batching_v2(
+    project_id: str,
+    gcs_uri: str,
+) -> cloud_speech.BatchRecognizeResults:
+    """Transcribes audio from a Google Cloud Storage URI.
+
+    Args:
+        project_id: The GCP project ID.
+        gcs_uri: The Google Cloud Storage URI.
+
+    Returns:
+        The RecognizeResponse.
+    """
+    # Instantiates a client
+    client = SpeechClient()
+
+    config = cloud_speech.RecognitionConfig(
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="long",
+    )
+
+    file_metadata = cloud_speech.BatchRecognizeFileMetadata(uri=gcs_uri)
+
+    request = cloud_speech.BatchRecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        files=[file_metadata],
+        recognition_output_config=cloud_speech.RecognitionOutputConfig(
+            inline_response_config=cloud_speech.InlineOutputConfig(),
+        ),
+        processing_strategy=cloud_speech.BatchRecognizeRequest.ProcessingStrategy.DYNAMIC_BATCHING,
+    )
+
+    # Transcribes the audio into text
+    operation = client.batch_recognize(request=request)
+
+    print("Waiting for operation to complete...")
+    response = operation.result(timeout=120)
+
+    for result in response.results[gcs_uri].transcript.results:
+        print(f"Transcript: {result.alternatives[0].transcript}")
+
+    return response.results[gcs_uri].transcript
+
+
+# [END speech_transcribe_batch_dynamic_batching_v2]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("gcs_uri", help="URI to GCS file")
+    args = parser.parse_args()
+    transcribe_batch_dynamic_batching_v2(args.project_id, args.gcs_uri)

--- a/speech/snippets/transcribe_batch_dynamic_batching_v2_test.py
+++ b/speech/snippets/transcribe_batch_dynamic_batching_v2_test.py
@@ -1,0 +1,44 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+from flaky import flaky
+
+import pytest
+
+import transcribe_batch_dynamic_batching_v2
+
+
+_TEST_AUDIO_FILE_PATH = "gs://cloud-samples-data/speech/audio.flac"
+
+
+@flaky(max_runs=10, min_passes=1)
+def test_transcribe_batch_dynamic_batching_v2(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+    response = (
+        transcribe_batch_dynamic_batching_v2.transcribe_batch_dynamic_batching_v2(
+            project_id, _TEST_AUDIO_FILE_PATH
+        )
+    )
+
+    assert re.search(
+        r"how old is the Brooklyn Bridge",
+        response.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )

--- a/speech/snippets/transcribe_batch_gcs_input_gcs_output_v2.py
+++ b/speech/snippets/transcribe_batch_gcs_input_gcs_output_v2.py
@@ -31,7 +31,7 @@ def transcribe_batch_gcs_input_gcs_output_v2(
     """Transcribes audio from a Google Cloud Storage URI.
 
     Args:
-        project_id: The GCP project ID.
+        project_id: The Google Cloud project ID.
         gcs_uri: The Google Cloud Storage URI.
         gcs_output_path: The Cloud Storage URI to which to write the transcript.
 

--- a/speech/snippets/transcribe_batch_gcs_input_gcs_output_v2.py
+++ b/speech/snippets/transcribe_batch_gcs_input_gcs_output_v2.py
@@ -1,0 +1,108 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_batch_gcs_input_gcs_output_v2]
+import re
+
+from google.cloud import storage
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+
+def transcribe_batch_gcs_input_gcs_output_v2(
+    project_id: str,
+    gcs_uri: str,
+    gcs_output_path: str,
+) -> cloud_speech.BatchRecognizeResults:
+    """Transcribes audio from a Google Cloud Storage URI.
+
+    Args:
+        project_id: The GCP project ID.
+        gcs_uri: The Google Cloud Storage URI.
+        gcs_output_path: The Cloud Storage URI to which to write the transcript.
+
+    Returns:
+        The BatchRecognizeResults message.
+    """
+    # Instantiates a client
+    client = SpeechClient()
+
+    config = cloud_speech.RecognitionConfig(
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="long",
+    )
+
+    file_metadata = cloud_speech.BatchRecognizeFileMetadata(uri=gcs_uri)
+
+    request = cloud_speech.BatchRecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        files=[file_metadata],
+        recognition_output_config=cloud_speech.RecognitionOutputConfig(
+            gcs_output_config=cloud_speech.GcsOutputConfig(
+                uri=gcs_output_path,
+            ),
+        ),
+    )
+
+    # Transcribes the audio into text
+    operation = client.batch_recognize(request=request)
+
+    print("Waiting for operation to complete...")
+    response = operation.result(timeout=120)
+
+    file_results = response.results[gcs_uri]
+
+    print(f"Operation finished. Fetching results from {file_results.uri}...")
+    output_bucket, output_object = re.match(
+        r"gs://([^/]+)/(.*)", file_results.uri
+    ).group(1, 2)
+
+    # Instantiates a Cloud Storage client
+    storage_client = storage.Client()
+
+    # Fetch results from Cloud Storage
+    bucket = storage_client.bucket(output_bucket)
+    blob = bucket.blob(output_object)
+    results_bytes = blob.download_as_bytes()
+    batch_recognize_results = cloud_speech.BatchRecognizeResults.from_json(
+        results_bytes, ignore_unknown_fields=True
+    )
+
+    for result in batch_recognize_results.results:
+        print(f"Transcript: {result.alternatives[0].transcript}")
+
+    return batch_recognize_results
+
+
+# [END speech_transcribe_batch_gcs_input_gcs_output_v2]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("gcs_uri", help="URI to GCS file")
+    parser.add_argument(
+        "gcs_output_path", help="GCS URI to which to write the transcript"
+    )
+    args = parser.parse_args()
+    transcribe_batch_gcs_input_gcs_output_v2(
+        args.project_id, args.gcs_uri, args.gcs_output_path
+    )

--- a/speech/snippets/transcribe_batch_gcs_input_gcs_output_v2_test.py
+++ b/speech/snippets/transcribe_batch_gcs_input_gcs_output_v2_test.py
@@ -1,0 +1,61 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from uuid import uuid4
+
+from flaky import flaky
+from google.cloud import storage
+
+import pytest
+
+import transcribe_batch_gcs_input_gcs_output_v2
+
+
+_TEST_AUDIO_FILE_PATH = "gs://cloud-samples-data/speech/audio.flac"
+
+
+def create_gcs_bucket() -> str:
+    client = storage.Client()
+    bucket = client.bucket("speech-samples-" + str(uuid4()))
+    new_bucket = client.create_bucket(bucket, location="us")
+    return new_bucket.name
+
+
+def delete_gcs_bucket(bucket_name: str) -> None:
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    bucket.delete(force=True)
+
+
+@flaky(max_runs=10, min_passes=1)
+def test_transcribe_batch_gcs_input_gcs_output_v2(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+    bucket_name = create_gcs_bucket()
+
+    response = transcribe_batch_gcs_input_gcs_output_v2.transcribe_batch_gcs_input_gcs_output_v2(
+        project_id, _TEST_AUDIO_FILE_PATH, f"gs://{bucket_name}"
+    )
+
+    assert re.search(
+        r"how old is the Brooklyn Bridge",
+        response.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )
+
+    delete_gcs_bucket(bucket_name)

--- a/speech/snippets/transcribe_batch_gcs_input_inline_output_v2.py
+++ b/speech/snippets/transcribe_batch_gcs_input_inline_output_v2.py
@@ -1,0 +1,78 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_batch_gcs_input_inline_output_v2]
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+
+def transcribe_batch_gcs_input_inline_output_v2(
+    project_id: str,
+    gcs_uri: str,
+) -> cloud_speech.BatchRecognizeResults:
+    """Transcribes audio from a Google Cloud Storage URI.
+
+    Args:
+        project_id: The GCP project ID.
+        gcs_uri: The Google Cloud Storage URI.
+
+    Returns:
+        The RecognizeResponse.
+    """
+    # Instantiates a client
+    client = SpeechClient()
+
+    config = cloud_speech.RecognitionConfig(
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="long",
+    )
+
+    file_metadata = cloud_speech.BatchRecognizeFileMetadata(uri=gcs_uri)
+
+    request = cloud_speech.BatchRecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        files=[file_metadata],
+        recognition_output_config=cloud_speech.RecognitionOutputConfig(
+            inline_response_config=cloud_speech.InlineOutputConfig(),
+        ),
+    )
+
+    # Transcribes the audio into text
+    operation = client.batch_recognize(request=request)
+
+    print("Waiting for operation to complete...")
+    response = operation.result(timeout=120)
+
+    for result in response.results[gcs_uri].transcript.results:
+        print(f"Transcript: {result.alternatives[0].transcript}")
+
+    return response.results[gcs_uri].transcript
+
+
+# [END speech_transcribe_batch_gcs_input_inline_output_v2]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("gcs_uri", help="URI to GCS file")
+    args = parser.parse_args()
+    transcribe_batch_gcs_input_inline_output_v2(args.project_id, args.gcs_uri)

--- a/speech/snippets/transcribe_batch_gcs_input_inline_output_v2.py
+++ b/speech/snippets/transcribe_batch_gcs_input_inline_output_v2.py
@@ -27,7 +27,7 @@ def transcribe_batch_gcs_input_inline_output_v2(
     """Transcribes audio from a Google Cloud Storage URI.
 
     Args:
-        project_id: The GCP project ID.
+        project_id: The Google Cloud project ID.
         gcs_uri: The Google Cloud Storage URI.
 
     Returns:

--- a/speech/snippets/transcribe_batch_gcs_input_inline_output_v2_test.py
+++ b/speech/snippets/transcribe_batch_gcs_input_inline_output_v2_test.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+
+from flaky import flaky
+
+import pytest
+
+import transcribe_batch_gcs_input_inline_output_v2
+
+
+_TEST_AUDIO_FILE_PATH = "gs://cloud-samples-data/speech/audio.flac"
+
+
+@flaky(max_runs=10, min_passes=1)
+def test_transcribe_batch_gcs_input_inline_output_v2(
+    capsys: pytest.CaptureFixture,
+) -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+    response = transcribe_batch_gcs_input_inline_output_v2.transcribe_batch_gcs_input_inline_output_v2(
+        project_id, _TEST_AUDIO_FILE_PATH
+    )
+
+    assert re.search(
+        r"how old is the Brooklyn Bridge",
+        response.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )

--- a/speech/snippets/transcribe_batch_multiple_files_v2.py
+++ b/speech/snippets/transcribe_batch_multiple_files_v2.py
@@ -1,0 +1,112 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_batch_multiple_files_v2]
+import re
+from typing import List
+
+from google.cloud import storage
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+
+def transcribe_batch_multiple_files_v2(
+    project_id: str,
+    gcs_uris: List[str],
+    gcs_output_path: str,
+) -> cloud_speech.BatchRecognizeResponse:
+    """Transcribes audio from a Google Cloud Storage URI.
+
+    Args:
+        project_id: The GCP project ID.
+        gcs_uris: The Google Cloud Storage URIs to transcribe.
+        gcs_output_path: The Cloud Storage URI to which to write the transcript.
+
+    Returns:
+        The BatchRecognizeResponse message.
+    """
+    # Instantiates a client
+    client = SpeechClient()
+
+    config = cloud_speech.RecognitionConfig(
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=["en-US"],
+        model="long",
+    )
+
+    files = []
+    for uri in gcs_uris:
+        files.append(cloud_speech.BatchRecognizeFileMetadata(uri=uri))
+
+    request = cloud_speech.BatchRecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        files=files,
+        recognition_output_config=cloud_speech.RecognitionOutputConfig(
+            gcs_output_config=cloud_speech.GcsOutputConfig(
+                uri=gcs_output_path,
+            ),
+        ),
+    )
+
+    # Transcribes the audio into text
+    operation = client.batch_recognize(request=request)
+
+    print("Waiting for operation to complete...")
+    response = operation.result(timeout=120)
+
+    print("Operation finished. Fetching results from:")
+    for uri in gcs_uris:
+        file_results = response.results[uri]
+        print(f"  {file_results.uri}...")
+        output_bucket, output_object = re.match(
+            r"gs://([^/]+)/(.*)", file_results.uri
+        ).group(1, 2)
+
+        # Instantiates a Cloud Storage client
+        storage_client = storage.Client()
+
+        # Fetch results from Cloud Storage
+        bucket = storage_client.bucket(output_bucket)
+        blob = bucket.blob(output_object)
+        results_bytes = blob.download_as_bytes()
+        batch_recognize_results = cloud_speech.BatchRecognizeResults.from_json(
+            results_bytes, ignore_unknown_fields=True
+        )
+
+        for result in batch_recognize_results.results:
+            print(f"     Transcript: {result.alternatives[0].transcript}")
+
+    return response
+
+
+# [END speech_transcribe_batch_multiple_files_v2]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("gcs_uri", nargs="+", help="URI to GCS file")
+    parser.add_argument(
+        "gcs_output_path", help="GCS URI to which to write the transcript"
+    )
+    args = parser.parse_args()
+    transcribe_batch_multiple_files_v2(
+        args.project_id, args.gcs_uri, args.gcs_output_path
+    )

--- a/speech/snippets/transcribe_batch_multiple_files_v2.py
+++ b/speech/snippets/transcribe_batch_multiple_files_v2.py
@@ -48,9 +48,10 @@ def transcribe_batch_multiple_files_v2(
         model="long",
     )
 
-    files = []
-    for uri in gcs_uris:
-        files.append(cloud_speech.BatchRecognizeFileMetadata(uri=uri))
+    files = [
+        cloud_speech.BatchRecognizeFileMetadata(uri=uri)
+        for uri in gcs_uris
+    ]
 
     request = cloud_speech.BatchRecognizeRequest(
         recognizer=f"projects/{project_id}/locations/global/recognizers/_",

--- a/speech/snippets/transcribe_batch_multiple_files_v2.py
+++ b/speech/snippets/transcribe_batch_multiple_files_v2.py
@@ -32,7 +32,7 @@ def transcribe_batch_multiple_files_v2(
     """Transcribes audio from a Google Cloud Storage URI.
 
     Args:
-        project_id: The GCP project ID.
+        project_id: The Google Cloud project ID.
         gcs_uris: The Google Cloud Storage URIs to transcribe.
         gcs_output_path: The Cloud Storage URI to which to write the transcript.
 

--- a/speech/snippets/transcribe_batch_multiple_files_v2_test.py
+++ b/speech/snippets/transcribe_batch_multiple_files_v2_test.py
@@ -1,0 +1,74 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from uuid import uuid4
+
+from flaky import flaky
+from google.cloud import storage
+from google.cloud.speech_v2.types import cloud_speech
+
+import pytest
+
+import transcribe_batch_multiple_files_v2
+
+
+_TEST_AUDIO_FILE_PATH = "gs://cloud-samples-data/speech/audio.flac"
+_GCS_BUCKET_OBJECT_RE = r"gs://([^/]+)/(.*)"
+
+
+def create_gcs_bucket() -> str:
+    client = storage.Client()
+    bucket = client.bucket("speech-samples-" + str(uuid4()))
+    new_bucket = client.create_bucket(bucket, location="us")
+    return new_bucket.name
+
+
+def delete_gcs_bucket(bucket_name: str) -> None:
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    bucket.delete(force=True)
+
+
+def get_gcs_object(gcs_path: str) -> cloud_speech.BatchRecognizeResults:
+    client = storage.Client()
+    bucket_name, object_name = re.match(_GCS_BUCKET_OBJECT_RE, gcs_path).group(1, 2)
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(object_name)
+    results_bytes = blob.download_as_bytes()
+    return cloud_speech.BatchRecognizeResults.from_json(
+        results_bytes, ignore_unknown_fields=True
+    )
+
+
+@flaky(max_runs=10, min_passes=1)
+def test_transcribe_batch_multiple_files_v2(capsys: pytest.CaptureFixture) -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+    bucket_name = create_gcs_bucket()
+
+    response = transcribe_batch_multiple_files_v2.transcribe_batch_multiple_files_v2(
+        project_id, [_TEST_AUDIO_FILE_PATH], f"gs://{bucket_name}"
+    )
+
+    results = get_gcs_object(response.results[_TEST_AUDIO_FILE_PATH].uri)
+
+    assert re.search(
+        r"how old is the Brooklyn Bridge",
+        results.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )
+
+    delete_gcs_bucket(bucket_name)

--- a/speech/snippets/transcribe_feature_in_recognizer.py
+++ b/speech/snippets/transcribe_feature_in_recognizer.py
@@ -1,0 +1,81 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_feature_in_recognizer]
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+
+def transcribe_feature_in_recognizer(
+    project_id: str,
+    recognizer_id: str,
+    audio_file: str,
+) -> cloud_speech.RecognizeResponse:
+    """Transcribe an audio file using an existing recognizer."""
+    # Instantiates a client
+    client = SpeechClient()
+
+    request = cloud_speech.CreateRecognizerRequest(
+        parent=f"projects/{project_id}/locations/global",
+        recognizer_id=recognizer_id,
+        recognizer=cloud_speech.Recognizer(
+            default_recognition_config=cloud_speech.RecognitionConfig(
+                auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+                language_codes=["en-US"],
+                model="latest_long",
+                features=cloud_speech.RecognitionFeatures(
+                    enable_automatic_punctuation=True,
+                ),
+            ),
+        ),
+    )
+
+    operation = client.create_recognizer(request=request)
+    recognizer = operation.result()
+
+    print("Created Recognizer:", recognizer.name)
+
+    # Reads a file as bytes
+    with open(audio_file, "rb") as f:
+        content = f.read()
+
+    request = cloud_speech.RecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/{recognizer_id}",
+        content=content,
+    )
+
+    # Transcribes the audio into text
+    response = client.recognize(request=request)
+
+    for result in response.results:
+        print(f"Transcript: {result.alternatives[0].transcript}")
+
+    return response
+
+
+# [END speech_transcribe_feature_in_recognizer]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("recognizer_id", help="Recognizer ID to use for recogniition")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    transcribe_feature_in_recognizer(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_feature_in_recognizer_test.py
+++ b/speech/snippets/transcribe_feature_in_recognizer_test.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from uuid import uuid4
+
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+import pytest
+
+import transcribe_feature_in_recognizer
+
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+
+
+def delete_recognizer(project_id: str, recognizer_id: str) -> None:
+    client = SpeechClient()
+    request = cloud_speech.DeleteRecognizerRequest(
+        name=f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
+    )
+    client.delete_recognizer(request=request)
+
+
+def test_transcribe_feature_in_recognizer(capsys: pytest.CaptureFixture) -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+    recognizer_id = "recognizer-" + str(uuid4())
+
+    response = transcribe_feature_in_recognizer.transcribe_feature_in_recognizer(
+        project_id, recognizer_id, os.path.join(_RESOURCES, "audio.wav")
+    )
+
+    assert re.search(
+        r"How old is the Brooklyn Bridge?",
+        response.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )
+
+    delete_recognizer(project_id, recognizer_id)

--- a/speech/snippets/transcribe_feature_in_recognizer_test.py
+++ b/speech/snippets/transcribe_feature_in_recognizer_test.py
@@ -34,9 +34,16 @@ def delete_recognizer(project_id: str, recognizer_id: str) -> None:
     client.delete_recognizer(request=request)
 
 
-def test_transcribe_feature_in_recognizer(capsys: pytest.CaptureFixture) -> None:
+def test_transcribe_feature_in_recognizer(
+    capsys: pytest.CaptureFixture, request: pytest.FixtureRequest
+) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
     recognizer_id = "recognizer-" + str(uuid4())
+
+    def cleanup():
+        delete_recognizer(project_id, recognizer_id)
+
+    request.addfinalizer(cleanup)
 
     response = transcribe_feature_in_recognizer.transcribe_feature_in_recognizer(
         project_id, recognizer_id, os.path.join(_RESOURCES, "audio.wav")
@@ -47,5 +54,3 @@ def test_transcribe_feature_in_recognizer(capsys: pytest.CaptureFixture) -> None
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
     )
-
-    delete_recognizer(project_id, recognizer_id)

--- a/speech/snippets/transcribe_multiple_languages_v2.py
+++ b/speech/snippets/transcribe_multiple_languages_v2.py
@@ -1,0 +1,74 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_multiple_languages_v2]
+from typing import List
+
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+
+def transcribe_multiple_languages_v2(
+    project_id: str,
+    language_codes: List[str],
+    audio_file: str,
+) -> cloud_speech.RecognizeResponse:
+    """Transcribe an audio file."""
+    # Instantiates a client
+    client = SpeechClient()
+
+    # Reads a file as bytes
+    with open(audio_file, "rb") as f:
+        content = f.read()
+
+    config = cloud_speech.RecognitionConfig(
+        auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+        language_codes=language_codes,
+        model="latest_long",
+    )
+
+    request = cloud_speech.RecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/_",
+        config=config,
+        content=content,
+    )
+
+    # Transcribes the audio into text
+    response = client.recognize(request=request)
+
+    for result in response.results:
+        print(f"Transcript: {result.alternatives[0].transcript}")
+
+    return response
+
+
+# [END speech_transcribe_multiple_languages_v2]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument(
+        "language_codes", nargs="+", help="Language codes to transcribe"
+    )
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    transcribe_multiple_languages_v2(
+        args.project_id, args.language_codes, args.audio_file
+    )

--- a/speech/snippets/transcribe_multiple_languages_v2_test.py
+++ b/speech/snippets/transcribe_multiple_languages_v2_test.py
@@ -1,10 +1,10 @@
-# Copyright 2017 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,22 @@ import os
 import re
 
 from google.api_core.retry import Retry
-import pytest
 
-import transcribe_streaming
+import transcribe_multiple_languages_v2
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 
 
 @Retry()
-def test_transcribe_streaming(capsys: pytest.CaptureFixture) -> None:
-    transcribe_streaming.transcribe_streaming(os.path.join(RESOURCES, "audio.raw"))
-    out, _ = capsys.readouterr()
+def test_transcribe_multiple_languages_v2() -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
 
-    assert re.search(r"how old is the Brooklyn Bridge", out, re.DOTALL | re.I)
+    response = transcribe_multiple_languages_v2.transcribe_multiple_languages_v2(
+        project_id, ["en-US", "fr-FR"], os.path.join(RESOURCES, "audio.wav")
+    )
+
+    assert re.search(
+        r"how old is the Brooklyn Bridge",
+        response.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )

--- a/speech/snippets/transcribe_override_recognizer.py
+++ b/speech/snippets/transcribe_override_recognizer.py
@@ -1,0 +1,89 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_override_recognizer]
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+from google.protobuf.field_mask_pb2 import FieldMask
+
+
+def transcribe_override_recognizer(
+    project_id: str,
+    recognizer_id: str,
+    audio_file: str,
+) -> cloud_speech.RecognizeResponse:
+    """Transcribe an audio file using an existing recognizer."""
+    # Instantiates a client
+    client = SpeechClient()
+
+    request = cloud_speech.CreateRecognizerRequest(
+        parent=f"projects/{project_id}/locations/global",
+        recognizer_id=recognizer_id,
+        recognizer=cloud_speech.Recognizer(
+            default_recognition_config=cloud_speech.RecognitionConfig(
+                auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+                language_codes=["en-US"],
+                model="latest_long",
+                features=cloud_speech.RecognitionFeatures(
+                    enable_automatic_punctuation=True,
+                    enable_word_time_offsets=True,
+                ),
+            ),
+        ),
+    )
+
+    operation = client.create_recognizer(request=request)
+    recognizer = operation.result()
+
+    print("Created Recognizer:", recognizer.name)
+
+    # Reads a file as bytes
+    with open(audio_file, "rb") as f:
+        content = f.read()
+
+    request = cloud_speech.RecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/{recognizer_id}",
+        config=cloud_speech.RecognitionConfig(
+            features=cloud_speech.RecognitionFeatures(
+                enable_word_time_offsets=False,
+            ),
+        ),
+        config_mask=FieldMask(paths=["features.enable_word_time_offsets"]),
+        content=content,
+    )
+
+    # Transcribes the audio into text
+    response = client.recognize(request=request)
+
+    for result in response.results:
+        print(f"Transcript: {result.alternatives[0].transcript}")
+
+    return response
+
+
+# [END speech_transcribe_override_recognizer]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("recognizer_id", help="Recognizer ID to use for recogniition")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    transcribe_override_recognizer(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_override_recognizer_test.py
+++ b/speech/snippets/transcribe_override_recognizer_test.py
@@ -1,0 +1,51 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from uuid import uuid4
+
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+import pytest
+
+import transcribe_override_recognizer
+
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+
+
+def delete_recognizer(project_id: str, recognizer_id: str) -> None:
+    client = SpeechClient()
+    request = cloud_speech.DeleteRecognizerRequest(
+        name=f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
+    )
+    client.delete_recognizer(request=request)
+
+
+def test_transcribe_override_recognizer(capsys: pytest.CaptureFixture) -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+    recognizer_id = "recognizer-" + str(uuid4())
+
+    response = transcribe_override_recognizer.transcribe_override_recognizer(
+        project_id, recognizer_id, os.path.join(_RESOURCES, "audio.wav")
+    )
+
+    assert re.search(
+        r"How old is the Brooklyn Bridge?",
+        response.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )
+
+    delete_recognizer(project_id, recognizer_id)

--- a/speech/snippets/transcribe_override_recognizer_test.py
+++ b/speech/snippets/transcribe_override_recognizer_test.py
@@ -34,9 +34,16 @@ def delete_recognizer(project_id: str, recognizer_id: str) -> None:
     client.delete_recognizer(request=request)
 
 
-def test_transcribe_override_recognizer(capsys: pytest.CaptureFixture) -> None:
+def test_transcribe_override_recognizer(
+    capsys: pytest.CaptureFixture, request: pytest.FixtureRequest
+) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
     recognizer_id = "recognizer-" + str(uuid4())
+
+    def cleanup():
+        delete_recognizer(project_id, recognizer_id)
+
+    request.addfinalizer(cleanup)
 
     response = transcribe_override_recognizer.transcribe_override_recognizer(
         project_id, recognizer_id, os.path.join(_RESOURCES, "audio.wav")
@@ -47,5 +54,3 @@ def test_transcribe_override_recognizer(capsys: pytest.CaptureFixture) -> None:
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
     )
-
-    delete_recognizer(project_id, recognizer_id)

--- a/speech/snippets/transcribe_reuse_recognizer.py
+++ b/speech/snippets/transcribe_reuse_recognizer.py
@@ -1,0 +1,61 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import argparse
+
+# [START speech_transcribe_reuse_recognizer]
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+
+def transcribe_reuse_recognizer(
+    project_id: str,
+    recognizer_id: str,
+    audio_file: str,
+) -> cloud_speech.RecognizeResponse:
+    """Transcribe an audio file using an existing recognizer."""
+    # Instantiates a client
+    client = SpeechClient()
+
+    # Reads a file as bytes
+    with open(audio_file, "rb") as f:
+        content = f.read()
+
+    request = cloud_speech.RecognizeRequest(
+        recognizer=f"projects/{project_id}/locations/global/recognizers/{recognizer_id}",
+        content=content,
+    )
+
+    # Transcribes the audio into text
+    response = client.recognize(request=request)
+
+    for result in response.results:
+        print(f"Transcript: {result.alternatives[0].transcript}")
+
+    return response
+
+
+# [END speech_transcribe_reuse_recognizer]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="GCP Project ID")
+    parser.add_argument("recognizer_id", help="Recognizer ID to use for recogniition")
+    parser.add_argument("audio_file", help="Audio file to stream")
+    args = parser.parse_args()
+    transcribe_reuse_recognizer(args.project_id, args.audio_file)

--- a/speech/snippets/transcribe_reuse_recognizer_test.py
+++ b/speech/snippets/transcribe_reuse_recognizer_test.py
@@ -52,9 +52,16 @@ def delete_recognizer(project_id: str, recognizer_id: str) -> None:
 
 
 @Retry()
-def test_transcribe_reuse_recognizer(capsys: pytest.CaptureFixture) -> None:
+def test_transcribe_reuse_recognizer(
+    capsys: pytest.CaptureFixture, request: pytest.FixtureRequest
+) -> None:
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
     recognizer_id = "recognizer-" + str(uuid4())
+
+    def cleanup():
+        delete_recognizer(project_id, recognizer_id)
+
+    request.addfinalizer(cleanup)
 
     create_recognizer(project_id, recognizer_id)
 
@@ -67,5 +74,3 @@ def test_transcribe_reuse_recognizer(capsys: pytest.CaptureFixture) -> None:
         response.results[0].alternatives[0].transcript,
         re.DOTALL | re.I,
     )
-
-    delete_recognizer(project_id, recognizer_id)

--- a/speech/snippets/transcribe_reuse_recognizer_test.py
+++ b/speech/snippets/transcribe_reuse_recognizer_test.py
@@ -1,0 +1,71 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import re
+from uuid import uuid4
+
+from google.api_core.retry import Retry
+from google.cloud.speech_v2 import SpeechClient
+from google.cloud.speech_v2.types import cloud_speech
+
+import pytest
+
+import transcribe_reuse_recognizer
+
+_RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
+
+
+def create_recognizer(project_id: str, recognizer_id: str) -> None:
+    client = SpeechClient()
+    request = cloud_speech.CreateRecognizerRequest(
+        parent=f"projects/{project_id}/locations/global",
+        recognizer_id=recognizer_id,
+        recognizer=cloud_speech.Recognizer(
+            default_recognition_config=cloud_speech.RecognitionConfig(
+                auto_decoding_config=cloud_speech.AutoDetectDecodingConfig(),
+                language_codes=["en-US"],
+                model="long",
+            ),
+        ),
+    )
+    client.create_recognizer(request=request)
+
+
+def delete_recognizer(project_id: str, recognizer_id: str) -> None:
+    client = SpeechClient()
+    request = cloud_speech.DeleteRecognizerRequest(
+        name=f"projects/{project_id}/locations/global/recognizers/{recognizer_id}"
+    )
+    client.delete_recognizer(request=request)
+
+
+@Retry()
+def test_transcribe_reuse_recognizer(capsys: pytest.CaptureFixture) -> None:
+    project_id = os.getenv("GOOGLE_CLOUD_PROJECT")
+    recognizer_id = "recognizer-" + str(uuid4())
+
+    create_recognizer(project_id, recognizer_id)
+
+    response = transcribe_reuse_recognizer.transcribe_reuse_recognizer(
+        project_id, recognizer_id, os.path.join(_RESOURCES, "audio.wav")
+    )
+
+    assert re.search(
+        r"how old is the Brooklyn Bridge",
+        response.results[0].alternatives[0].transcript,
+        re.DOTALL | re.I,
+    )
+
+    delete_recognizer(project_id, recognizer_id)


### PR DESCRIPTION
## Description

Added samples for:

* Enabling CMEK
* BatchRecognize (GCS output, inline output, dynamic batching, multiple files)
* Multiple languages recognition
* Various recognizer features

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved