### PR TITLE
fix: assign practice-folder CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -93,6 +93,10 @@
 /pubsublite/**/*                       @GoogleCloudPlatform/api-pubsub-and-pubsublite @GoogleCloudPlatform/python-samples-reviewers
 /cloud_tasks/**/*                      @GoogleCloudPlatform/torus-dpe @GoogleCloudPlatform/python-samples-reviewers
 
+# For practicing
+# ---* Use with codelabs to learn to submit samples
+/practice-folder/**/*                  @engelke
+
 # ---* Fully Eng Owned
 /appengine/**/*                        @GoogleCloudPlatform/serverless-runtimes @GoogleCloudPlatform/python-samples-reviewers
 /appengine/standard_python3/spanner/*  @GoogleCloudPlatform/api-spanner-python @GoogleCloudPlatform/python-samples-reviewers


### PR DESCRIPTION
There are now codelabs for learning to edit and submit new samples. Assign ownership of that file to restrict review requests.
