### PR TITLE
Pin MySQL sample to Python 3.11

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/Dockerfile
+++ b/cloud-sql/mysql/sqlalchemy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3
+FROM python:3.11
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.


### PR DESCRIPTION
The current base image 'python:3' takes the latest image available, which is 3.12 (recently released). All dependencies of the mySql sample are not yet compatible with 3.12. Thus, pinning the base version to 3.11 like all other samples in this repository.
