### PR TITLE
feat: Add Auto Approve bot config

### DIFF
--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -1,0 +1,31 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# # AutoApproveBot - PythonSampleDependency Process Features:
+#  - Checks that the author is 'renovate-bot'
+#  - Checks that the title of the PR matches the regexp:
+#    - /^(fix|chore)\(deps\): update dependency (@?\S*) to v(\S*)$/
+#  - Each file path must match one of these regexps:
+#    - /requirements.txt$/
+#  - All files must:
+#    - Match this regexp: /requirements.txt$/
+#       - Ignore files with path /airflow/, /composer/
+#    - Increase the non-major package version of a dependency
+#    - Change the dependency that was there previously, and that is on the title of the PR
+#    - Not match any regexes in the 'excluded' list
+#
+# ReadMe: https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
+# SourceCode: https://github.com/googleapis/repo-automation-bots/blob/main/packages/auto-approve/src/process-checks/python/sample-dependency.ts
+processes:
+  - "PythonSampleDependency"

--- a/.github/auto-approve.yml
+++ b/.github/auto-approve.yml
@@ -21,6 +21,7 @@
 #  - All files must:
 #    - Match this regexp: /requirements.txt$/
 #       - Ignore files with path /airflow/, /composer/
+#    - Only change one dependency, that must be a google dependency
 #    - Increase the non-major package version of a dependency
 #    - Change the dependency that was there previously, and that is on the title of the PR
 #    - Not match any regexes in the 'excluded' list


### PR DESCRIPTION
## Description

Adds auto-approve.yml for Renovate only.

ReadMe: https://github.com/googleapis/repo-automation-bots/tree/main/packages/auto-approve
SourceCode: https://github.com/googleapis/repo-automation-bots/blob/main/packages/auto-approve/src/process-checks/python/sample-dependency.ts