### PR TITLE
fix: refactor error reporting code sample

### DIFF
--- a/error_reporting/snippets/report_exception.py
+++ b/error_reporting/snippets/report_exception.py
@@ -17,13 +17,13 @@
 
 # [START error_reporting_quickstart]
 # [START error_reporting_setup_python]
-def simulate_error():
+def report_exception():
     from google.cloud import error_reporting
 
     client = error_reporting.Client()
     try:
         # simulate calling a method that's not defined
-        raise NameError
+        raise Exception('Something went wrong')
     except Exception:
         client.report_exception()
 
@@ -46,5 +46,5 @@ def report_manual_error():
 
 
 if __name__ == "__main__":
-    simulate_error()
+    report_exception()
     report_manual_error()

--- a/error_reporting/snippets/report_exception.py
+++ b/error_reporting/snippets/report_exception.py
@@ -22,7 +22,6 @@ def report_exception():
 
     client = error_reporting.Client()
     try:
-        # simulate calling a method that's not defined
         raise Exception('Something went wrong')
     except Exception:
         client.report_exception()

--- a/error_reporting/snippets/report_exception.py
+++ b/error_reporting/snippets/report_exception.py
@@ -22,7 +22,7 @@ def report_exception():
 
     client = error_reporting.Client()
     try:
-        raise Exception('Something went wrong')
+        raise Exception("Something went wrong")
     except Exception:
         client.report_exception()
 

--- a/error_reporting/snippets/report_exception_test.py
+++ b/error_reporting/snippets/report_exception_test.py
@@ -18,7 +18,7 @@ import report_exception
 
 
 def test_error_sends():
-    report_exception.simulate_error()
+    report_exception.report_exception()
 
 
 def test_manual_error_sends():


### PR DESCRIPTION
align code sample for error reporting with code in other languages (b/275730159):

- use the "same" exception type and message
- refactor the method name

