### PR TITLE
chore(flakybot): Changing default flaky issue priority to p2

### DIFF
--- a/.github/flakybot.yaml
+++ b/.github/flakybot.yaml
@@ -1,0 +1,1 @@
+issuePriority: p2

--- a/.github/flakybot.yaml
+++ b/.github/flakybot.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/flakybot.yaml
+++ b/.github/flakybot.yaml
@@ -1,1 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 issuePriority: p2


### PR DESCRIPTION
Following https://github.com/googleapis/repo-automation-bots/tree/main/packages/flakybot#configuration to make the issues created by flaky bot as P2.