### PR TITLE
fix: Change Gen App Builder test to use a different engine.

### DIFF
--- a/discoveryengine/requirements.txt
+++ b/discoveryengine/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-discoveryengine==0.8.1
+google-cloud-discoveryengine==0.9.1
 google-api-core==2.11.1

--- a/discoveryengine/search_sample.py
+++ b/discoveryengine/search_sample.py
@@ -46,8 +46,7 @@ def search_sample(
     )
 
     request = discoveryengine.SearchRequest(
-        serving_config=serving_config,
-        query=search_query,
+        serving_config=serving_config, query=search_query, page_size=10
     )
     response = client.search(request)
     for result in response.results:

--- a/discoveryengine/search_sample_test.py
+++ b/discoveryengine/search_sample_test.py
@@ -19,7 +19,7 @@ from discoveryengine import search_sample
 
 project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
 location = "global"
-search_engine_id = "test-search-engine"
+search_engine_id = "test-search-engine_1689960780551"
 serving_config_id = "default_config"
 search_query = "Google"
 


### PR DESCRIPTION
- Some engines created in Preview no longer work after the GA Launch.
- Updated discovery engine client to use latest version
- Reduced page size default

## Description

Fixes #10368 