### PR TITLE
Fix(KMS): Fixing failling tests

### DIFF
--- a/kms/snippets/requirements.txt
+++ b/kms/snippets/requirements.txt
@@ -1,4 +1,5 @@
-google-cloud-kms==2.17.0
+google-cloud-kms==2.19.1
 cryptography==41.0.3
 crcmod==1.7
 jwcrypto==1.5.0
+six==1.16.0


### PR DESCRIPTION
## Description

Add missing requirement + bump up google-cloud-kms versions.

Fixes #10609 #10610 #10611 #10612 #10613 #10614

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] Please **merge** this PR for me once it is approved