### PR TITLE
[DLP] Implemented dlp_k_anonymity_with_entity_id

### DIFF
--- a/dlp/snippets/risk.py
+++ b/dlp/snippets/risk.py
@@ -387,7 +387,7 @@ def k_anonymity_analysis(
 import time  # noqa: I100,  F811, E402
 from typing import List  # noqa: E402, F811
 
-import google.cloud.dlp  # noqa: I100, F811, E402
+import google.cloud.dlp_v2  # noqa: I100, F811, E402
 
 
 def k_anonymity_with_entity_id(

--- a/dlp/snippets/risk.py
+++ b/dlp/snippets/risk.py
@@ -388,7 +388,6 @@ import time  # noqa: I100,  F811, E402
 from typing import List  # noqa: E402, F811
 
 import google.cloud.dlp  # noqa: I100, F811, E402
-import google.cloud.pubsub  # noqa: I100, F811, E402
 
 
 def k_anonymity_with_entity_id(
@@ -482,9 +481,8 @@ def k_anonymity_with_entity_id(
             "risk_job": risk_job,
         }
     )
-    print("Inspection Job started : {}".format(response.name))
-
     job_name = response.name
+    print(f"Inspection Job started : {job_name}")
 
     # Waiting for a maximum of 15 minutes for the job to be completed.
     job = dlp.get_dlp_job(request={"name": job_name})
@@ -493,7 +491,7 @@ def k_anonymity_with_entity_id(
         # Check if the job has completed
         if job.state == google.cloud.dlp_v2.DlpJob.JobState.DONE:
             break
-        elif job.state == google.cloud.dlp_v2.DlpJob.JobState.FAILED:
+        if job.state == google.cloud.dlp_v2.DlpJob.JobState.FAILED:
             print('Job Failed, Please check the configuration.')
             return
 
@@ -521,23 +519,12 @@ def k_anonymity_with_entity_id(
     for i, bucket in enumerate(histogram_buckets):
         print(f"Bucket {i}:")
         if bucket.equivalence_class_size_lower_bound:
-            print(
-                "   Bucket size range: [{}, {}]".format(
-                    bucket.equivalence_class_size_lower_bound,
-                    bucket.equivalence_class_size_upper_bound,
-                )
-            )
+            print(f"Bucket size range: [{bucket.equivalence_class_size_lower_bound}, "
+                  f"{bucket.equivalence_class_size_upper_bound}]"
+                  )
             for value_bucket in bucket.bucket_values:
-                print(
-                    "   Quasi-ID values: {}".format(
-                        get_values(value_bucket.quasi_ids_values[0])
-                    )
-                )
-                print(
-                    "   Class size: {}".format(
-                        value_bucket.equivalence_class_size
-                    )
-                )
+                print(f"Quasi-ID values: {get_values(value_bucket.quasi_ids_values[0])}")
+                print(f"Class size: {value_bucket.equivalence_class_size}")
         else:
             print("No findings.")
 

--- a/dlp/snippets/risk.py
+++ b/dlp/snippets/risk.py
@@ -410,7 +410,9 @@ def k_anonymity_with_entity_id(
             is stored.
         source_dataset_id: The id of the dataset to inspect.
         source_table_id: The id of the table to inspect.
-        entity_id: It enables you to accurately determine k-anonymity.
+        entity_id: The column name of the table that enables accurately determining k-anonymity
+         in the common scenario wherein several rows of dataset correspond to the same sensitive
+         information.
         quasi_ids: A set of columns that form a composite key.
         output_table_project_id: The Google Cloud project id where the output BigQuery table
             is stored.
@@ -952,7 +954,8 @@ if __name__ == "__main__":
     )
     k_anonymity_entity_parser.add_argument(
         "entity_id",
-        help="It enables you to accurately determine k-anonymity.",
+        help="The column name of the table that enables accurately "
+        "determining k-anonymity",
     )
     k_anonymity_entity_parser.add_argument(
         "quasi_ids",

--- a/dlp/snippets/risk.py
+++ b/dlp/snippets/risk.py
@@ -383,6 +383,167 @@ def k_anonymity_analysis(
 # [END dlp_k_anonymity]
 
 
+# [START dlp_k_anonymity_with_entity_id]
+import time  # noqa: I100,  F811, E402
+from typing import List  # noqa: E402, F811
+
+import google.cloud.dlp  # noqa: I100, F811, E402
+import google.cloud.pubsub  # noqa: I100, F811, E402
+
+
+def k_anonymity_with_entity_id(
+    project: str,
+    source_table_project_id: str,
+    source_dataset_id: str,
+    source_table_id: str,
+    entity_id: str,
+    quasi_ids: List[str],
+    output_table_project_id: str,
+    output_dataset_id: str,
+    output_table_id: str,
+) -> None:
+
+    """Uses the Data Loss Prevention API to compute the k-anonymity using entity_id
+        of a column set in a Google BigQuery table.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        source_table_project_id: The Google Cloud project id where the BigQuery table
+            is stored.
+        source_dataset_id: The id of the dataset to inspect.
+        source_table_id: The id of the table to inspect.
+        entity_id: It enables you to accurately determine k-anonymity.
+        quasi_ids: A set of columns that form a composite key.
+        output_table_project_id: The Google Cloud project id where the output BigQuery table
+            is stored.
+        output_dataset_id: The id of the output BigQuery dataset.
+        output_table_id: The id of the output BigQuery table.
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Location info of the source BigQuery table.
+    source_table = {
+        "project_id": source_table_project_id,
+        "dataset_id": source_dataset_id,
+        "table_id": source_table_id,
+    }
+
+    # Specify the bigquery table to store the findings.
+    # The output_table_id in the given BigQuery dataset will be created if it doesn't
+    # already exist.
+    dest_table = {
+        "project_id": output_table_project_id,
+        "dataset_id": output_dataset_id,
+        "table_id": output_table_id,
+    }
+
+    # Convert quasi id list to Protobuf type
+    def map_fields(field: str) -> dict:
+        return {"name": field}
+
+    #  Configure column names of quasi-identifiers to analyze
+    quasi_ids = map(map_fields, quasi_ids)
+
+    # Tell the API where to send a notification when the job is complete.
+    actions = [
+        {
+            "save_findings": {
+                "output_config": {"table": dest_table}
+            }
+        }
+    ]
+
+    # Configure the privacy metric to compute for re-identification risk analysis.
+    # Specify the unique identifier in the source table for the k-anonymity analysis.
+    privacy_metric = {
+        "k_anonymity_config": {
+            "entity_id": {
+                "field": {"name": entity_id}
+            },
+            "quasi_ids": quasi_ids,
+        }
+    }
+
+    # Configure risk analysis job.
+    risk_job = {
+        "privacy_metric": privacy_metric,
+        "source_table": source_table,
+        "actions": actions,
+    }
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}/locations/global"
+
+    # Call API to start risk analysis job.
+    response = dlp.create_dlp_job(
+        request={
+            "parent": parent,
+            "risk_job": risk_job,
+        }
+    )
+    print("Inspection Job started : {}".format(response.name))
+
+    job_name = response.name
+
+    # Waiting for a maximum of 15 minutes for the job to be completed.
+    job = dlp.get_dlp_job(request={"name": job_name})
+    no_of_attempts = 30
+    while no_of_attempts > 0:
+        # Check if the job has completed
+        if job.state == google.cloud.dlp_v2.DlpJob.JobState.DONE:
+            break
+        elif job.state == google.cloud.dlp_v2.DlpJob.JobState.FAILED:
+            print('Job Failed, Please check the configuration.')
+            return
+
+        # Sleep for a short duration before checking the job status again
+        time.sleep(30)
+        no_of_attempts -= 1
+
+        # Get the DLP job status
+        job = dlp.get_dlp_job(request={"name": job_name})
+
+    if job.state != google.cloud.dlp_v2.DlpJob.JobState.DONE:
+        print("Job did not complete within 15 minutes.")
+        return
+
+    # Create helper function for unpacking values
+    def get_values(obj: types.Value) -> str:
+        return str(obj.string_value)
+
+    # Print out the results.
+    print(f"Job name: {job.name}")
+    histogram_buckets = (
+        job.risk_details.k_anonymity_result.equivalence_class_histogram_buckets
+    )
+    # Print bucket stats
+    for i, bucket in enumerate(histogram_buckets):
+        print(f"Bucket {i}:")
+        if bucket.equivalence_class_size_lower_bound:
+            print(
+                "   Bucket size range: [{}, {}]".format(
+                    bucket.equivalence_class_size_lower_bound,
+                    bucket.equivalence_class_size_upper_bound,
+                )
+            )
+            for value_bucket in bucket.bucket_values:
+                print(
+                    "   Quasi-ID values: {}".format(
+                        get_values(value_bucket.quasi_ids_values[0])
+                    )
+                )
+                print(
+                    "   Class size: {}".format(
+                        value_bucket.equivalence_class_size
+                    )
+                )
+        else:
+            print("No findings.")
+
+# [END dlp_k_anonymity_with_entity_id]
+
+
 # [START dlp_l_diversity]
 from typing import List  # noqa: I100, F811, E402
 import concurrent.futures  # noqa: I100, F811, E402
@@ -782,6 +943,49 @@ if __name__ == "__main__":
         help="The number of seconds to wait for a response from the API.",
     )
 
+    k_anonymity_entity_parser = subparsers.add_parser(
+        "k_anonymity_w_entity",
+        help="Computes the k-anonymity of a column set in a Google BigQuery table.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "source_table_project_id",
+        help="The Google Cloud project id where the BigQuery table is stored.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "source_dataset_id",
+        help="The id of the dataset to inspect.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "source_table_id",
+        help="The id of the table to inspect.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "entity_id",
+        help="It enables you to accurately determine k-anonymity.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "quasi_ids",
+        nargs="+",
+        help="A set of columns that form a composite key.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "output_table_project_id",
+        help="The Google Cloud project id where the output BigQuery table "
+        "would be stored.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "output_dataset_id",
+        help="The id of the output BigQuery dataset.",
+    )
+    k_anonymity_entity_parser.add_argument(
+        "output_table_id",
+        help="The id of the output BigQuery table.",
+    )
+
     l_diversity_parser = subparsers.add_parser(
         "l_diversity",
         help="Computes the l-diversity of a column set in a Google BigQuery" "table.",
@@ -905,6 +1109,18 @@ if __name__ == "__main__":
             args.subscription_id,
             args.quasi_ids,
             timeout=args.timeout,
+        )
+    elif args.content == "k_anonymity_w_entity":
+        k_anonymity_with_entity_id(
+            args.project,
+            args.source_table_project_id,
+            args.source_dataset_id,
+            args.source_table_id,
+            args.entity_id,
+            args.quasi_ids,
+            args.output_table_project_id,
+            args.output_dataset_id,
+            args.output_table_id,
         )
     elif args.content == "l_diversity":
         l_diversity_analysis(

--- a/dlp/snippets/risk_test.py
+++ b/dlp/snippets/risk_test.py
@@ -14,6 +14,10 @@
 
 import os
 from typing import Iterator
+
+from unittest import mock
+from unittest.mock import MagicMock
+
 import uuid
 
 import google.cloud.bigquery
@@ -421,3 +425,58 @@ def test_k_map_estimate_analysis_quasi_ids_info_types_equal(
             [NUMERIC_FIELD, STRING_BOOLEAN_FIELD],
             ["AGE"],
         )
+
+
+@mock.patch("google.cloud.dlp_v2.DlpServiceClient")
+def test_k_anonymity_with_entity_id(
+    dlp_client: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+
+    # Configure the mock DLP client and its behavior.
+    mock_dlp_instance = dlp_client.return_value
+    # Configure the mock CreateDlpJob DLP method and its behavior.
+    mock_dlp_instance.create_dlp_job.return_value.name = f'projects/{GCLOUD_PROJECT}/dlpJobs/test_job'
+
+    # Configure the mock GetDlpJob DLP method and its behavior.
+    mock_job = mock_dlp_instance.get_dlp_job.return_value
+    mock_job.name = f'projects/{GCLOUD_PROJECT}/dlpJobs/test_job'
+    mock_job.state = google.cloud.dlp_v2.DlpJob.JobState.DONE
+
+    # Mocking value for quasi_id ("Age", for instance)
+    mock_job.risk_details.k_anonymity_result.equivalence_class_histogram_buckets.bucket_values.quasi_ids_values = [
+        MagicMock(string_value="[\"27\"]")
+    ]
+    quasi_ids_values = \
+        mock_job.risk_details.k_anonymity_result.equivalence_class_histogram_buckets.bucket_values.quasi_ids_values
+
+    mock_job.risk_details.k_anonymity_result.equivalence_class_histogram_buckets.bucket_values = [
+        MagicMock(quasi_ids_values=quasi_ids_values, equivalence_class_size=1)
+    ]
+    bucket_values = mock_job.risk_details.k_anonymity_result.equivalence_class_histogram_buckets.bucket_values
+
+    mock_job.risk_details.k_anonymity_result.equivalence_class_histogram_buckets = [
+        MagicMock(equivalence_class_size_lower_bound=1, equivalence_class_size_upper_bound=1, bucket_size=1,
+                  bucket_values=bucket_values, bucket_value_count=1)
+    ]
+
+    # Call the sample function considering "Name" as entity_id and "Age" as quasi_id.
+    risk.k_anonymity_with_entity_id(
+        GCLOUD_PROJECT,
+        "SOURCE_TABLE_PROJECT",
+        "SOURCE_DATASET_ID",
+        "SOURCE_TABLE_ID",
+        "Name",
+        ["Age"],
+        "OUTPUT_TABLE_PROJECT",
+        "OUTPUT_DATASET_ID",
+        "OUTPUT_TABLE_ID",
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Quasi-ID values:" in out
+    assert "Class size:" in out
+    assert "Job name:" in out
+
+    mock_dlp_instance.create_dlp_job.assert_called_once()
+    mock_dlp_instance.get_dlp_job.assert_called_once()


### PR DESCRIPTION
## Description
Implemented dlp_k_anonymity_with_entity_id. Json equivalent: https://cloud.google.com/dlp/docs/visualizing_re-id_risk#step_1_calculate_k-anonymity_on_the_dataset

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved