### PR TITLE
fix(secretmanager): Use retry-wrapper for function calls to avoid flaky bot issues

### DIFF
--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -14,7 +14,7 @@
 import base64
 import os
 import time
-from typing import Iterator, Tuple
+from typing import Iterator, Optional, Tuple, Union
 import uuid
 
 from google.api_core import exceptions, retry
@@ -75,7 +75,8 @@ def retry_client_secret_path(
 
 @retry.Retry()
 def retry_client_create_secret(
-    client: secretmanager.SecretManagerServiceClient, request: dict
+    client: secretmanager.SecretManagerServiceClient,
+    request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
 ) -> secretmanager.Secret:
     # Retry to avoid 503 error & flaky issues
     return client.create_secret(request=request)
@@ -83,7 +84,8 @@ def retry_client_create_secret(
 
 @retry.Retry()
 def retry_client_access_secret_version(
-    client: secretmanager.SecretManagerServiceClient, request: dict
+    client: secretmanager.SecretManagerServiceClient,
+    request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
 ) -> secretmanager.AccessSecretVersionResponse:
     # Retry to avoid 503 error & flaky issues
     return client.access_secret_version(request=request)
@@ -91,7 +93,8 @@ def retry_client_access_secret_version(
 
 @retry.Retry()
 def retry_client_delete_secret(
-    client: secretmanager.SecretManagerServiceClient, request: dict
+    client: secretmanager.SecretManagerServiceClient,
+    request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
 ) -> None:
     # Retry to avoid 503 error & flaky issues
     return client.delete_secret(request=request)
@@ -99,7 +102,8 @@ def retry_client_delete_secret(
 
 @retry.Retry()
 def retry_client_add_secret_version(
-    client: secretmanager.SecretManagerServiceClient, request: dict
+    client: secretmanager.SecretManagerServiceClient,
+    request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
 ) -> secretmanager.SecretVersion:
     # Retry to avoid 503 error & flaky issues
     return client.add_secret_version(request=request)

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -85,7 +85,7 @@ def retry_client_create_secret(
 @retry.Retry()
 def retry_client_access_secret_version(
     client: secretmanager.SecretManagerServiceClient,
-    request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
+    request: Optional[Union[secretmanager.AccessSecretVersionRequest, dict]],
 ) -> secretmanager.AccessSecretVersionResponse:
     # Retry to avoid 503 error & flaky issues
     return client.access_secret_version(request=request)
@@ -94,7 +94,7 @@ def retry_client_access_secret_version(
 @retry.Retry()
 def retry_client_delete_secret(
     client: secretmanager.SecretManagerServiceClient,
-    request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
+    request: Optional[Union[secretmanager.DeleteSecretRequest, dict]],
 ) -> None:
     # Retry to avoid 503 error & flaky issues
     return client.delete_secret(request=request)
@@ -103,7 +103,7 @@ def retry_client_delete_secret(
 @retry.Retry()
 def retry_client_add_secret_version(
     client: secretmanager.SecretManagerServiceClient,
-    request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
+    request: Optional[Union[secretmanager.AddSecretVersionRequest, dict]],
 ) -> secretmanager.SecretVersion:
     # Retry to avoid 503 error & flaky issues
     return client.add_secret_version(request=request)

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -153,7 +153,7 @@ def secret_version(
     project_id, secret_id, _ = secret
 
     print(f"adding secret version to {secret_id}")
-    parent = retry_client_secret_path(client, secret_id)
+    parent = retry_client_secret_path(client, project_id, secret_id)
     payload = b"hello world!"
     time.sleep(5)
     version = client.add_secret_version(

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -64,16 +64,6 @@ def iam_user() -> str:
 
 
 @retry.Retry()
-def retry_client_secret_path(
-    client: secretmanager.SecretManagerServiceClient,
-    project_id: str,
-    secret_id: str,
-) -> str:
-    # Retry to avoid 503 error & flaky issues
-    return client.secret_path(project_id, secret_id)
-
-
-@retry.Retry()
 def retry_client_create_secret(
     client: secretmanager.SecretManagerServiceClient,
     request: Optional[Union[secretmanager.CreateSecretRequest, dict]],
@@ -116,7 +106,7 @@ def secret_id(
     secret_id = f"python-secret-{uuid.uuid4()}"
 
     yield secret_id
-    secret_path = retry_client_secret_path(client, project_id, secret_id)
+    secret_path = client.secret_path(project_id, secret_id)
     print(f"deleting secret {secret_id}")
     try:
         time.sleep(5)
@@ -153,7 +143,7 @@ def secret_version(
     project_id, secret_id, _ = secret
 
     print(f"adding secret version to {secret_id}")
-    parent = retry_client_secret_path(client, project_id, secret_id)
+    parent = client.secret_path(project_id, secret_id)
     payload = b"hello world!"
     time.sleep(5)
     version = client.add_secret_version(

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -66,7 +66,7 @@ def iam_user() -> str:
 @retry.Retry()
 def retry_client_secret_path(
     client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str
-):
+) -> str:
     # Retry to avoid 503 error & flaky issues
     return client.secret_path(project_id, secret_id)
 
@@ -74,7 +74,7 @@ def retry_client_secret_path(
 @retry.Retry()
 def retry_client_create_secret(
     client: secretmanager.SecretManagerServiceClient, request: dict
-):
+) -> secretmanager.Secret:
     # Retry to avoid 503 error & flaky issues
     return client.create_secret(request=request)
 

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -64,13 +64,17 @@ def iam_user() -> str:
 
 
 @retry.Retry()
-def retry_client_secret_path(client, project_id, secret_id):
+def retry_client_secret_path(
+    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str
+):
     # Retry to avoid 503 error & flaky issues
     return client.secret_path(project_id, secret_id)
 
 
 @retry.Retry()
-def retry_client_create_secret(client, request):
+def retry_client_create_secret(
+    client: secretmanager.SecretManagerServiceClient, request: dict
+):
     # Retry to avoid 503 error & flaky issues
     return client.create_secret(request=request)
 

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -153,7 +153,7 @@ def secret_version(
     project_id, secret_id, _ = secret
 
     print(f"adding secret version to {secret_id}")
-    parent = retry_client_create_secret(client, secret_id)
+    parent = retry_client_secret_path(client, secret_id)
     payload = b"hello world!"
     time.sleep(5)
     version = client.add_secret_version(

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -149,7 +149,7 @@ def secret_version(
     project_id, secret_id, _ = secret
 
     print(f"adding secret version to {secret_id}")
-    parent = retry_client_create_secret(client, project_id, secret_id)
+    parent = retry_client_create_secret(client, secret_id)
     payload = b"hello world!"
     time.sleep(5)
     version = client.add_secret_version(


### PR DESCRIPTION
## Description

Note: This is WIP!

Add fix flaky bot issues in snippet's test file.

### Fixes 
* https://github.com/GoogleCloudPlatform/python-docs-samples/issues/10763
* https://github.com/GoogleCloudPlatform/python-docs-samples/issues/10764

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved