### PR TITLE
fix: practice-folder CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,7 +95,7 @@
 
 # For practicing
 # ---* Use with codelabs to learn to submit samples
-/practice-folder/**/*                  @engelke
+/practice-folder/**/*                  engelke@google.com
 
 # ---* Fully Eng Owned
 /appengine/**/*                        @GoogleCloudPlatform/serverless-runtimes @GoogleCloudPlatform/python-samples-reviewers


### PR DESCRIPTION
Fixes CODEOWNERS for /practice-folder to avoid spamming other reviewers with training PRs