### PR TITLE
werkzeug flask upgrade

### DIFF
--- a/appengine/flexible/hello_world/requirements.txt
+++ b/appengine/flexible/hello_world/requirements.txt
@@ -1,3 +1,5 @@
-Flask==2.3.3
+Flask==3.0.0; python_version > '3.6'
+Flask==2.3.3; python_version < '3.7'
+Werkzeug==3.0.1; python_version > '3.6'
+Werkzeug==2.3.7; python_version < '3.7'
 gunicorn==20.1.0
-Werkzeug==2.3.7

--- a/appengine/standard/migration/memorystore/requirements.txt
+++ b/appengine/standard/migration/memorystore/requirements.txt
@@ -1,6 +1,6 @@
 redis==4.5.4; python_version > '3.0'
 redis<5; python_version < '3.0'
 Flask==1.1.4; python_version < '3.0'
-Flask==2.1.0; python_version > '3.0'
+Flask==3.0.0; python_version > '3.0'
 Werkzeug==1.0.1; python_version < '3.0'
 Werkzeug==3.0.1; python_version > '3.0'

--- a/appengine/standard/migration/ndb/overview/requirements.txt
+++ b/appengine/standard/migration/ndb/overview/requirements.txt
@@ -3,6 +3,6 @@ rsa==4.5; python_version < '3'
 googleapis_common_protos
 google-cloud-ndb
 Flask==1.1.4; python_version < '3.0'
-Flask==2.1.0; python_version > '3.0'
+Flask==3.0.0; python_version > '3.0'
 Werkzeug==1.0.1; python_version < '3.0'
 Werkzeug==3.0.1; python_version > '3.0'

--- a/appengine/standard/migration/ndb/redis_cache/requirements.txt
+++ b/appengine/standard/migration/ndb/redis_cache/requirements.txt
@@ -3,6 +3,6 @@ rsa==4.5; python_version < '3'
 googleapis_common_protos
 google-cloud-ndb
 Flask==1.1.4; python_version < '3.0'
-Flask==2.1.0; python_version > '3.0'
+Flask==3.0.0; python_version > '3.0'
 Werkzeug==1.0.1; python_version < '3.0'
 Werkzeug==3.0.1; python_version > '3.0'

--- a/appengine/standard/migration/storage/requirements.txt
+++ b/appengine/standard/migration/storage/requirements.txt
@@ -1,6 +1,6 @@
 google-cloud-storage==1.44.0; python_version < '3.7'
 google-cloud-storage==2.8.0; python_version > '3.6'
 Flask==1.1.4; python_version < '3.0'
-Flask==2.1.0; python_version > '3.0'
+Flask==3.0.0; python_version > '3.0'
 Werkzeug==1.0.1; python_version < '3.0'
 Werkzeug==3.0.1; python_version > '3.0'

--- a/appengine/standard/migration/taskqueue/counter/requirements.txt
+++ b/appengine/standard/migration/taskqueue/counter/requirements.txt
@@ -5,4 +5,4 @@ google-cloud-datastore==1.15.5; python_version < "3.0"
 google-cloud-tasks==2.13.1; python_version >= "3.0"
 google-cloud-tasks==1.5.2; python_version < "3.0"
 Werkzeug==1.0.1; python_version < '3.0'
-Werkzeug==2.3.7; python_version > '3.0'
+Werkzeug==3.0.1; python_version > '3.0'

--- a/appengine/standard/ndb/transactions/requirements.txt
+++ b/appengine/standard/ndb/transactions/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.1.4; python_version < '3.0'
-Flask==2.1.0; python_version > '3.0'
+Flask==3.0.0; python_version > '3.0'
 Werkzeug==1.0.1; python_version < '3.0'
 Werkzeug==3.0.1; python_version > '3.0'

--- a/appengine/standard/urlfetch/requests/requirements.txt
+++ b/appengine/standard/urlfetch/requests/requirements.txt
@@ -3,4 +3,4 @@ Flask==3.0.0; python_version > '3.0'
 requests==2.27.1
 requests-toolbelt==0.10.1
 Werkzeug==1.0.1; python_version < '3.0'
-Werkzeug==2.3.7; python_version > '3.0'
+Werkzeug==3.0.1; python_version > '3.0'

--- a/appengine/standard_python3/bundled-services/blobstore/flask/requirements.txt
+++ b/appengine/standard_python3/bundled-services/blobstore/flask/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.0.1
+Flask==3.0.0
 appengine-python-standard>=0.2.3
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/appengine/standard_python3/bundled-services/deferred/flask/requirements.txt
+++ b/appengine/standard_python3/bundled-services/deferred/flask/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.0.1
+Flask==3.0.0
 appengine-python-standard>=0.3.1
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/appengine/standard_python3/bundled-services/mail/flask/main.py
+++ b/appengine/standard_python3/bundled-services/mail/flask/main.py
@@ -14,9 +14,11 @@
 
 import os
 
-from flask import escape, Flask, request
+from flask import Flask, request
 from google.appengine.api import mail
 from google.appengine.api import wrap_wsgi_app
+from markupsafe import escape
+
 
 app = Flask(__name__)
 

--- a/appengine/standard_python3/bundled-services/mail/flask/requirements.txt
+++ b/appengine/standard_python3/bundled-services/mail/flask/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.1.2
+Flask==3.0.0
 appengine-python-standard>=1.0.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/appengine/standard_python3/bundled-services/mail/flask/requirements.txt
+++ b/appengine/standard_python3/bundled-services/mail/flask/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.0
-appengine-python-standard>=1.0.0
+appengine-python-standard==1.1.4
 Werkzeug==3.0.1
+MarkupSafe==2.1.3

--- a/cloud_scheduler/snippets/requirements.txt
+++ b/cloud_scheduler/snippets/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==3.0.0
 gunicorn==20.1.0
 google-cloud-scheduler==2.11.2
 Werkzeug==3.0.1

--- a/compute/managed-instances/demo/requirements.txt
+++ b/compute/managed-instances/demo/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.1.0
+Flask==3.0.0
 requests==2.31.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/datastore/cloud-ndb/requirements.txt
+++ b/datastore/cloud-ndb/requirements.txt
@@ -1,5 +1,5 @@
 # [START ndb_version]
 google-cloud-ndb==2.2.1
 # [END ndb_version]
-Flask==2.2.5
+Flask==3.0.0
 Werkzeug==3.0.1

--- a/endpoints/getting-started/main.py
+++ b/endpoints/getting-started/main.py
@@ -33,10 +33,14 @@ app = Flask(__name__)
 
 
 def _base64_decode(encoded_str):
+    # in versions of Werkzeug <3.x this function expected an encoded string that did not have the b' prefix
+    # post Werkzeug 3.x this variable came in as a 'str' type but with the b' prefix. Removing it
+    if encoded_str[0] == "b":
+        encoded_str = encoded_str[1:]
     # Add paddings manually if necessary.
     num_missed_paddings = 4 - len(encoded_str) % 4
     if num_missed_paddings != 4:
-        encoded_str += b"=" * num_missed_paddings
+        encoded_str += "=" * num_missed_paddings
     return base64.b64decode(encoded_str).decode("utf-8")
 
 
@@ -51,7 +55,6 @@ def echo():
 def auth_info():
     """Retrieves the authenication information from Google Cloud Endpoints."""
     encoded_info = request.headers.get("X-Endpoint-API-UserInfo", None)
-
     if encoded_info:
         info_json = _base64_decode(encoded_info)
         user_info = json.loads(info_json)

--- a/endpoints/getting-started/main_test.py
+++ b/endpoints/getting-started/main_test.py
@@ -49,7 +49,6 @@ def test_auth_info(client):
     ]
 
     encoded_info = base64.b64encode(json.dumps({"id": "123"}).encode("utf-8"))
-
     for endpoint in endpoints:
         r = client.get(endpoint, headers={"Content-Type": "application/json"})
 

--- a/endpoints/getting-started/requirements.txt
+++ b/endpoints/getting-started/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.2.5
+Flask==3.0.0
 flask-cors==4.0.0
 gunicorn==20.1.0
 six==1.16.0
@@ -6,4 +6,4 @@ pyyaml==6.0
 requests==2.31.0
 google-auth==2.19.1
 google-auth-oauthlib==1.0.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/iap/app_engine_app/requirements.txt
+++ b/iap/app_engine_app/requirements.txt
@@ -1,2 +1,2 @@
-Flask==2.2.5
+Flask==3.0.0
 Werkzeug==3.0.1

--- a/iap/requirements.txt
+++ b/iap/requirements.txt
@@ -1,5 +1,5 @@
 cryptography==41.0.4
-Flask==2.2.5
+Flask==3.0.0
 google-auth==2.19.1
 gunicorn==20.1.0
 requests==2.31.0

--- a/memorystore/redis/requirements.txt
+++ b/memorystore/redis/requirements.txt
@@ -11,8 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START memorystore_requirements]
-Flask==2.1.0
+Flask==3.0.0
 gunicorn==20.1.0
 redis==5.0.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1
 # [END memorystore_requirements]

--- a/monitoring/prometheus/requirements.txt
+++ b/monitoring/prometheus/requirements.txt
@@ -1,8 +1,8 @@
-Flask==2.1.0
+Flask==3.0.0
 google-api-core==2.11.1
 google-auth==2.19.1
 googleapis-common-protos==1.59.1
 prometheus-client==0.17.0
 prometheus-flask-exporter==0.22.4
 requests==2.31.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/people-and-planet-ai/geospatial-classification/serving_app/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/serving_app/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.0
+Flask==3.0.0
 gunicorn==20.1.0
 tensorflow==2.12.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/people-and-planet-ai/land-cover-classification/serving/requirements.txt
+++ b/people-and-planet-ai/land-cover-classification/serving/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for the prediction web service.
-Flask==2.2.2
+Flask==3.0.0
 earthengine-api==0.1.358
 gunicorn==20.1.0
 tensorflow==2.12.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/people-and-planet-ai/timeseries-classification/requirements.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements.txt
@@ -1,7 +1,7 @@
-Flask==2.2.3
+Flask==3.0.0
 apache-beam[gcp]==2.46.0
 google-cloud-aiplatform==1.25.0
 gunicorn==20.1.0
 pandas==2.0.1
 tensorflow==2.12.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/people-and-planet-ai/weather-forecasting/serving/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/serving/requirements.txt
@@ -1,6 +1,6 @@
-Flask==2.2.2
+Flask==3.0.0
 gunicorn==20.1.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1
 
 # Local packages.
 ./weather-data

--- a/profiler/appengine/flexible/requirements.txt
+++ b/profiler/appengine/flexible/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.3.3
+Flask==3.0.0
 gunicorn==20.1.0
 google-cloud-profiler==4.0.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/profiler/appengine/standard_python37/requirements.txt
+++ b/profiler/appengine/standard_python37/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.3.3
+Flask==3.0.0
 google-cloud-profiler==4.0.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/recaptcha_enterprise/demosite/app/requirements.txt
+++ b/recaptcha_enterprise/demosite/app/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.2
+Flask==3.0.0
 gunicorn==20.1.0
 google-cloud-recaptcha-enterprise==1.12.0
-Werkzeug==2.2.0
+Werkzeug==3.0.1

--- a/run/hello-broken/requirements.txt
+++ b/run/hello-broken/requirements.txt
@@ -3,4 +3,4 @@ pytest==7.0.1; python_version > "3.0"
 # pin pytest to 4.6.11 for Python2.
 pytest==7.0.1; python_version < "3.0"
 gunicorn==20.1.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/run/hello-broken/requirements.txt
+++ b/run/hello-broken/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.0
+Flask==3.0.0
 pytest==7.0.1; python_version > "3.0"
 # pin pytest to 4.6.11 for Python2.
 pytest==7.0.1; python_version < "3.0"

--- a/run/helloworld/requirements.txt
+++ b/run/helloworld/requirements.txt
@@ -1,3 +1,3 @@
 Flask==2.1.0
 gunicorn==20.1.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/run/helloworld/requirements.txt
+++ b/run/helloworld/requirements.txt
@@ -1,3 +1,3 @@
-Flask==2.1.0
+Flask==3.0.0
 gunicorn==20.1.0
 Werkzeug==3.0.1

--- a/run/image-processing/requirements.txt
+++ b/run/image-processing/requirements.txt
@@ -3,4 +3,4 @@ google-cloud-storage==2.12.0
 google-cloud-vision==3.4.5
 gunicorn==21.2.0
 Wand==0.6.11
-Werkzeug==3.0.0
+Werkzeug==3.0.1

--- a/run/logging-manual/requirements.txt
+++ b/run/logging-manual/requirements.txt
@@ -3,4 +3,4 @@ pytest==7.0.1; python_version > "3.0"
 # pin pytest to 4.6.11 for Python2.
 pytest==7.0.1; python_version < "3.0"
 gunicorn==20.1.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/run/logging-manual/requirements.txt
+++ b/run/logging-manual/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.0
+Flask==3.0.0
 pytest==7.0.1; python_version > "3.0"
 # pin pytest to 4.6.11 for Python2.
 pytest==7.0.1; python_version < "3.0"

--- a/run/markdown-preview/editor/requirements.txt
+++ b/run/markdown-preview/editor/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.0
+Flask==3.0.0
 gunicorn==20.1.0
 google-auth==2.19.1
 requests==2.31.0

--- a/run/markdown-preview/editor/requirements.txt
+++ b/run/markdown-preview/editor/requirements.txt
@@ -2,4 +2,4 @@ Flask==2.1.0
 gunicorn==20.1.0
 google-auth==2.19.1
 requests==2.31.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/run/markdown-preview/renderer/requirements.txt
+++ b/run/markdown-preview/renderer/requirements.txt
@@ -2,4 +2,4 @@ Flask==2.1.0
 gunicorn==20.1.0
 Markdown==3.4.3
 bleach==6.0.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/run/markdown-preview/renderer/requirements.txt
+++ b/run/markdown-preview/renderer/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.0
+Flask==3.0.0
 gunicorn==20.1.0
 Markdown==3.4.3
 bleach==6.0.0

--- a/run/pubsub/requirements.txt
+++ b/run/pubsub/requirements.txt
@@ -3,4 +3,4 @@ pytest==7.0.1; python_version > "3.0"
 # pin pytest to 4.6.11 for Python2.
 pytest==7.0.1; python_version < "3.0"
 gunicorn==20.1.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/run/pubsub/requirements.txt
+++ b/run/pubsub/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.0
+Flask==3.0.0
 pytest==7.0.1; python_version > "3.0"
 # pin pytest to 4.6.11 for Python2.
 pytest==7.0.1; python_version < "3.0"

--- a/run/service-auth/requirements.txt
+++ b/run/service-auth/requirements.txt
@@ -2,4 +2,4 @@ google-auth==2.19.1
 requests==2.31.0
 Flask==2.1.2
 gunicorn==20.1.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/run/service-auth/requirements.txt
+++ b/run/service-auth/requirements.txt
@@ -1,5 +1,5 @@
 google-auth==2.19.1
 requests==2.31.0
-Flask==2.1.2
+Flask==3.0.0
 gunicorn==20.1.0
 Werkzeug==3.0.1

--- a/trace/cloud-trace-demo-app-opentelemetry/app/requirements.txt
+++ b/trace/cloud-trace-demo-app-opentelemetry/app/requirements.txt
@@ -1,8 +1,8 @@
-Flask==2.2.2
+Flask==3.0.0
 gunicorn==20.1.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
 opentelemetry-instrumentation-flask==0.34b0
 opentelemetry-instrumentation-requests==0.34b0
 google-cloud-trace==1.11.1
-Werkzeug==2.3.7
+Werkzeug==3.0.1

--- a/trace/trace-python-sample-opentelemetry/requirements.txt
+++ b/trace/trace-python-sample-opentelemetry/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.0
+Flask==3.0.0
 opentelemetry-exporter-gcp-trace==1.5.0
 opentelemetry-propagator-gcp==1.5.0
-Werkzeug==2.3.7
+Werkzeug==3.0.1


### PR DESCRIPTION
This PR upgrades `Werkzeug` to >3.x and `Flask` to >3.x where possible. In a couple of instances, slight code adjustments were made to fix code that changed in the major version upgrades.