### PR TITLE
fix(recaptcha): Fixing Flask+Werkzeug versioning problem

### DIFF
--- a/recaptcha_enterprise/snippets/requirements-test.txt
+++ b/recaptcha_enterprise/snippets/requirements-test.txt
@@ -1,5 +1,6 @@
 selenium==4.10.0
 Flask==2.2.2
+Werkzeug==2.3.7
 pytest==7.2.1
 pytest-flask==1.2.0
 webdriver-manager==4.0.1


### PR DESCRIPTION
The tests were failing with:

```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/workspace/recaptcha_enterprise/snippets/.nox/py-3-8/lib/python3.8/site-packages/werkzeug/urls.py)
```