### PR TITLE
chore(KMS): Remove six dependency

### DIFF
--- a/kms/snippets/decrypt_asymmetric.py
+++ b/kms/snippets/decrypt_asymmetric.py
@@ -84,10 +84,9 @@ def crc32c(data: bytes) -> int:
         An int representing the CRC32C checksum of the provided bytes.
     """
     import crcmod  # type: ignore
-    import six  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(six.ensure_binary(data))
+    return crc32c_fun(bytes(data))
 
 
 # [END kms_decrypt_asymmetric]

--- a/kms/snippets/decrypt_asymmetric.py
+++ b/kms/snippets/decrypt_asymmetric.py
@@ -86,7 +86,7 @@ def crc32c(data: bytes) -> int:
     import crcmod  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(bytes(data))
+    return crc32c_fun(data)
 
 
 # [END kms_decrypt_asymmetric]

--- a/kms/snippets/decrypt_symmetric.py
+++ b/kms/snippets/decrypt_symmetric.py
@@ -76,7 +76,7 @@ def crc32c(data: bytes) -> int:
     import crcmod  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(bytes(data))
+    return crc32c_fun(data)
 
 
 # [END kms_decrypt_symmetric]

--- a/kms/snippets/decrypt_symmetric.py
+++ b/kms/snippets/decrypt_symmetric.py
@@ -74,10 +74,9 @@ def crc32c(data: bytes) -> int:
         An int representing the CRC32C checksum of the provided bytes.
     """
     import crcmod  # type: ignore
-    import six  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(six.ensure_binary(data))
+    return crc32c_fun(bytes(data))
 
 
 # [END kms_decrypt_symmetric]

--- a/kms/snippets/encrypt_symmetric.py
+++ b/kms/snippets/encrypt_symmetric.py
@@ -89,7 +89,7 @@ def crc32c(data: bytes) -> int:
     import crcmod  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(bytes(data))
+    return crc32c_fun(data)
 
 
 # [END kms_encrypt_symmetric]

--- a/kms/snippets/encrypt_symmetric.py
+++ b/kms/snippets/encrypt_symmetric.py
@@ -87,10 +87,9 @@ def crc32c(data: bytes) -> int:
         An int representing the CRC32C checksum of the provided bytes.
     """
     import crcmod  # type: ignore
-    import six  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(six.ensure_binary(data))
+    return crc32c_fun(bytes(data))
 
 
 # [END kms_encrypt_symmetric]

--- a/kms/snippets/get_public_key.py
+++ b/kms/snippets/get_public_key.py
@@ -69,10 +69,9 @@ def crc32c(data: bytes) -> int:
         An int representing the CRC32C checksum of the provided bytes.
     """
     import crcmod  # type: ignore
-    import six  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(six.ensure_binary(data))
+    return crc32c_fun(bytes(data))
 
 
 # [END kms_get_public_key]

--- a/kms/snippets/get_public_key.py
+++ b/kms/snippets/get_public_key.py
@@ -50,7 +50,7 @@ def get_public_key(
     if not public_key.name == key_version_name:
         raise Exception("The request sent to the server was corrupted in-transit.")
     # See crc32c() function defined below.
-    if not public_key.pem_crc32c == crc32c(public_key.pem):
+    if not public_key.pem_crc32c == crc32c(public_key.pem.encode("utf-8")):
         raise Exception(
             "The response received from the server was corrupted in-transit."
         )
@@ -71,7 +71,7 @@ def crc32c(data: bytes) -> int:
     import crcmod  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(bytes(data))
+    return crc32c_fun(data)
 
 
 # [END kms_get_public_key]

--- a/kms/snippets/get_public_key_jwk.py
+++ b/kms/snippets/get_public_key_jwk.py
@@ -51,7 +51,7 @@ def get_public_key_jwk(
     if not public_key.name == key_version_name:
         raise Exception("The request sent to the server was corrupted in-transit.")
     # See crc32c() function defined below.
-    if not public_key.pem_crc32c == crc32c(public_key.pem):
+    if not public_key.pem_crc32c == crc32c(public_key.pem.encode("utf-8")):
         raise Exception(
             "The response received from the server was corrupted in-transit."
         )
@@ -73,7 +73,7 @@ def crc32c(data: bytes) -> int:
     import crcmod  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(bytes(data))
+    return crc32c_fun(data)
 
 
 # [END kms_get_public_key_jwk]

--- a/kms/snippets/get_public_key_jwk.py
+++ b/kms/snippets/get_public_key_jwk.py
@@ -71,10 +71,9 @@ def crc32c(data: bytes) -> int:
         An int representing the CRC32C checksum of the provided bytes.
     """
     import crcmod  # type: ignore
-    import six  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(six.ensure_binary(data))
+    return crc32c_fun(bytes(data))
 
 
 # [END kms_get_public_key_jwk]

--- a/kms/snippets/requirements.txt
+++ b/kms/snippets/requirements.txt
@@ -2,4 +2,3 @@ google-cloud-kms==2.19.1
 cryptography==41.0.3
 crcmod==1.7
 jwcrypto==1.5.0
-six==1.16.0

--- a/kms/snippets/sign_asymmetric.py
+++ b/kms/snippets/sign_asymmetric.py
@@ -106,7 +106,7 @@ def crc32c(data: bytes) -> int:
     import crcmod  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(bytes(data))
+    return crc32c_fun(data)
 
 
 # [END kms_sign_asymmetric]

--- a/kms/snippets/sign_asymmetric.py
+++ b/kms/snippets/sign_asymmetric.py
@@ -104,10 +104,9 @@ def crc32c(data: bytes) -> int:
         An int representing the CRC32C checksum of the provided bytes.
     """
     import crcmod  # type: ignore
-    import six  # type: ignore
 
     crc32c_fun = crcmod.predefined.mkPredefinedCrcFun("crc-32c")
-    return crc32c_fun(six.ensure_binary(data))
+    return crc32c_fun(bytes(data))
 
 
 # [END kms_sign_asymmetric]


### PR DESCRIPTION
## Description

Follow-up to previous fix - complete removal of `six` dependency as we no longer support Python 2.7.

Fixes #10614
Fixes #10613
Fixes #10612 
Fixes #10611 
Fixes #10610 
Fixes #10609 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] Please **merge** this PR for me once it is approved