### PR TITLE
Fix: [DLP] Mocked stored infotype related test cases to resolve #10556

### DIFF
--- a/dlp/snippets/stored_infotype_test.py
+++ b/dlp/snippets/stored_infotype_test.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import os
-import time
-from typing import Iterator
+
+from unittest import mock
+from unittest.mock import MagicMock
+
 import uuid
 
-import google.api_core.exceptions
-import google.cloud.dlp_v2
-import google.cloud.exceptions
-import google.cloud.storage
 import pytest
 
 import stored_infotype
@@ -32,82 +30,79 @@ RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "resources")
 RESOURCE_FILE_NAMES = ["term_list.txt"]
 STORED_INFO_TYPE_ID = "github-usernames" + UNIQUE_STRING
 
-DLP_CLIENT = google.cloud.dlp_v2.DlpServiceClient()
 
-
-@pytest.fixture(scope="module")
-def bucket() -> Iterator[google.cloud.storage.bucket.Bucket]:
-    # Creates a GCS bucket, uploads files required for the test, and tears down
-    # the entire bucket afterwards.
-
-    client = google.cloud.storage.Client()
-    try:
-        bucket = client.get_bucket(TEST_BUCKET_NAME)
-    except google.cloud.exceptions.NotFound:
-        bucket = client.create_bucket(TEST_BUCKET_NAME)
-
-    # Upload the blobs and keep track of them in a list.
-    blobs = []
-    for name in RESOURCE_FILE_NAMES:
-        path = os.path.join(RESOURCE_DIRECTORY, name)
-        blob = bucket.blob(name)
-        blob.upload_from_filename(path)
-        blobs.append(blob)
-
-    # Yield the object to the test; lines after this execute as a teardown.
-    yield bucket
-
-    # Delete the files.
-    for blob in blobs:
-        try:
-            blob.delete()
-        except google.cloud.exceptions.NotFound:
-            print("Issue during teardown, missing blob")
-
-    bucket.delete(force=True)
-
-
-def delete_stored_info_type(out: str) -> None:
-    for line in str(out).split("\n"):
-        if "Updated stored infoType successfully" in line:
-            stored_info_type_id = line.split(":")[1].strip()
-            DLP_CLIENT.delete_stored_info_type(name=stored_info_type_id)
-
-
-def test_create_update_and_inspect_with_stored_infotype(
-    bucket: google.cloud.storage.bucket.Bucket, capsys: pytest.CaptureFixture
+@mock.patch("google.cloud.dlp_v2.DlpServiceClient")
+def test_create_stored_infotype(
+    dlp_client: MagicMock, capsys: pytest.CaptureFixture
 ) -> None:
-    out = ""
-    try:
-        stored_infotype.create_stored_infotype(
-            GCLOUD_PROJECT,
-            STORED_INFO_TYPE_ID,
-            bucket.name,
-        )
-        out, _ = capsys.readouterr()
-        assert STORED_INFO_TYPE_ID in out
+    # Configure the mock DLP client and its behavior.
+    mock_dlp_instance = dlp_client.return_value
 
-        stored_info_type_id = str(out).split("\n")[0].split(":")[1].strip()
+    # Configure the mock CreateStoredInfoType DLP method and its behavior.
+    mock_dlp_instance.create_stored_info_type.return_value.name = (
+        f"projects/{GCLOUD_PROJECT}/storedInfoTypes/{STORED_INFO_TYPE_ID}"
+    )
 
-        stored_infotype.update_stored_infotype(
-            GCLOUD_PROJECT,
-            STORED_INFO_TYPE_ID,
-            f"{bucket.name}/{RESOURCE_FILE_NAMES[0]}",
-            f"{bucket.name}",
-        )
-        out, _ = capsys.readouterr()
-        assert stored_info_type_id in out
+    stored_infotype.create_stored_infotype(
+        GCLOUD_PROJECT,
+        STORED_INFO_TYPE_ID,
+        TEST_BUCKET_NAME,
+    )
 
-        time.sleep(30)
+    out, _ = capsys.readouterr()
+    assert STORED_INFO_TYPE_ID in out
 
-        stored_infotype.inspect_with_stored_infotype(
-            GCLOUD_PROJECT,
-            STORED_INFO_TYPE_ID,
-            "The commit was made by gary1998",
-        )
-        out, _ = capsys.readouterr()
-        assert "STORED_TYPE" in out
-        assert "Quote: gary1998" in out
 
-    finally:
-        delete_stored_info_type(out)
+@mock.patch("google.cloud.dlp_v2.DlpServiceClient")
+def test_update_stored_infotype_dictionary(
+    dlp_client: MagicMock,
+    capsys: pytest.CaptureFixture
+) -> None:
+    # Configure the mock DLP client and its behavior.
+    mock_dlp_instance = dlp_client.return_value
+
+    # Configure the mock UpdateStoredInfoType DLP method and its behavior.
+    stored_infotype_path = f"projects/{GCLOUD_PROJECT}/storedInfoTypes/{STORED_INFO_TYPE_ID}"
+    mock_dlp_instance.update_stored_info_type.return_value.name = stored_infotype_path
+
+    test_updated_list_path = f"{TEST_BUCKET_NAME}/{RESOURCE_FILE_NAMES[0]}"
+
+    stored_infotype.update_stored_infotype(
+        GCLOUD_PROJECT,
+        STORED_INFO_TYPE_ID,
+        test_updated_list_path,
+        TEST_BUCKET_NAME,
+    )
+
+    out, _ = capsys.readouterr()
+    assert stored_infotype_path in out
+
+
+@mock.patch("google.cloud.dlp_v2.DlpServiceClient")
+def test_inspect_with_stored_infotype(
+    dlp_client: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    # Configure the mock DLP client and its behavior.
+    mock_dlp_instance = dlp_client.return_value
+
+    # Configure the mock InspectContent DLP method and its behavior.
+    mock_inspect_result = mock_dlp_instance.inspect_content.return_value
+
+    mock_inspect_result.result.findings.info_type.name = "STORED_TYPE"
+    finding = mock_inspect_result.result.findings.info_type
+
+    mock_inspect_result.result.findings = [
+        MagicMock(info_type=finding, quote="gary1998", likelihood='LIKELY'),
+    ]
+
+    # Call the sample.
+    stored_infotype.inspect_with_stored_infotype(
+        GCLOUD_PROJECT,
+        STORED_INFO_TYPE_ID,
+        "The commit was made by gary1998",
+    )
+
+    out, _ = capsys.readouterr()
+    assert "STORED_TYPE" in out
+    assert "Quote: gary1998" in out


### PR DESCRIPTION
## Description
This is a duplicate PR of #10567 (I have closed #10567 as CLA test was failing). Please re-review this one. Thank you!

Details:
Mocked stored Info type related test cases solving the revert request: #10556

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved