### PR TITLE
fix: add constraint to the age of import log range

### DIFF
--- a/logging/import-logs/main.py
+++ b/logging/import-logs/main.py
@@ -79,6 +79,18 @@ def _day(blob_name: str) -> int:
     return int(blob_name[offset : offset + 2])
 
 
+def _is_valid_import_range() -> bool:
+    if START_DATE > END_DATE:
+        eprint("Start date of the import time range should be earlier than end date")
+        return False
+    # avoid importing time range older than 29 days
+    today = date.today()
+    if (today - START_DATE).days > 29 or (today - END_DATE).days > 29:
+        eprint("Date range includes days older than 29 days from today.")
+        return False
+    return True
+
+
 def calc_import_range() -> Tuple[date, date]:
     """Calculate import range for the task based on full import range and number of tasks"""
     if TASK_COUNT == 1:
@@ -201,12 +213,10 @@ def import_logs(
 
 def main() -> None:
     """Imports logs from Cloud Storage to Cloud Logging"""
-
     if not START_DATE or not END_DATE or not LOG_ID or not BUCKET_NAME:
         eprint("Missing some of required parameters")
         sys.exit(1)
-    if START_DATE > END_DATE:
-        eprint("Start date of the import time range should be earlier than end date")
+    if not _is_valid_import_range():
         sys.exit(1)
 
     start_date, end_date = calc_import_range()

--- a/logging/import-logs/main.py
+++ b/logging/import-logs/main.py
@@ -80,13 +80,16 @@ def _day(blob_name: str) -> int:
 
 
 def _is_valid_import_range() -> bool:
+    """Check the import range dates to ensure that
+    - start date is earlier than end date
+    - no dates in the range is older than 29 days
+    (for reason see https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.timestamp)
+    """
     if START_DATE > END_DATE:
         eprint("Start date of the import time range should be earlier than end date")
         return False
-    # avoid importing time range older than 29 days
-    today = date.today()
-    if (today - START_DATE).days > 29 or (today - END_DATE).days > 29:
-        eprint("Date range includes days older than 29 days from today.")
+    if (date.today() - START_DATE).days > 29:
+        eprint("Import range includes dates older than 29 days from today.")
         return False
     return True
 

--- a/logging/import-logs/main_test.py
+++ b/logging/import-logs/main_test.py
@@ -56,34 +56,21 @@ def _setup_environment(
 @pytest.mark.parametrize(
     "start_date, end_date, expected_validity",
     [
-        (
-            date.today() - timedelta(days=29),
-            date.today() - timedelta(days=10),
-            True
-        ),
-        (
-            date.today() - timedelta(days=10),
-            date.today() - timedelta(days=29),
-            False
-        ),
-        (
-            date.today() - timedelta(days=30),
-            date.today(),
-            False
-        ),
-        (
-            '07/01/2023',
-            '06/01/2023',
-            False
-        ),
+        (date.today() - timedelta(days=29), date.today() - timedelta(days=10), True),
+        (date.today() - timedelta(days=10), date.today() - timedelta(days=29), False),
+        (date.today() - timedelta(days=30), date.today(), False),
+        ("07/01/2023", "06/01/2023", False),
     ],
     ids=[
         "valid range",
         "invalid range: start later than end",
         "invalid range: start older than 29 days",
         "invalid range: end older than 29 days",
-    ],)
-def test_import_range_validation(start_date: str, end_date: str, expected_validity: bool) -> None:
+    ],
+)
+def test_import_range_validation(
+    start_date: str, end_date: str, expected_validity: bool
+) -> None:
     _setup_environment(
         start_date=start_date,
         end_date=end_date,
@@ -137,8 +124,7 @@ def test_import_range_validation(start_date: str, end_date: str, expected_validi
             date(2001, 1, 22),
             date(2001, 2, 1),
         ),
-        (date(2001, 5, 5), date(2002, 2, 2), 1,
-         2, date(2001, 9, 19), date(2002, 2, 2)),
+        (date(2001, 5, 5), date(2002, 2, 2), 1, 2, date(2001, 9, 19), date(2002, 2, 2)),
     ],
     ids=[
         "simple single range",
@@ -175,104 +161,61 @@ def test_calc_import_range(
 
 
 TEST_FILES_JUN_2001 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JUL_2001 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_AUG_2001 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAY_2002 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JAN_2003 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_FEB_2003 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAR_2003 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
 ]
 
 
@@ -305,8 +248,7 @@ def _args_based_list_blobs_return(*_args: str, **kwargs: TypedDict) -> List[str]
 @pytest.mark.parametrize(
     "first_day, last_day, expected_paths",
     [
-        (date(2001, 6, 1), date(2001, 6, 30), [
-         f.name for f in TEST_FILES_JUN_2001]),
+        (date(2001, 6, 1), date(2001, 6, 30), [f.name for f in TEST_FILES_JUN_2001]),
         (
             date(2001, 6, 2),
             date(2001, 6, 3),
@@ -333,8 +275,7 @@ def test_list_log_files(first_day: str, last_day: str, expected_paths: List) -> 
     _setup_environment()
 
     mocked_client = MagicMock(spec=storage.Client)
-    mocked_client.list_blobs = MagicMock(
-        side_effect=_args_based_list_blobs_return)
+    mocked_client.list_blobs = MagicMock(side_effect=_args_based_list_blobs_return)
 
     paths = main.list_log_files(first_day, last_day, mocked_client)
 
@@ -355,8 +296,7 @@ TEST_LOG_SIZE = sys.getsizeof(json.loads(TEST_CONTENT["file4.json"]))
 
 def _args_based_blob_return(*args: Tuple, **_kwargs: TypedDict) -> str:
     mocked_blob = MagicMock(spec=storage.Blob)
-    mocked_blob.download_as_string = MagicMock(
-        return_value=TEST_CONTENT.get(args[0]))
+    mocked_blob.download_as_string = MagicMock(return_value=TEST_CONTENT.get(args[0]))
     return mocked_blob
 
 
@@ -375,8 +315,7 @@ def _calc_args_size(*args: Tuple) -> int:
         (
             TEST_LOG_FILES[:2],
             (TEST_LOG_SIZE + 10),
-            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE,
-                TEST_LOG_SIZE, TEST_LOG_SIZE],
+            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE],
         ),
         (
             TEST_LOG_FILES[:3],

--- a/logging/import-logs/main_test.py
+++ b/logging/import-logs/main_test.py
@@ -17,7 +17,7 @@
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-return-statements
 
-from datetime import date
+from datetime import date, timedelta
 import json
 import os
 import sys
@@ -51,6 +51,47 @@ def _setup_environment(
     main.START_DATE = start_date
     main.END_DATE = end_date
     main._LOGS_MAX_SIZE_BYTES = max_size  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    "start_date, end_date, expected_validity",
+    [
+        (
+            date.today() - timedelta(days=29),
+            date.today() - timedelta(days=10),
+            True
+        ),
+        (
+            date.today() - timedelta(days=10),
+            date.today() - timedelta(days=29),
+            False
+        ),
+        (
+            date.today() - timedelta(days=30),
+            date.today(),
+            False
+        ),
+        (
+            '07/01/2023',
+            '06/01/2023',
+            False
+        ),
+    ],
+    ids=[
+        "valid range",
+        "invalid range: start later than end",
+        "invalid range: start older than 29 days",
+        "invalid range: end older than 29 days",
+    ],)
+def test_import_range_validation(start_date: str, end_date: str, expected_validity: bool) -> None:
+    _setup_environment(
+        start_date=start_date,
+        end_date=end_date,
+    )
+    isvalid = main._is_valid_import_range()  # pylint: disable=protected-access
+    assert (
+        isvalid == expected_validity
+    ), f"import range ({start_date} -> {end_date}) validation failed: expected {expected_validity} and got {isvalid}"
 
 
 @pytest.mark.parametrize(
@@ -96,7 +137,8 @@ def _setup_environment(
             date(2001, 1, 22),
             date(2001, 2, 1),
         ),
-        (date(2001, 5, 5), date(2002, 2, 2), 1, 2, date(2001, 9, 19), date(2002, 2, 2)),
+        (date(2001, 5, 5), date(2002, 2, 2), 1,
+         2, date(2001, 9, 19), date(2002, 2, 2)),
     ],
     ids=[
         "simple single range",
@@ -133,61 +175,104 @@ def test_calc_import_range(
 
 
 TEST_FILES_JUN_2001 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JUL_2001 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_AUG_2001 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAY_2002 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JAN_2003 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_FEB_2003 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAR_2003 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
 ]
 
 
@@ -220,7 +305,8 @@ def _args_based_list_blobs_return(*_args: str, **kwargs: TypedDict) -> List[str]
 @pytest.mark.parametrize(
     "first_day, last_day, expected_paths",
     [
-        (date(2001, 6, 1), date(2001, 6, 30), [f.name for f in TEST_FILES_JUN_2001]),
+        (date(2001, 6, 1), date(2001, 6, 30), [
+         f.name for f in TEST_FILES_JUN_2001]),
         (
             date(2001, 6, 2),
             date(2001, 6, 3),
@@ -247,7 +333,8 @@ def test_list_log_files(first_day: str, last_day: str, expected_paths: List) -> 
     _setup_environment()
 
     mocked_client = MagicMock(spec=storage.Client)
-    mocked_client.list_blobs = MagicMock(side_effect=_args_based_list_blobs_return)
+    mocked_client.list_blobs = MagicMock(
+        side_effect=_args_based_list_blobs_return)
 
     paths = main.list_log_files(first_day, last_day, mocked_client)
 
@@ -268,7 +355,8 @@ TEST_LOG_SIZE = sys.getsizeof(json.loads(TEST_CONTENT["file4.json"]))
 
 def _args_based_blob_return(*args: Tuple, **_kwargs: TypedDict) -> str:
     mocked_blob = MagicMock(spec=storage.Blob)
-    mocked_blob.download_as_string = MagicMock(return_value=TEST_CONTENT.get(args[0]))
+    mocked_blob.download_as_string = MagicMock(
+        return_value=TEST_CONTENT.get(args[0]))
     return mocked_blob
 
 
@@ -287,7 +375,8 @@ def _calc_args_size(*args: Tuple) -> int:
         (
             TEST_LOG_FILES[:2],
             (TEST_LOG_SIZE + 10),
-            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE],
+            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE,
+                TEST_LOG_SIZE, TEST_LOG_SIZE],
         ),
         (
             TEST_LOG_FILES[:3],


### PR DESCRIPTION
Ensure that neither start nor end dates of the range are older than 29 days from now.

Fixes #10632
