### PR TITLE
fix: run button sets env variable

### DIFF
--- a/run/logging-manual/app.json
+++ b/run/logging-manual/app.json
@@ -1,0 +1,8 @@
+{
+    "name": "logging-manual",
+    "env": {
+        "GOOGLE_CLOUD_PROJECT": {
+            "description": "the project you selected or created"
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #10494 

Added "app.json" to get the "Run on Google Cloud" button to prompt for the environment variable the service needs.