### PR TITLE
Fix: [DLP] bug fix #10556

### DIFF
--- a/dlp/snippets/stored_infotype_test.py
+++ b/dlp/snippets/stored_infotype_test.py
@@ -67,17 +67,10 @@ def bucket() -> Iterator[google.cloud.storage.bucket.Bucket]:
     bucket.delete(force=True)
 
 
-def delete_stored_info_type(out: str) -> None:
-    for line in str(out).split("\n"):
-        if "Updated stored infoType successfully" in line:
-            stored_info_type_id = line.split(":")[1].strip()
-            DLP_CLIENT.delete_stored_info_type(name=stored_info_type_id)
-
-
 def test_create_update_and_inspect_with_stored_infotype(
     bucket: google.cloud.storage.bucket.Bucket, capsys: pytest.CaptureFixture
 ) -> None:
-    out = ""
+    stored_info_type_id = ""
     try:
         stored_infotype.create_stored_infotype(
             GCLOUD_PROJECT,
@@ -110,4 +103,4 @@ def test_create_update_and_inspect_with_stored_infotype(
         assert "Quote: gary1998" in out
 
     finally:
-        delete_stored_info_type(out)
+        DLP_CLIENT.delete_stored_info_type(name=stored_info_type_id)

--- a/dlp/snippets/stored_infotype_test.py
+++ b/dlp/snippets/stored_infotype_test.py
@@ -30,7 +30,7 @@ UNIQUE_STRING = str(uuid.uuid4()).split("-")[0]
 TEST_BUCKET_NAME = GCLOUD_PROJECT + "-dlp-python-client-test" + UNIQUE_STRING
 RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "resources")
 RESOURCE_FILE_NAMES = ["term_list.txt"]
-STORED_INFO_TYPE_ID = "github-usernames" + UNIQUE_STRING
+STORED_INFO_TYPE_ID = "github-user-names" + UNIQUE_STRING
 
 DLP_CLIENT = google.cloud.dlp_v2.DlpServiceClient()
 


### PR DESCRIPTION
## Description
solving the revert request: #10556

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved