### PR TITLE
fix(firestore): Add await to the example

### DIFF
--- a/firestore/cloud-async-client/snippets.py
+++ b/firestore/cloud-async-client/snippets.py
@@ -788,7 +788,7 @@ async def update_document_increment(db):
     # [START firestore_data_set_numeric_increment_async]
     washington_ref = db.collection("cities").document("DC")
 
-    washington_ref.update({"population": firestore.Increment(50)})
+    await washington_ref.update({"population": firestore.Increment(50)})
     # [END firestore_data_set_numeric_increment_async]
 
 

--- a/firestore/cloud-async-client/snippets_test.py
+++ b/firestore/cloud-async-client/snippets_test.py
@@ -307,7 +307,7 @@ async def test_collection_group_query(db):
 
 async def test_update_document_increment(db):
     await db.collection("cities").document("DC").set({"population": 1})
-    await snippets.update_document_increment()
+    await snippets.update_document_increment(db)
 
 
 async def test_list_document_subcollections():

--- a/firestore/cloud-async-client/snippets_test.py
+++ b/firestore/cloud-async-client/snippets_test.py
@@ -305,5 +305,10 @@ async def test_collection_group_query(db):
     }
 
 
+async def test_update_document_increment(db):
+    await db.collection("cities").document("DC").set({"population": 1})
+    await snippets.update_document_increment()
+
+
 async def test_list_document_subcollections():
     await snippets.list_document_subcollections()


### PR DESCRIPTION
## Description

`update_document_increment()` in `firestore/cloud-async-client/snippets.py` does not work as expected. Add `await` to fix.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved