### PR TITLE
feat(dlp): Split metadata samples into multiple files such that each region tag gets its own file

### DIFF
--- a/dlp/snippets/Metadata/list_info_types.py
+++ b/dlp/snippets/Metadata/list_info_types.py
@@ -20,7 +20,7 @@ import argparse
 
 
 # [START dlp_list_info_types]
-from typing import Optional  # noqa: I100, E402
+from typing import Optional
 
 import google.cloud.dlp
 
@@ -31,7 +31,7 @@ def list_info_types(
     """List types of sensitive information within a category.
     Args:
         language_code: The BCP-47 language code to use, e.g. 'en-US'.
-        filter: An optional filter to only return info types supported by
+        result_filter: An optional filter to only return info types supported by
                 certain parts of the API. Defaults to "supported_by=INSPECT".
     Returns:
         None; the response from the API is printed to the terminal.

--- a/dlp/snippets/Metadata/list_info_types_test.py
+++ b/dlp/snippets/Metadata/list_info_types_test.py
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import list_info_types as metadata
 
 import pytest
-
-import list_info_types as metadata
 
 
 def test_fetch_info_types(capsys: pytest.CaptureFixture) -> None:

--- a/dlp/snippets/Metadata/list_info_types_test.py
+++ b/dlp/snippets/Metadata/list_info_types_test.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-import metadata
+import list_info_types as metadata
 
 
 def test_fetch_info_types(capsys: pytest.CaptureFixture) -> None:


### PR DESCRIPTION
## Description
Fix PR as part of the issue: https://github.com/GoogleCloudPlatform/python-docs-samples/issues/10601
This PR only splits metadata related samples into multiple files

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved