### PR TITLE
docs(samples): Add getting started flex template

### DIFF
--- a/dataflow/flex-templates/getting_started/getting_started.py
+++ b/dataflow/flex-templates/getting_started/getting_started.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import apache_beam as beam
+from apache_beam.io.textio import WriteToText
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+def write_to_cloud_storage(argv=None):
+    # Parse the pipeline options passed into the application.
+    class MyOptions(PipelineOptions):
+        @classmethod
+        # Define a custom pipeline option that specfies the Cloud Storage bucket.
+        def _add_argparse_args(cls, parser):
+            parser.add_argument("--output", required=True)
+
+    wordsList = ["1", "2", "3", "4"]
+    options = MyOptions()
+
+    with beam.Pipeline(options=options) as pipeline:
+        (
+            pipeline
+            | "Create elements" >> beam.Create(wordsList)
+            | "Write Files" >> WriteToText(options.output, file_name_suffix=".txt")
+        )
+
+
+if __name__ == "__main__":
+    write_to_cloud_storage()

--- a/dataflow/flex-templates/getting_started/metadata.json
+++ b/dataflow/flex-templates/getting_started/metadata.json
@@ -1,0 +1,14 @@
+{
+  "name": "Getting started Python flex template",
+  "description": "An example flex template for Python.",
+  "parameters": [
+    {
+      "name": "output",
+      "label": "Output destination",
+      "helpText": "The path and filename prefix for writing output files. Example: gs://your-bucket/your-path.",
+      "regexes": [
+        "^gs:\\/\\/[^\\n\\r]+$"
+      ]
+    }
+  ]
+}

--- a/dataflow/flex-templates/getting_started/requirements.txt
+++ b/dataflow/flex-templates/getting_started/requirements.txt
@@ -1,0 +1,1 @@
+apache-beam[gcp]==2.48.0


### PR DESCRIPTION
## Description

Add a "getting started" flex template for [Flex template tutorial](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates)

DRAFT - DO NOT MERGE

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved