### PR TITLE
fix: add retries to e2e Cloud Run tests

### DIFF
--- a/run/filesystem/e2e_test.py
+++ b/run/filesystem/e2e_test.py
@@ -148,4 +148,4 @@ def test_end_to_end(service_url_auth_token):
 
     date = datetime.datetime.utcnow()
     body = response.content.decode("UTF-8")
-    assert "{dt:%a}-{dt:%b}-{dt:%d}-{dt:%H}".format(dt=date) in body.decode()
+    assert "{dt:%a}-{dt:%b}-{dt:%d}-{dt:%H}".format(dt=date) in body

--- a/run/filesystem/e2e_test.py
+++ b/run/filesystem/e2e_test.py
@@ -23,6 +23,9 @@ from urllib import request
 import uuid
 
 import pytest
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 # Unique suffix to create distinct service names
 SUFFIX = uuid.uuid4().hex
@@ -122,19 +125,26 @@ def service_url_auth_token(deployed_service):
 
 def test_end_to_end(service_url_auth_token):
     service_url, auth_token = service_url_auth_token
+
+    retry_strategy = Retry(
+        total=3,
+        status_forcelist=[400, 401, 403, 404, 500, 502, 503, 504],
+        allowed_methods=["GET", "POST"],
+        backoff_factor=3,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+
     # Non mnt directory
-    req = request.Request(
+    response = client.get(
         service_url, headers={"Authorization": f"Bearer {auth_token}"}
     )
-    response = request.urlopen(req)
-    assert response.status == 200
+    assert response.status_code == 200
 
     # Mnt directory
     mnt_url = f"{service_url}/mnt/nfs/filestore"
-    req = request.Request(mnt_url, headers={"Authorization": f"Bearer {auth_token}"})
-    response = request.urlopen(req)
-    assert response.status == 200
+    response = client.get(mnt_url, headers={"Authorization": f"Bearer {auth_token}"})
+    assert response.status_code == 200
 
     date = datetime.datetime.utcnow()
-    body = response.read()
+    body = response.content.decode("UTF-8")
     assert "{dt:%a}-{dt:%b}-{dt:%d}-{dt:%H}".format(dt=date) in body.decode()

--- a/run/filesystem/e2e_test.py
+++ b/run/filesystem/e2e_test.py
@@ -19,7 +19,6 @@
 import datetime
 import os
 import subprocess
-from urllib import request
 import uuid
 
 import pytest
@@ -133,6 +132,8 @@ def test_end_to_end(service_url_auth_token):
         backoff_factor=3,
     )
     adapter = HTTPAdapter(max_retries=retry_strategy)
+    client = requests.session()
+    client.mount("https://", adapter)
 
     # Non mnt directory
     response = client.get(

--- a/run/filesystem/requirements-test.txt
+++ b/run/filesystem/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest==7.0.1
+requests==2.31.0

--- a/run/hello-broken/e2e_test.py
+++ b/run/hello-broken/e2e_test.py
@@ -20,6 +20,9 @@ import os
 import subprocess
 import time
 from urllib import request
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 import uuid
 
 import pytest

--- a/run/hello-broken/e2e_test.py
+++ b/run/hello-broken/e2e_test.py
@@ -19,14 +19,14 @@
 import os
 import subprocess
 import time
-import requests
 import uuid
-
 from urllib import request
+
+import requests
 from requests.adapters import HTTPAdapter
+import pytest
 from requests.packages.urllib3.util.retry import Retry
 
-import pytest
 
 # Unique suffix to create distinct service names
 SUFFIX = uuid.uuid4().hex[:10]

--- a/run/hello-broken/e2e_test.py
+++ b/run/hello-broken/e2e_test.py
@@ -19,11 +19,12 @@
 import os
 import subprocess
 import time
-from urllib import request
 import requests
+import uuid
+
+from urllib import request
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-import uuid
 
 import pytest
 

--- a/run/hello-broken/e2e_test.py
+++ b/run/hello-broken/e2e_test.py
@@ -22,8 +22,8 @@ import time
 from urllib import request
 import uuid
 
-import requests
 import pytest
+import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 

--- a/run/hello-broken/e2e_test.py
+++ b/run/hello-broken/e2e_test.py
@@ -19,12 +19,12 @@
 import os
 import subprocess
 import time
-import uuid
 from urllib import request
+import uuid
 
 import requests
-from requests.adapters import HTTPAdapter
 import pytest
+from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 

--- a/run/hello-broken/e2e_test.py
+++ b/run/hello-broken/e2e_test.py
@@ -19,7 +19,6 @@
 import os
 import subprocess
 import time
-from urllib import request
 import uuid
 
 import pytest

--- a/run/hello-broken/requirements-test.txt
+++ b/run/hello-broken/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest==7.0.1
+requests==2.31.0

--- a/run/idp-sql/e2e_test.py
+++ b/run/idp-sql/e2e_test.py
@@ -79,7 +79,7 @@ if not IDP_KEY:
 
 retry_strategy = Retry(
     total=5,
-    status_forcelist=[400, 401, 403, 500, 502, 503, 504],
+    status_forcelist=[400, 401, 403, 404, 500, 502, 503, 504],
     allowed_methods=["GET", "POST"],
     backoff_factor=5,
 )

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -18,13 +18,13 @@
 import os
 import subprocess
 from urllib import error, request
-import requests
 import uuid
 
+import requests
 from requests.adapters import HTTPAdapter
+import pytest
 from requests.packages.urllib3.util.retry import Retry
 
-import pytest
 
 
 @pytest.fixture()

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -26,7 +26,6 @@ import pytest
 from requests.packages.urllib3.util.retry import Retry
 
 
-
 @pytest.fixture()
 def services():
     # Unique suffix to create distinct service names

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -20,9 +20,9 @@ import subprocess
 from urllib import error, request
 import uuid
 
+import pytest
 import requests
 from requests.adapters import HTTPAdapter
-import pytest
 from requests.packages.urllib3.util.retry import Retry
 
 

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -23,7 +23,7 @@ import uuid
 import pytest
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from requests.packages.urllib3.util.retry import Retr
 
 
 @pytest.fixture()

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -18,6 +18,9 @@
 import os
 import subprocess
 from urllib import error, request
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 import uuid
 
 import pytest

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -98,8 +98,19 @@ def test_auth(services):
     except error.HTTPError as e:
         assert e.code == 403
 
-    req = request.Request(url, headers={"Authorization": f"Bearer {token}"})
-    response = request.urlopen(req)
-    assert response.status == 200
-    assert "Hello" in response.read().decode()
-    assert "anonymous" not in response.read().decode()
+    retry_strategy = Retry(
+        total=3,
+        status_forcelist=[400, 401, 403, 404, 500, 502, 503, 504],
+        allowed_methods=["GET", "POST"],
+        backoff_factor=3,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+
+    client = requests.session()
+    client.mount("https://", adapter)
+
+    response = client.get(url, headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert "Hello" in response.content.decode("UTF-8")
+    assert "anonymous" not in response.content.decode("UTF-8")

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -19,9 +19,10 @@ import os
 import subprocess
 from urllib import error, request
 import requests
+import uuid
+
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-import uuid
 
 import pytest
 

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -23,7 +23,7 @@ import uuid
 import pytest
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retr
+from requests.packages.urllib3.util.retry import Retry
 
 
 @pytest.fixture()

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -20,8 +20,8 @@ import os
 import subprocess
 import uuid
 
-import requests
 import pytest
+import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -19,9 +19,10 @@
 import os
 import subprocess
 import requests
+import uuid
+
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-import uuid
 
 import pytest
 

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -21,8 +21,8 @@ import subprocess
 import uuid
 
 import requests
-from requests.adapters import HTTPAdapter
 import pytest
+from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -18,7 +18,9 @@
 
 import os
 import subprocess
-from urllib import request
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 import uuid
 
 import pytest
@@ -143,19 +145,29 @@ def service_url_auth_token(deployed_service):
 def test_end_to_end(service_url_auth_token):
     service_url, auth_token = service_url_auth_token
 
-    data = "diagram.png?dot=digraph G { A -> {B, C, D} -> {F} }".replace(" ", "%20")
-    print(f"{service_url}{data}")
+    data = "diagram.png?dot=digraph G { A -> {B, C, D} -> {F} }".replace(
+        " ", "%20")
+    print(f"{service_url}/{data}")
 
-    req = request.Request(
+    retry_strategy = Retry(
+        total=3,
+        status_forcelist=[400, 401, 403, 404, 500, 502, 503, 504],
+        allowed_methods=["GET", "POST"],
+        backoff_factor=3,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+
+    client = requests.session()
+    client.mount("https://", adapter)
+
+    response = client.get(
         f"{service_url}/{data}",
         headers={
             "Authorization": f"Bearer {auth_token}",
         },
     )
+    assert response.status_code == 200
 
-    response = request.urlopen(req)
-    assert response.status == 200
-
-    body = response.read()
+    body = response.content.decode("UTF-8")
     # Response is a png
-    assert b"PNG" in body
+    assert "PNG" in body

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -145,8 +145,7 @@ def service_url_auth_token(deployed_service):
 def test_end_to_end(service_url_auth_token):
     service_url, auth_token = service_url_auth_token
 
-    data = "diagram.png?dot=digraph G { A -> {B, C, D} -> {F} }".replace(
-        " ", "%20")
+    data = "diagram.png?dot=digraph G { A -> {B, C, D} -> {F} }".replace(" ", "%20")
     print(f"{service_url}/{data}")
 
     retry_strategy = Retry(

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -18,13 +18,13 @@
 
 import os
 import subprocess
-import requests
 import uuid
 
+import requests
 from requests.adapters import HTTPAdapter
+import pytest
 from requests.packages.urllib3.util.retry import Retry
 
-import pytest
 
 # build container image + push w/ cloud build
 # deploy to cloud run

--- a/run/system-package/e2e_test.py
+++ b/run/system-package/e2e_test.py
@@ -168,6 +168,6 @@ def test_end_to_end(service_url_auth_token):
     )
     assert response.status_code == 200
 
-    body = response.content.decode("UTF-8")
+    body = response.content
     # Response is a png
-    assert "PNG" in body
+    assert b"PNG" in body

--- a/run/system-package/requirements-test.txt
+++ b/run/system-package/requirements-test.txt
@@ -1,1 +1,2 @@
 pytest==7.0.1
+requests==2.31.0


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved