### PR TITLE
re-add removed file - fixes buganizer bug 288143688

### DIFF
--- a/composer/2022_airflow_summit/DATAPROC_EXPANSION_README.md
+++ b/composer/2022_airflow_summit/DATAPROC_EXPANSION_README.md
@@ -3,6 +3,7 @@
 ## Data in this directory
 * [`ghcnd-stations.txt`](./ghcnd-stations.txt) is a freely available dataset about weather stations used in [US government climate data](https://www.ncei.noaa.gov/access/metadata/landing-page/bin/iso?id=gov.noaa.ncdc:C00861). A direct download link can be found at that linked site.
 * [`ghcn-stations-processed.csv`](./ghcn-stations-processed.csv) is generated from the `ghcnd-stations.txt` text file. To generate this file yourself, run `python data_processing_helper.py` from this directory
+* [`holidays.csv`](.holidays.csv) is derived from data found on the [US Open Government Federal Holiday Webpage](https://www.opm.gov/about-us/open-government/Data/Apps/Holidays/Index.aspx). It was converted from iCalendar format to CSV following instructions found in [this blog post](https://medium.com/@leah.e.cole/how-to-use-python-to-turn-icalendar-data-into-a-csv-of-dates-93d95926231d).
 
 
 ## Prerequisites

--- a/composer/2022_airflow_summit/holidays.csv
+++ b/composer/2022_airflow_summit/holidays.csv
@@ -1,0 +1,257 @@
+Date,Holiday
+2016-10-10,Columbus Day
+2017-1-20,Washington’s Birthday
+2006-2-20,Washington’s Birthday
+2001-5-28,Memorial Day
+2014-1-20,"Birthday of Martin Luther King, Jr."
+2008-10-13,Columbus Day
+2002-9-2,Labor Day
+2019-7-4,Independence Day
+2012-11-12,Veterans Day
+2008-1-1,New Year’s Day
+2000-2-21,Washington’s Birthday
+1998-12-25,Christmas Day
+1998-1-1,New Year’s Day
+2019-12-25,Christmas Day
+2004-1-1,New Year's Day
+2014-5-26,Memorial Day
+2008-12-25,Christmas Day
+2007-7-4,Independence Day
+2021-7-5,Independence Day
+2005-7-4,Independence Day
+2012-10-8,Columbus Day
+1999-12-31,New Year’s Day
+1999-9-6,Labor Day
+1999-12-24,Christmas Day
+2004-11-11,Veterans Day
+2016-2-15,Washington’s Birthday
+2015-10-12,Columbus Day
+2015-7-3,Independence Day
+2008-1-21,"Birthday of Martin Luther King, Jr."
+2007-10-8,Columbus Day
+2007-2-19,Washington’s Birthday
+2005-11-24,Thanksgiving Day
+2000-12-25,Christmas Day
+2004-1-19,"Birthday of Martin Luther King, Jr."
+2011-11-14,Thanksgiving Day
+2020-1-20,"Birthday of Martin Luther King, Jr."
+2016-9-5,Labor Day
+1997-10-13,Columbus Day
+2003-11-27,Thanksgiving Day
+2018-5-28,Memorial Day
+2003-10-13,Columbus Day
+2018-1-1,New Year’s Day
+2006-10-9,Columbus Day
+2005-12-26,Christmas Day
+2017-1-2,New Year’s Day
+1997-5-26,Memorial Day
+2009-10-12,Columbus Day
+2008-2-18,Washington’s Birthday
+2008-11-11,Veterans Day
+2001-7-4,Independence Day
+2009-1-19,"Birthday of Martin Luther King, Jr."
+2008-9-1,Labor Day
+2010-11-11,Veterans Day
+2015-1-19,"Birthday of Martin Luther King, Jr."
+2004-5-31,Memorial Day
+1998-1-19,"Birthday of Martin Luther King, Jr."
+2016-1-18,"Birthday of Martin Luther King, Jr."
+2013-1-1,New Year’s Day
+2010-12-31,New Year’s Day
+2008-5-26,Memorial Day
+2011-10-10,Columbus Day
+2005-1-17,"Birthday of Martin Luther King, Jr."
+2004-2-16,Washington's Birthday
+2013-12-25,Christmas Day
+2012-12-25,Christmas Day
+2003-1-20,"Birthday of Martin Luther King, Jr."
+2002-2-18,Washington’s Birthday
+1999-7-5,Independence Day
+2019-11-28,Thanksgiving Day
+2015-1-1,New Year’s Day
+2010-9-6,Labor Day
+2016-7-4,Independence Day
+2009-1-1,New Year’s Day
+2000-9-4,Labor Day
+2000-5-29,Memorial Day
+2004-10-11,Columbus Day
+2020-11-26,Thanksgiving Day
+2006-5-29,Memorial Day
+2005-9-5,Labor Day
+2001-9-3,Labor Day
+2019-11-11,Veterans Day
+1998-10-12,Columbus Day
+2013-10-14,Columbus Day
+2007-1-15,"Birthday of Martin Luther King, Jr."
+2007-12-25,Christmas Day
+2016-1-1,New Year’s Day
+2017-12-23,Thanksgiving Day
+2011-7-4,Independence Day
+2005-5-30,Memorial Day
+2004-11-25,Thanksgiving Day
+2016-11-24,Thanksgiving Day
+2003-11-11,Veterans Day
+2011-11-11,Veterans Day
+2000-7-4,Independence Day
+2017-12-25,Christmas Day
+2020-9-7,Labor Day
+2013-2-18,Washington’s Birthday
+1998-2-16,Washington’s Birthday
+2013-7-4,Independence Day
+2005-2-21,Washington’s Birthday
+2009-2-16,Washington’s Birthday
+2016-11-11,Veterans Day
+1998-5-25,Memorial Day
+2001-11-12,Veterans Day
+2000-1-17,"Birthday of Martin Luther King, Jr."
+1997-11-27,Thanksgiving Day
+2018-11-12,Veterans Day
+2010-12-24,Christmas Day
+2014-11-11,Veterans Day
+2001-1-15,"Birthday of Martin Luther King, Jr."
+1997-1-1,New Year’s Day
+2015-12-25,Christmas Day
+2020-1-1,New Year’s Day
+2021-1-20,Inauguation Day
+2020-2-17,Washington’s Birthday
+2004-7-5,Independence Day
+2019-9-2,Labor Day
+2004-12-31,New Year’s Day
+2005-11-11,Veterans Day
+1998-9-7,Labor Day
+2015-5-25,Memorial Day
+1999-11-11,Veterans Day
+2009-11-26,Thanksgiving Day
+2018-1-15,"Birthday of Martin Luther King, Jr."
+2010-10-11,Columbus Day
+2006-7-4,Independence Day
+2006-1-2,New Year’s Day
+2010-11-25,Thanksgiving Day
+2007-11-22,Thanksgiving Day
+2001-10-8,Columbus Day
+1997-7-4,Independence Day
+1997-2-17,Washington’s Birthday
+2000-11-10,Veterans Day
+1999-1-1,New Year’s Day
+2015-9-7,Labor Day
+2002-1-21,"Birthday of Martin Luther King, Jr."
+2019-10-14,Columbus Day
+2014-1-1,New Year’s Day
+2019-1-21,"Birthday of Martin Luther King, Jr."
+2002-11-28,Thanksgiving Day
+1998-11-26,Thanksgiving Day
+2010-7-5,Independence Day
+1997-1-20,"Birthday of Martin Luther King, Jr."
+1997-12-25,Christmas Day
+2021-2-15,Washington’s Birthday
+2017-7-4,Independence Day
+2003-1-1,New Year’s Day
+2006-11-10,Veterans Day
+2012-11-22,Thanksgiving Day
+2009-11-11,Veterans Day
+2004-12-24,Christmas Day
+2003-2-17,Washington’s Birthday
+2000-10-9,Columbus Day
+2009-5-25,Memorial Day
+2021-10-11,Columbus Day
+2008-7-4,Independence Day
+2021-11-25,Thanksgiving Day
+2013-1-20,Inauguration Day
+2020-7-3,Independence Day
+2019-1-1,New Year’s Day
+2009-7-3,Independence Day
+2010-5-31,Memorial Day
+2006-1-16,"Birthday of Martin Luther King, Jr."
+2002-1-1,New Year’s Day
+2007-1-1,New Year’s Day
+2021-11-11,Veterans Day
+2008-11-27,Thanksgiving Day
+2014-11-27,Thanksgiving Day
+2017-10-9,Columbus Day
+2003-7-4,Independence Day
+1998-7-3,Independence Day
+2009-9-7,Labor Day
+2011-12-26,Christmas Day
+2018-12-25,Christmas Day
+2006-12-25,Christmas Day
+2014-12-25,Christmas Day
+2017-1-16,"Birthday of Martin Luther King, Jr."
+2017-9-4,Labor Day
+2016-12-26,Christmas Day
+2011-5-30,Memorial Day
+2017-5-29,Memorial Day
+2002-10-14,Columbus Day
+2014-7-4,Independence Day
+2015-2-16,Washington’s Birthday
+2005-10-10,Columbus Day
+2011-9-5,Labor Day
+2012-7-4,Independence Day
+2005-1-20,Inauguration Day
+1999-2-15,Washington’s Birthday
+2002-11-11,Veterans Day
+2020-10-12,Columbus Day
+2004-9-6,Labor Day
+1999-5-31,Memorial Day
+2007-5-28,Memorial Day
+2020-5-25,Memorial Day
+2013-1-21,"Birthday of Martin Luther King, Jr."
+1999-11-25,Thanksgiving Day
+2001-1-20,Inauguration Day
+2014-2-17,Washington’s Birthday
+2003-9-1,Labor Day
+2003-5-26,Memorial Day
+2021-12-25,Christmas Day
+2003-12-25,Christmas Day
+2011-1-17,"Birthday of Martin Luther King, Jr."
+2014-9-1,Labor Day
+2021-9-6,Labor Day
+1997-9-1,Labor Day
+2006-11-23,Thanksgiving Day
+2012-1-16,"Birthday of Martin Luther King, Jr."
+2013-9-2,Labor Day
+2009-1-20,Inauguration Day
+1998-11-11,Veterans Day
+2002-5-27,Memorial Day
+2013-11-11,Veterans Day
+2015-11-26,Thanksgiving Day
+2010-1-1,New Year’s Day
+2018-9-3,Labor Day
+2009-12-25,Christmas Day
+2018-7-4,Independence Day
+2012-1-2,New Year's Day
+2002-7-4,Independence Day
+2020-12-25,Christmas Day
+2020-11-11,Veterans Day
+2012-5-28,Memorial Day
+2021-1-1,New Year’s Day
+2002-12-25,Christmas Day
+2014-10-13,Columbus Day
+2007-11-12,Veterans Day
+2018-11-22,Thanksgiving Day
+2006-9-4,Labor Day
+1999-10-11,Columbus Day
+2021-5-31,Memorial Day
+2001-2-19,Washington’s Birthday
+1999-1-8,"Birthday of Martin Luther King, Jr."
+2021-1-18,"Birthday of Martin Luther King, Jr."
+2017-1-20,Inauguration Day
+2013-11-28,Thanksgiving Day
+2007-9-3,Labor Day
+2012-2-20,Washington's Birthday
+2018-2-19,Washington’s Birthday
+2012-9-3,Labor Day
+2017-11-10,Veterans Day
+2016-5-30,Memorial Day
+2010-2-15,Washington’s Birthday
+2001-12-25,Christmas Day
+2001-1-1,New Year’s Day
+2000-11-23,Thanksgiving Day
+1997-11-11,Veterans Day
+2018-10-8,Columbus Day
+2010-1-18,"Birthday of Martin Luther King, Jr."
+2019-5-27,Memorial Day
+2019-2-18,Washington’s Birthday
+2001-11-22,Thanksgiving Day
+2011-2-21,Washington’s Birthday
+2015-11-11,Veterans Day
+2013-5-27,Memorial Day


### PR DESCRIPTION
## Description

I removed this file as part of removing the `data-science-onramp` directory but it turns out that this CSV was used in another tutorial and I broke a hyperlink in the process. This re-adds it and adds the info about the source data to fix buganzier bug 288143688

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

