### PR TITLE
Update main.py

### DIFF
--- a/appengine/standard_python3/pubsub/main.py
+++ b/appengine/standard_python3/pubsub/main.py
@@ -21,7 +21,7 @@ import os
 from flask import current_app, Flask, render_template, request
 from google.auth.transport import requests
 from google.cloud import pubsub_v1
-from google.oauth2 import id_token
+# from google.oauth2 import id_token
 
 
 app = Flask(__name__)

--- a/appengine/standard_python3/pubsub/main.py
+++ b/appengine/standard_python3/pubsub/main.py
@@ -19,7 +19,7 @@ import logging
 import os
 
 from flask import current_app, Flask, render_template, request
-from google.auth.transport import requests
+# from google.auth.transport import requests
 from google.cloud import pubsub_v1
 # from google.oauth2 import id_token
 

--- a/appengine/standard_python3/pubsub/main.py
+++ b/appengine/standard_python3/pubsub/main.py
@@ -72,33 +72,33 @@ def receive_messages_handler():
         return "Invalid request", 400
 
     # Verify that the push request originates from Cloud Pub/Sub.
-    try:
-        # Get the Cloud Pub/Sub-generated JWT in the "Authorization" header.
-        bearer_token = request.headers.get("Authorization")
-        token = bearer_token.split(" ")[1]
-        TOKENS.append(token)
+    # try:
+    #     # Get the Cloud Pub/Sub-generated JWT in the "Authorization" header.
+    #     bearer_token = request.headers.get("Authorization")
+    #     token = bearer_token.split(" ")[1]
+    #     TOKENS.append(token)
 
-        # Verify and decode the JWT. `verify_oauth2_token` verifies
-        # the JWT signature, the `aud` claim, and the `exp` claim.
-        # Note: For high volume push requests, it would save some network
-        # overhead if you verify the tokens offline by downloading Google's
-        # Public Cert and decode them using the `google.auth.jwt` module;
-        # caching already seen tokens works best when a large volume of
-        # messages have prompted a single push server to handle them, in which
-        # case they would all share the same token for a limited time window.
-        claim = id_token.verify_oauth2_token(
-            token, requests.Request(), audience="example.com"
-        )
+    #     # Verify and decode the JWT. `verify_oauth2_token` verifies
+    #     # the JWT signature, the `aud` claim, and the `exp` claim.
+    #     # Note: For high volume push requests, it would save some network
+    #     # overhead if you verify the tokens offline by downloading Google's
+    #     # Public Cert and decode them using the `google.auth.jwt` module;
+    #     # caching already seen tokens works best when a large volume of
+    #     # messages have prompted a single push server to handle them, in which
+    #     # case they would all share the same token for a limited time window.
+    #     claim = id_token.verify_oauth2_token(
+    #         token, requests.Request(), audience="example.com"
+    #     )
 
-        # IMPORTANT: you should validate claim details not covered by signature
-        # and audience verification above, including:
-        #   - Ensure that `claim["email"]` is equal to the expected service
-        #     account set up in the push subscription settings.
-        #   - Ensure that `claim["email_verified"]` is set to true.
+    #     # IMPORTANT: you should validate claim details not covered by signature
+    #     # and audience verification above, including:
+    #     #   - Ensure that `claim["email"]` is equal to the expected service
+    #     #     account set up in the push subscription settings.
+    #     #   - Ensure that `claim["email_verified"]` is set to true.
 
-        CLAIMS.append(claim)
-    except Exception as e:
-        return f"Invalid token: {e}\n", 400
+    #     CLAIMS.append(claim)
+    # except Exception as e:
+    #     return f"Invalid token: {e}\n", 400
 
     envelope = json.loads(request.data.decode("utf-8"))
     payload = base64.b64decode(envelope["message"]["data"])


### PR DESCRIPTION
To match other examples maybe it's best to comment this out or remove it

The difference in effect cause this part of instruction returns to 400 - https://cloud.google.com/appengine/docs/standard/writing-and-responding-to-pub-sub-messages?tab=python#simulating_push_notifications

If this is intentional; we should update the doc to get the token to be passed in the request header

context: 
- https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/appengine/flexible/pubsub/main.py#L64-L75
- https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/appengine/flexible_python37_and_earlier/pubsub/main.py#L64-L75
- https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/appengine/standard/pubsub/main.py#L62-L73

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved