### PR TITLE
fix(docker): Hardcoding virtualenv version to keep Python 2.7 support

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -90,6 +90,9 @@ export PATH="${HOME}/.local/bin:${PATH}"
 # upgrade pip when needed
 pip install --upgrade pip
 
+# Install virtualenv in version 20.21, since version 20.22 no longer supports Python 2.7
+pip install --user -q virtualenv==20.21
+
 # install nox for testing
 pip install --user -q nox
 

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -91,7 +91,9 @@ export PATH="${HOME}/.local/bin:${PATH}"
 pip install --upgrade pip
 
 # Install virtualenv in version 20.21, since version 20.22 no longer supports Python 2.7
-pip install --user -q virtualenv==20.21
+if [[ "${RUN_TESTS_SESSION}" == "py-2.7" ]]; then
+  pip install --user -q virtualenv==20.21
+fi
 
 # install nox for testing
 pip install --user -q nox


### PR DESCRIPTION
Since version [20.22 virtualenv no longer supports Python 2.7](https://virtualenv.pypa.io/en/latest/changelog.html#v20-22-0-2023-04-19). We hardcode virtualenv version to keep Python 2.7 while we work on deprecating it from our repositories.
