### PR TITLE
chore(deps): Upgrade NDB version used in samples

### DIFF
--- a/datastore/cloud-ndb/requirements.txt
+++ b/datastore/cloud-ndb/requirements.txt
@@ -1,4 +1,4 @@
 # [START ndb_version]
-google-cloud-ndb==2.1.1
+google-cloud-ndb==2.2.1
 # [END ndb_version]
 Flask==2.1.0


### PR DESCRIPTION
## Description

Running the sample tests currently fails due to a missing dependency on `six`. As a temporary measure, version 2.2.1 adds `six` as a dependency (see https://github.com/googleapis/python-ndb/issues/911)

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample

1. [x] Please **merge** this PR for me once it is approved