### PR TITLE
fix: restore python 3.7 in docker image used for samples testing

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -117,7 +117,7 @@ RUN set -ex \
   && export GNUPGHOME="$(mktemp -d)" \
   && echo "disable-ipv6" >> "${GNUPGHOME}/dirmngr.conf" \
   && /tmp/fetch_gpg_keys.sh \
-  && for PYTHON_VERSION in 2.7.18 3.8.17 3.9.17 3.10.12 3.11.4; do \
+  && for PYTHON_VERSION in 2.7.18 3.7.17 3.8.17 3.9.17 3.10.12 3.11.4; do \
   wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
   && wget --no-check-certificate -O python-${PYTHON_VERSION}.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
   && gpg --batch --verify python-${PYTHON_VERSION}.tar.xz.asc python-${PYTHON_VERSION}.tar.xz \
@@ -160,10 +160,12 @@ RUN wget --no-check-certificate -O /tmp/get-pip.py 'https://bootstrap.pypa.io/ge
 RUN python3.11 /tmp/get-pip.py
 RUN python3.9 /tmp/get-pip.py
 RUN python3.8 /tmp/get-pip.py
+RUN python3.7 /tmp/get-pip.py
 RUN rm /tmp/get-pip.py
 
 # Test Pip
 RUN python3 -m pip
+RUN python3.7 -m pip
 RUN python3.8 -m pip
 RUN python3.9 -m pip
 RUN python3.10 -m pip


### PR DESCRIPTION
Partial revert of https://github.com/GoogleCloudPlatform/python-docs-samples/pull/10453 which removed python 3.7 from the docker image used for samples testing. This is causing presubmits to fail downstream, for example in https://github.com/googleapis/python-logging/pull/770.