### PR TITLE
specify V3 parser version when creating HL7v2 store

### DIFF
--- a/healthcare/api-client/v1/hl7v2/hl7v2_stores.py
+++ b/healthcare/api-client/v1/hl7v2/hl7v2_stores.py
@@ -39,12 +39,15 @@ def create_hl7v2_store(project_id, location, dataset_id, hl7v2_store_id):
         project_id, location, dataset_id
     )
 
+    # Use the V3 parser. Immutable after HL7v2 store creation.
+    body = {"parserConfig": {"version": "V3"}}
+
     request = (
         client.projects()
         .locations()
         .datasets()
         .hl7V2Stores()
-        .create(parent=hl7v2_store_parent, body={}, hl7V2StoreId=hl7v2_store_id)
+        .create(parent=hl7v2_store_parent, body=body, hl7V2StoreId=hl7v2_store_id)
     )
 
     response = request.execute()


### PR DESCRIPTION
## Description

Fixes b/253274073

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] Please **merge** this PR for me once it is approved