### PR TITLE
feat(ndb): New sample for named-database support in Cloud NDB

### DIFF
--- a/datastore/cloud-ndb/named_db.py
+++ b/datastore/cloud-ndb/named_db.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def create_named_db_client():
+    # [START datastore_ndb_named_db]
+    import os
+
+    from google.cloud import ndb
+
+    database = os.environ.get("DATASTORE_DATABASE", "prod-database")
+    client = ndb.Client(database=database)
+    # [END datastore_ndb_named_db]
+    return client

--- a/datastore/cloud-ndb/named_db_test.py
+++ b/datastore/cloud-ndb/named_db_test.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from named_db import create_named_db_client
+
+
+def test_named_db():
+    os.environ["DATASTORE_DATABASE"] = "test"
+    client = create_named_db_client()
+    assert client.database == "test"

--- a/testing/test-env.tmpl.sh
+++ b/testing/test-env.tmpl.sh
@@ -113,3 +113,6 @@ export CONNECTOR=
 # Dialogflow examples.
 export SMART_REPLY_MODEL=
 export SMART_REPLY_ALLOWLIST=
+
+# Datastore/Firestore
+export DATASTORE_DATABASE=


### PR DESCRIPTION
## Description

New sample for Cloud NDB, demonstrating how to access a named database.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
  ** DATASTORE_DATABASE, needs to be changed to the database ID of any Datastore-mode database (recommend "prod-database")
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved