### PR TITLE
feat(dlp): Split inspect samples into multiple files such that each region tag gets its own file part -1

### DIFF
--- a/dlp/snippets/Inspect/inspect_augment_infotypes.py
+++ b/dlp/snippets/Inspect/inspect_augment_infotypes.py
@@ -1,0 +1,115 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_augment_infotypes]
+from typing import List
+
+import google.cloud.dlp
+
+
+def inspect_string_augment_infotype(
+    project: str,
+    input_str: str,
+    info_type: str,
+    word_list: List[str],
+) -> None:
+    """Uses the Data Loss Prevention API to augment built-in infoType
+    detector and inspect the content string with augmented infoType.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        input_str: The string to inspect using augmented infoType
+            (will be treated as text).
+        info_type: A string representing built-in infoType to augment.
+            A full list of infoType categories can be fetched from the API.
+        word_list: List of words or phrases to be added to extend the behaviour
+            of built-in infoType.
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct the custom infoTypes dictionary with declaration of a built-in detector.
+    custom_info_types = [
+        {
+            "info_type": {"name": info_type},
+            "dictionary": {"word_list": {"words": word_list}},
+        }
+    ]
+
+    # Construct inspect configuration dictionary with the custom info type.
+    inspect_config = {
+        "custom_info_types": custom_info_types,
+        "include_quote": True,
+    }
+
+    # Construct the `item` to be inspected.
+    item = {"value": input_str}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={
+            "parent": parent,
+            "inspect_config": inspect_config,
+            "item": item,
+        }
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            print(f"Quote: {finding.quote}")
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood} \n")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_augment_infotypes]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument("input_str", help="The string to inspect.")
+    parser.add_argument(
+        "--info_type",
+        help="A String representing info types to look for. A full list of "
+             "info categories and types is available from the API. Examples "
+             'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". ',
+    )
+    parser.add_argument(
+        "--word_list",
+        help="List of words or phrases to be added to extend the behaviour "
+             "of built-in infoType.",
+    )
+    args = parser.parse_args()
+
+    inspect_string_augment_infotype(
+        args.project,
+        args.input_str,
+        args.info_type,
+        args.word_list,
+    )

--- a/dlp/snippets/Inspect/inspect_augment_infotypes_test.py
+++ b/dlp/snippets/Inspect/inspect_augment_infotypes_test.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_augment_infotypes as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def test_inspect_string_augment_infotype(capsys: pytest.CaptureFixture) -> None:
+    inspect_content.inspect_string_augment_infotype(
+        GCLOUD_PROJECT,
+        "The patient's name is Quasimodo",
+        "PERSON_NAME",
+        ["quasimodo"],
+    )
+    out, _ = capsys.readouterr()
+    assert "Quote: Quasimodo" in out
+    assert "Info type: PERSON_NAME" in out

--- a/dlp/snippets/Inspect/inspect_column_values_w_custom_hotwords.py
+++ b/dlp/snippets/Inspect/inspect_column_values_w_custom_hotwords.py
@@ -1,0 +1,157 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_column_values_w_custom_hotwords]
+from typing import List
+
+import google.cloud.dlp
+
+
+def inspect_column_values_w_custom_hotwords(
+    project: str,
+    table_header: List[str],
+    table_rows: List[List[str]],
+    info_types: List[str],
+    custom_hotword: str,
+) -> None:
+    """Uses the Data Loss Prevention API to inspect table data using built-in
+    infoType detectors, excluding columns that match a custom hot-word.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        table_header: List of strings representing table field names.
+        table_rows: List of rows representing table values.
+        info_types: The infoType for which hot-word rule is applied.
+        custom_hotword: The custom regular expression used for likelihood boosting.
+    """
+
+    # Instantiate a client
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct the `table`. For more details on the table schema, please see
+    # https://cloud.google.com/dlp/docs/reference/rest/v2/ContentItem#Table
+    headers = [{"name": val} for val in table_header]
+    rows = []
+    for row in table_rows:
+        rows.append({"values": [{"string_value": cell_val} for cell_val in row]})
+    table = {"headers": headers, "rows": rows}
+
+    # Construct the `item` for table to be inspected.
+    item = {"table": table}
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries.
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Construct a rule set with caller provided hot-word, with a likelihood
+    # boost to VERY_UNLIKELY when the hot-word are present
+    hotword_rule = {
+        "hotword_regex": {"pattern": custom_hotword},
+        "likelihood_adjustment": {
+            "fixed_likelihood": google.cloud.dlp_v2.Likelihood.VERY_UNLIKELY
+        },
+        "proximity": {"window_before": 1},
+    }
+
+    rule_set = [
+        {
+            "info_types": info_types,
+            "rules": [{"hotword_rule": hotword_rule}],
+        }
+    ]
+
+    # Construct the configuration dictionary, which defines the entire inspect content task.
+    inspect_config = {
+        "info_types": info_types,
+        "rule_set": rule_set,
+        "min_likelihood": google.cloud.dlp_v2.Likelihood.POSSIBLE,
+        "include_quote": True,
+    }
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}/locations/global"
+
+    # Call the API
+    response = dlp.inspect_content(
+        request={
+            "parent": parent,
+            "inspect_config": inspect_config,
+            "item": item,
+        }
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_column_values_w_custom_hotwords]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument(
+        "--table_header",
+        help="List of strings representing table field names."
+             "Example include '['Fake_Email_Address', 'Real_Email_Address]'. "
+             "The method can be used to exclude matches from entire column"
+             '"Fake_Email_Address".',
+    )
+    parser.add_argument(
+        "--table_rows",
+        help="List of rows representing table values."
+             "Example: "
+             '"[["example1@example.org", "test1@example.com],'
+             '["example2@example.org", "test2@example.com]]"',
+    )
+    parser.add_argument(
+        "--info_types",
+        action="append",
+        help="Strings representing info types to look for. A full list of "
+             "info categories and types is available from the API. Examples "
+             'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". ',
+    )
+    parser.add_argument(
+        "custom_hotword",
+        help="The custom regular expression used for likelihood boosting.",
+    )
+
+    args = parser.parse_args()
+
+    inspect_column_values_w_custom_hotwords(
+        args.project,
+        args.table_header,
+        args.table_rows,
+        args.info_types,
+        args.custom_hotword,
+    )

--- a/dlp/snippets/Inspect/inspect_column_values_w_custom_hotwords_test.py
+++ b/dlp/snippets/Inspect/inspect_column_values_w_custom_hotwords_test.py
@@ -1,0 +1,43 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_column_values_w_custom_hotwords as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def test_inspect_column_values_w_custom_hotwords(capsys: pytest.CaptureFixture) -> None:
+    table_data = {
+        "header": ["Fake Social Security Number", "Real Social Security Number"],
+        "rows": [
+            ["111-11-1111", "222-22-2222"],
+            ["987-23-1234", "333-33-3333"],
+            ["678-12-0909", "444-44-4444"],
+        ],
+    }
+    inspect_content.inspect_column_values_w_custom_hotwords(
+        GCLOUD_PROJECT,
+        table_data["header"],
+        table_data["rows"],
+        ["US_SOCIAL_SECURITY_NUMBER"],
+        "Fake Social Security Number",
+    )
+    out, _ = capsys.readouterr()
+    assert "Info type: US_SOCIAL_SECURITY_NUMBER" in out
+    assert "222-22-2222" in out
+    assert "111-11-1111" not in out

--- a/dlp/snippets/Inspect/inspect_file.py
+++ b/dlp/snippets/Inspect/inspect_file.py
@@ -1,0 +1,217 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_file]
+import mimetypes
+from typing import List
+from typing import Optional
+
+import google.cloud.dlp
+
+
+def inspect_file(
+    project: str,
+    filename: str,
+    info_types: List[str],
+    min_likelihood: str = None,
+    custom_dictionaries: List[str] = None,
+    custom_regexes: List[str] = None,
+    max_findings: Optional[int] = None,
+    include_quote: bool = True,
+    mime_type: str = None,
+) -> None:
+    """Uses the Data Loss Prevention API to analyze a file for protected data.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        filename: The path to the file to inspect.
+        info_types: A list of strings representing info types to look for.
+            A full list of info type categories can be fetched from the API.
+        min_likelihood: A string representing the minimum likelihood threshold
+            that constitutes a match. One of: 'LIKELIHOOD_UNSPECIFIED',
+            'VERY_UNLIKELY', 'UNLIKELY', 'POSSIBLE', 'LIKELY', 'VERY_LIKELY'.
+        max_findings: The maximum number of findings to report; 0 = no maximum.
+        include_quote: Boolean for whether to display a quote of the detected
+            information in the results.
+        mime_type: The MIME type of the file. If not specified, the type is
+            inferred via the Python standard library's mimetypes module.
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries (protos are also accepted).
+    if not info_types:
+        info_types = ["FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS"]
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [
+        {
+            "info_type": {"name": f"CUSTOM_DICTIONARY_{i}"},
+            "dictionary": {"word_list": {"words": custom_dict.split(",")}},
+        }
+        for i, custom_dict in enumerate(custom_dictionaries)
+    ]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [
+        {
+            "info_type": {"name": f"CUSTOM_REGEX_{i}"},
+            "regex": {"pattern": custom_regex},
+        }
+        for i, custom_regex in enumerate(custom_regexes)
+    ]
+    custom_info_types = dictionaries + regexes
+
+    # Construct the configuration dictionary. Keys which are None may
+    # optionally be omitted entirely.
+    inspect_config = {
+        "info_types": info_types,
+        "custom_info_types": custom_info_types,
+        "min_likelihood": min_likelihood,
+        "include_quote": include_quote,
+        "limits": {"max_findings_per_request": max_findings},
+    }
+
+    # If mime_type is not specified, guess it from the filename.
+    if mime_type is None:
+        mime_guess = mimetypes.MimeTypes().guess_type(filename)
+        mime_type = mime_guess[0]
+
+    # Select the content type index from the list of supported types.
+    supported_content_types = {
+        None: 0,  # "Unspecified"
+        "image/jpeg": 1,
+        "image/bmp": 2,
+        "image/png": 3,
+        "image/svg": 4,
+        "text/plain": 5,
+    }
+    content_type_index = supported_content_types.get(mime_type, 0)
+
+    # Construct the item, containing the file's byte data.
+    with open(filename, mode="rb") as f:
+        item = {"byte_item": {"type_": content_type_index, "data": f.read()}}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_file]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("filename", help="The path to the file to inspect.")
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument(
+        "--info_types",
+        action="append",
+        help="Strings representing info types to look for. A full list of "
+             "info categories and types is available from the API. Examples "
+             'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
+             "If unspecified, the three above examples will be used.",
+        default=["FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS"],
+    )
+    parser.add_argument(
+        "--custom_dictionaries",
+        action="append",
+        help="Strings representing comma-delimited lists of dictionary words"
+             " to search for as custom info types. Each string is a comma "
+             "delimited list of words representing a distinct dictionary.",
+        default=None,
+    )
+    parser.add_argument(
+        "--custom_regexes",
+        action="append",
+        help="Strings representing regex patterns to search for as custom "
+             " info types.",
+        default=None,
+    )
+    parser.add_argument(
+        "--min_likelihood",
+        choices=[
+            "LIKELIHOOD_UNSPECIFIED",
+            "VERY_UNLIKELY",
+            "UNLIKELY",
+            "POSSIBLE",
+            "LIKELY",
+            "VERY_LIKELY",
+        ],
+        help="A string representing the minimum likelihood threshold that "
+             "constitutes a match.",
+    )
+    parser.add_argument(
+        "--max_findings",
+        type=int,
+        help="The maximum number of findings to report; 0 = no maximum.",
+    )
+    parser.add_argument(
+        "--include_quote",
+        type=bool,
+        help="A boolean for whether to display a quote of the detected "
+             "information in the results.",
+        default=True,
+    )
+    parser.add_argument(
+        "--mime_type",
+        help="The MIME type of the file. If not specified, the type is "
+             "inferred via the Python standard library's mimetypes module.",
+    )
+    args = parser.parse_args()
+
+    inspect_file(
+        args.project,
+        args.filename,
+        args.info_types,
+        custom_dictionaries=args.custom_dictionaries,
+        custom_regexes=args.custom_regexes,
+        min_likelihood=args.min_likelihood,
+        max_findings=args.max_findings,
+        include_quote=args.include_quote,
+        mime_type=args.mime_type,
+    )

--- a/dlp/snippets/Inspect/inspect_file_test.py
+++ b/dlp/snippets/Inspect/inspect_file_test.py
@@ -1,0 +1,83 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_file as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "../resources")
+
+
+def test_inspect_file(capsys: pytest.CaptureFixture) -> None:
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.txt")
+
+    inspect_content.inspect_file(
+        GCLOUD_PROJECT,
+        test_filepath,
+        ["FIRST_NAME", "EMAIL_ADDRESS"],
+        include_quote=True,
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Info type: EMAIL_ADDRESS" in out
+
+
+def test_inspect_file_with_custom_info_types(capsys: pytest.CaptureFixture) -> None:
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.txt")
+    dictionaries = ["gary@somedomain.com"]
+    regexes = ["\\(\\d{3}\\) \\d{3}-\\d{4}"]
+
+    inspect_content.inspect_file(
+        GCLOUD_PROJECT,
+        test_filepath,
+        [],
+        custom_dictionaries=dictionaries,
+        custom_regexes=regexes,
+        include_quote=True,
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Info type: CUSTOM_DICTIONARY_0" in out
+    assert "Info type: CUSTOM_REGEX_0" in out
+
+
+def test_inspect_file_no_results(capsys: pytest.CaptureFixture) -> None:
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "harmless.txt")
+
+    inspect_content.inspect_file(
+        GCLOUD_PROJECT,
+        test_filepath,
+        ["FIRST_NAME", "EMAIL_ADDRESS"],
+        include_quote=True,
+    )
+
+    out, _ = capsys.readouterr()
+    assert "No findings" in out
+
+
+def test_inspect_image_file(capsys: pytest.CaptureFixture) -> None:
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+
+    inspect_content.inspect_file(
+        GCLOUD_PROJECT,
+        test_filepath,
+        ["FIRST_NAME", "EMAIL_ADDRESS", "PHONE_NUMBER"],
+        include_quote=True,
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Info type: PHONE_NUMBER" in out

--- a/dlp/snippets/Inspect/inspect_image_all_infotypes.py
+++ b/dlp/snippets/Inspect/inspect_image_all_infotypes.py
@@ -1,0 +1,94 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_image_all_infotypes]
+import google.cloud.dlp
+
+
+def inspect_image_file_all_infotypes(
+    project: str,
+    filename: str,
+    include_quote: bool = True,
+) -> None:
+    """Uses the Data Loss Prevention API to analyze strings for protected data in image file.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        filename: The path to the file to inspect.
+        include_quote: Boolean for whether to display a quote of the detected
+            information in the results.
+
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Construct the byte_item, containing the image file's byte data.
+    with open(filename, mode="rb") as f:
+        byte_item = {"type_": "IMAGE", "data": f.read()}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={
+            "parent": parent,
+            "inspect_config": {"include_quote": include_quote},
+            "item": {"byte_item": byte_item},
+        }
+    )
+
+    # Print out the results.
+    print("Findings: ", response.result.findings.count)
+    if response.result.findings:
+        for finding in response.result.findings:
+            print(f"Quote: {finding.quote}")
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_image_all_infotypes]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument("filename", help="The path to the file to inspect.")
+    parser.add_argument(
+        "--include_quote",
+        help="A Boolean for whether to display a quote of the detected"
+             "information in the results.",
+        default=True,
+    )
+    args = parser.parse_args()
+
+    inspect_image_file_all_infotypes(
+        args.project,
+        args.filename,
+        include_quote=args.include_quote,
+    )

--- a/dlp/snippets/Inspect/inspect_image_all_infotypes_test.py
+++ b/dlp/snippets/Inspect/inspect_image_all_infotypes_test.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_image_all_infotypes as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "../resources")
+
+
+def test_inspect_image_file_all_infotypes(capsys: pytest.CaptureFixture) -> None:
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+
+    inspect_content.inspect_image_file_all_infotypes(GCLOUD_PROJECT, test_filepath)
+
+    out, _ = capsys.readouterr()
+    assert "Info type: PHONE_NUMBER" in out
+    assert "Info type: EMAIL_ADDRESS" in out

--- a/dlp/snippets/Inspect/inspect_image_file.py
+++ b/dlp/snippets/Inspect/inspect_image_file.py
@@ -1,0 +1,103 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_image_file]
+import google.cloud.dlp
+
+
+def inspect_image_file(
+    project: str,
+    filename: str,
+    include_quote: bool = True,
+) -> None:
+    """Uses the Data Loss Prevention API to analyze strings for
+    protected data in image file.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        filename: The path to the file to inspect.
+        include_quote: Boolean for whether to display a quote of the detected
+            information in the results.
+    """
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries.
+    info_types = ["PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD_NUMBER"]
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Construct the configuration for the Inspect request.
+    inspect_config = {
+        "info_types": info_types,
+        "include_quote": include_quote,
+    }
+
+    # Construct the byte_item, containing the image file's byte data.
+    with open(filename, mode="rb") as f:
+        byte_item = {"type_": "IMAGE", "data": f.read()}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}/locations/global"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={
+            "parent": parent,
+            "inspect_config": inspect_config,
+            "item": {"byte_item": byte_item},
+        }
+    )
+
+    # Parse the response and process results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            print(f"Quote: {finding.quote}")
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_image_file]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument(
+        "filename", help="The path to the file to inspect."
+    )
+    parser.add_argument(
+        "--include_quote",
+        help="A Boolean for whether to display a quote of the detected"
+             "information in the results.",
+        default=True,
+    )
+    args = parser.parse_args()
+
+    inspect_image_file(
+        args.project,
+        args.filename,
+        include_quote=args.include_quote,
+    )

--- a/dlp/snippets/Inspect/inspect_image_file_test.py
+++ b/dlp/snippets/Inspect/inspect_image_file_test.py
@@ -19,7 +19,7 @@ import inspect_image_file as inspect_content
 import pytest
 
 GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
-RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "resources")
+RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "../resources")
 
 
 def test_inspect_image_file_default_infotypes(capsys: pytest.CaptureFixture) -> None:

--- a/dlp/snippets/Inspect/inspect_image_file_test.py
+++ b/dlp/snippets/Inspect/inspect_image_file_test.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_image_file as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "resources")
+
+
+def test_inspect_image_file_default_infotypes(capsys: pytest.CaptureFixture) -> None:
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+
+    inspect_content.inspect_image_file(GCLOUD_PROJECT, test_filepath)
+
+    out, _ = capsys.readouterr()
+    assert "Info type: PHONE_NUMBER" in out
+    assert "Info type: EMAIL_ADDRESS" in out

--- a/dlp/snippets/Inspect/inspect_image_listed_infotypes.py
+++ b/dlp/snippets/Inspect/inspect_image_listed_infotypes.py
@@ -1,0 +1,118 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_image_listed_infotypes]
+from typing import List
+
+import google.cloud.dlp
+
+
+def inspect_image_file_listed_infotypes(
+    project: str,
+    filename: str,
+    info_types: List[str],
+    include_quote: bool = True,
+) -> None:
+    """Uses the Data Loss Prevention API to analyze strings in an image for
+    data matching the given infoTypes.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        filename: The path of the image file to inspect.
+        info_types:  A list of strings representing infoTypes to look for.
+            A full list of info type categories can be fetched from the API.
+        include_quote: Boolean for whether to display a matching snippet of
+            the detected information in the results.
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries.
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Construct the configuration dictionary.
+    inspect_config = {
+        "info_types": info_types,
+        "include_quote": include_quote,
+    }
+
+    # Construct the byte_item, containing the image file's byte data.
+    with open(filename, mode="rb") as f:
+        byte_item = {"type_": "IMAGE", "data": f.read()}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={
+            "parent": parent,
+            "inspect_config": inspect_config,
+            "item": {"byte_item": byte_item},
+        }
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            print(f"Info type: {finding.info_type.name}")
+            if include_quote:
+                print(f"Quote: {finding.quote}")
+            print(f"Likelihood: {finding.likelihood} \n")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_image_listed_infotypes]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument(
+        "filename", help="The path to the file to inspect."
+    )
+    parser.add_argument(
+        "--info_types",
+        nargs="+",
+        help="Strings representing info types to look for. A full list of "
+             "info categories and types is available from the API. Examples "
+             'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". ',
+    )
+    parser.add_argument(
+        "--include_quote",
+        help="A Boolean for whether to display a quote of the detected"
+             "information in the results.",
+        default=True,
+    )
+
+    args = parser.parse_args()
+
+    inspect_image_file_listed_infotypes(
+        args.project,
+        args.filename,
+        args.info_types,
+        include_quote=args.include_quote,
+    )

--- a/dlp/snippets/Inspect/inspect_image_listed_infotypes_test.py
+++ b/dlp/snippets/Inspect/inspect_image_listed_infotypes_test.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_image_listed_infotypes as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+RESOURCE_DIRECTORY = os.path.join(os.path.dirname(__file__), "../resources")
+
+
+def test_inspect_image_file_listed_infotypes(capsys: pytest.CaptureFixture) -> None:
+    test_filepath = os.path.join(RESOURCE_DIRECTORY, "test.png")
+
+    inspect_content.inspect_image_file_listed_infotypes(
+        GCLOUD_PROJECT,
+        test_filepath,
+        ["EMAIL_ADDRESS"],
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Info type: EMAIL_ADDRESS" in out

--- a/dlp/snippets/Inspect/inspect_phone_number.py
+++ b/dlp/snippets/Inspect/inspect_phone_number.py
@@ -1,0 +1,85 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_phone_number]
+import google.cloud.dlp
+
+
+def inspect_phone_number(
+    project: str,
+    content_string: str,
+) -> None:
+    """Uses the Data Loss Prevention API to analyze strings for protected data.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect phone number from.
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries (protos are also accepted).
+    info_types = [{"name": "PHONE_NUMBER"}]
+
+    # Construct the configuration dictionary.
+    inspect_config = {
+        "info_types": info_types,
+        "include_quote": True,
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            print(f"Quote: {finding.quote}")
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_phone_number]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "content_string",
+        help="The string to inspect phone number from.",
+    )
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    args = parser.parse_args()
+
+    inspect_phone_number(args.project, args.content_string)

--- a/dlp/snippets/Inspect/inspect_phone_number_test.py
+++ b/dlp/snippets/Inspect/inspect_phone_number_test.py
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_phone_number as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def test_inspect_phone_number(capsys: pytest.CaptureFixture) -> None:
+    test_string = "String with a phone number: 234-555-6789"
+
+    inspect_content.inspect_phone_number(GCLOUD_PROJECT, test_string)
+
+    out, _ = capsys.readouterr()
+    assert "Info type: PHONE_NUMBER" in out
+    assert "Quote: 234-555-6789" in out

--- a/dlp/snippets/Inspect/inspect_string.py
+++ b/dlp/snippets/Inspect/inspect_string.py
@@ -1,0 +1,187 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+
+# [START dlp_inspect_string]
+from typing import List
+
+import google.cloud.dlp
+
+
+def inspect_string(
+    project: str,
+    content_string: str,
+    info_types: List[str],
+    custom_dictionaries: List[str] = None,
+    custom_regexes: List[str] = None,
+    min_likelihood: str = None,
+    max_findings: str = None,
+    include_quote: bool = True,
+) -> None:
+    """Uses the Data Loss Prevention API to analyze strings for protected data.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        content_string: The string to inspect.
+        info_types: A list of strings representing info types to look for.
+            A full list of info type categories can be fetched from the API.
+        min_likelihood: A string representing the minimum likelihood threshold
+            that constitutes a match. One of: 'LIKELIHOOD_UNSPECIFIED',
+            'VERY_UNLIKELY', 'UNLIKELY', 'POSSIBLE', 'LIKELY', 'VERY_LIKELY'.
+        max_findings: The maximum number of findings to report; 0 = no maximum.
+        include_quote: Boolean for whether to display a quote of the detected
+            information in the results.
+    Returns:
+        None; the response from the API is printed to the terminal.
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries (protos are also accepted).
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [
+        {
+            "info_type": {"name": f"CUSTOM_DICTIONARY_{i}"},
+            "dictionary": {"word_list": {"words": custom_dict.split(",")}},
+        }
+        for i, custom_dict in enumerate(custom_dictionaries)
+    ]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [
+        {
+            "info_type": {"name": f"CUSTOM_REGEX_{i}"},
+            "regex": {"pattern": custom_regex},
+        }
+        for i, custom_regex in enumerate(custom_regexes)
+    ]
+    custom_info_types = dictionaries + regexes
+
+    # Construct the configuration dictionary. Keys which are None may
+    # optionally be omitted entirely.
+    inspect_config = {
+        "info_types": info_types,
+        "custom_info_types": custom_info_types,
+        "min_likelihood": min_likelihood,
+        "include_quote": include_quote,
+        "limits": {"max_findings_per_request": max_findings},
+    }
+
+    # Construct the `item`.
+    item = {"value": content_string}
+
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_string]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("item", help="The string to inspect.")
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument(
+        "--info_types",
+        nargs="+",
+        help="Strings representing info types to look for. A full list of "
+             "info categories and types is available from the API. Examples "
+             'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
+             "If unspecified, the three above examples will be used.",
+        default=["FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS"],
+    )
+    parser.add_argument(
+        "--custom_dictionaries",
+        action="append",
+        help="Strings representing comma-delimited lists of dictionary words"
+             " to search for as custom info types. Each string is a comma "
+             "delimited list of words representing a distinct dictionary.",
+        default=None,
+    )
+    parser.add_argument(
+        "--custom_regexes",
+        action="append",
+        help="Strings representing regex patterns to search for as custom "
+             " info types.",
+        default=None,
+    )
+    parser.add_argument(
+        "--min_likelihood",
+        choices=[
+            "LIKELIHOOD_UNSPECIFIED",
+            "VERY_UNLIKELY",
+            "UNLIKELY",
+            "POSSIBLE",
+            "LIKELY",
+            "VERY_LIKELY",
+        ],
+        help="A string representing the minimum likelihood threshold that "
+             "constitutes a match.",
+    )
+    parser.add_argument(
+        "--max_findings",
+        type=int,
+        help="The maximum number of findings to report; 0 = no maximum.",
+    )
+    parser.add_argument(
+        "--include_quote",
+        type=bool,
+        help="A boolean for whether to display a quote of the detected "
+             "information in the results.",
+        default=True,
+    )
+    args = parser.parse_args()
+
+    inspect_string(
+        args.project,
+        args.item,
+        args.info_types,
+        custom_dictionaries=args.custom_dictionaries,
+        custom_regexes=args.custom_regexes,
+        min_likelihood=args.min_likelihood,
+        max_findings=args.max_findings,
+        include_quote=args.include_quote,
+    )

--- a/dlp/snippets/Inspect/inspect_string_test.py
+++ b/dlp/snippets/Inspect/inspect_string_test.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_string as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def test_inspect_string(capsys: pytest.CaptureFixture) -> None:
+    test_string = "My name is Gary Smith and my email is gary@example.com"
+
+    inspect_content.inspect_string(
+        GCLOUD_PROJECT,
+        test_string,
+        ["FIRST_NAME", "EMAIL_ADDRESS"],
+        include_quote=True,
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Info type: FIRST_NAME" in out
+    assert "Info type: EMAIL_ADDRESS" in out

--- a/dlp/snippets/Inspect/inspect_table.py
+++ b/dlp/snippets/Inspect/inspect_table.py
@@ -1,0 +1,227 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Sample app that uses the Data Loss Prevention API to inspect a string, a
+local file or a file on Google Cloud Storage."""
+
+
+import argparse
+import json
+
+# [START dlp_inspect_table]
+from typing import List, Optional
+
+import google.cloud.dlp
+
+
+def inspect_table(
+    project: str,
+    data: str,
+    info_types: List[str],
+    custom_dictionaries: List[str] = None,
+    custom_regexes: List[str] = None,
+    min_likelihood: Optional[str] = None,
+    max_findings: Optional[int] = None,
+    include_quote: bool = True,
+) -> None:
+    """Uses the Data Loss Prevention API to analyze strings for protected data.
+    Args:
+        project: The Google Cloud project id to use as a parent resource.
+        data: Json string representing table data.
+        info_types: A list of strings representing info types to look for.
+            A full list of info type categories can be fetched from the API.
+        min_likelihood: A string representing the minimum likelihood threshold
+            that constitutes a match. One of: 'LIKELIHOOD_UNSPECIFIED',
+            'VERY_UNLIKELY', 'UNLIKELY', 'POSSIBLE', 'LIKELY', 'VERY_LIKELY'.
+        max_findings: The maximum number of findings to report; 0 = no maximum.
+        include_quote: Boolean for whether to display a quote of the detected
+            information in the results.
+    Returns:
+        None; the response from the API is printed to the terminal.
+    Example:
+        data = {
+            "header":[
+                "email",
+                "phone number"
+            ],
+            "rows":[
+                [
+                    "robertfrost@xyz.com",
+                    "4232342345"
+                ],
+                [
+                    "johndoe@pqr.com",
+                    "4253458383"
+                ]
+            ]
+        }
+
+        >> $ python inspect_content.py table \
+        '{"header": ["email", "phone number"],
+        "rows": [["robertfrost@xyz.com", "4232342345"],
+        ["johndoe@pqr.com", "4253458383"]]}'
+        >>  Quote: robertfrost@xyz.com
+            Info type: EMAIL_ADDRESS
+            Likelihood: 4
+            Quote: johndoe@pqr.com
+            Info type: EMAIL_ADDRESS
+            Likelihood: 4
+    """
+
+    # Instantiate a client.
+    dlp = google.cloud.dlp_v2.DlpServiceClient()
+
+    # Prepare info_types by converting the list of strings into a list of
+    # dictionaries (protos are also accepted).
+    info_types = [{"name": info_type} for info_type in info_types]
+
+    # Prepare custom_info_types by parsing the dictionary word lists and
+    # regex patterns.
+    if custom_dictionaries is None:
+        custom_dictionaries = []
+    dictionaries = [
+        {
+            "info_type": {"name": f"CUSTOM_DICTIONARY_{i}"},
+            "dictionary": {"word_list": {"words": custom_dict.split(",")}},
+        }
+        for i, custom_dict in enumerate(custom_dictionaries)
+    ]
+    if custom_regexes is None:
+        custom_regexes = []
+    regexes = [
+        {
+            "info_type": {"name": f"CUSTOM_REGEX_{i}"},
+            "regex": {"pattern": custom_regex},
+        }
+        for i, custom_regex in enumerate(custom_regexes)
+    ]
+    custom_info_types = dictionaries + regexes
+
+    # Construct the configuration dictionary. Keys which are None may
+    # optionally be omitted entirely.
+    inspect_config = {
+        "info_types": info_types,
+        "custom_info_types": custom_info_types,
+        "min_likelihood": min_likelihood,
+        "include_quote": include_quote,
+        "limits": {"max_findings_per_request": max_findings},
+    }
+
+    # Construct the `table`. For more details on the table schema, please see
+    # https://cloud.google.com/dlp/docs/reference/rest/v2/ContentItem#Table
+    headers = [{"name": val} for val in data["header"]]
+    rows = []
+    for row in data["rows"]:
+        rows.append({"values": [{"string_value": cell_val} for cell_val in row]})
+
+    table = {}
+    table["headers"] = headers
+    table["rows"] = rows
+    item = {"table": table}
+    # Convert the project id into a full resource id.
+    parent = f"projects/{project}"
+
+    # Call the API.
+    response = dlp.inspect_content(
+        request={"parent": parent, "inspect_config": inspect_config, "item": item}
+    )
+
+    # Print out the results.
+    if response.result.findings:
+        for finding in response.result.findings:
+            try:
+                if finding.quote:
+                    print(f"Quote: {finding.quote}")
+            except AttributeError:
+                pass
+            print(f"Info type: {finding.info_type.name}")
+            print(f"Likelihood: {finding.likelihood}")
+    else:
+        print("No findings.")
+
+
+# [END dlp_inspect_table]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "data", help="Json string representing a table.", type=json.loads
+    )
+    parser.add_argument(
+        "--project",
+        help="The Google Cloud project id to use as a parent resource.",
+    )
+    parser.add_argument(
+        "--info_types",
+        action="append",
+        help="Strings representing info types to look for. A full list of "
+             "info categories and types is available from the API. Examples "
+             'include "FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS". '
+             "If unspecified, the three above examples will be used.",
+        default=["FIRST_NAME", "LAST_NAME", "EMAIL_ADDRESS"],
+    )
+    parser.add_argument(
+        "--custom_dictionaries",
+        action="append",
+        help="Strings representing comma-delimited lists of dictionary words"
+             " to search for as custom info types. Each string is a comma "
+             "delimited list of words representing a distinct dictionary.",
+        default=None,
+    )
+    parser.add_argument(
+        "--custom_regexes",
+        action="append",
+        help="Strings representing regex patterns to search for as custom "
+             " info types.",
+        default=None,
+    )
+    parser.add_argument(
+        "--min_likelihood",
+        choices=[
+            "LIKELIHOOD_UNSPECIFIED",
+            "VERY_UNLIKELY",
+            "UNLIKELY",
+            "POSSIBLE",
+            "LIKELY",
+            "VERY_LIKELY",
+        ],
+        help="A string representing the minimum likelihood threshold that "
+             "constitutes a match.",
+    )
+    parser.add_argument(
+        "--max_findings",
+        type=int,
+        help="The maximum number of findings to report; 0 = no maximum.",
+    )
+    parser.add_argument(
+        "--include_quote",
+        type=bool,
+        help="A boolean for whether to display a quote of the detected "
+             "information in the results.",
+        default=True,
+    )
+    args = parser.parse_args()
+
+    inspect_table(
+        args.project,
+        args.data,
+        args.info_types,
+        custom_dictionaries=args.custom_dictionaries,
+        custom_regexes=args.custom_regexes,
+        min_likelihood=args.min_likelihood,
+        max_findings=args.max_findings,
+        include_quote=args.include_quote,
+    )

--- a/dlp/snippets/Inspect/inspect_table_test.py
+++ b/dlp/snippets/Inspect/inspect_table_test.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import inspect_table as inspect_content
+
+import pytest
+
+GCLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def test_inspect_table(capsys: pytest.CaptureFixture) -> None:
+    test_tabular_data = {
+        "header": ["email", "phone number"],
+        "rows": [
+            ["robertfrost@xyz.com", "4232342345"],
+            ["johndoe@pqr.com", "4253458383"],
+        ],
+    }
+
+    inspect_content.inspect_table(
+        GCLOUD_PROJECT,
+        test_tabular_data,
+        ["PHONE_NUMBER", "EMAIL_ADDRESS"],
+        include_quote=True,
+    )
+
+    out, _ = capsys.readouterr()
+    assert "Info type: PHONE_NUMBER" in out
+    assert "Info type: EMAIL_ADDRESS" in out


### PR DESCRIPTION
## Description
Fix PR as part of the issue: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/10601
This PR only splits inspect related samples into multiple files - part 1

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved