### PR TITLE
fix: correct deprecated Django functionality, update Django deps

### DIFF
--- a/appengine/standard_python3/bundled-services/mail/django/main.py
+++ b/appengine/standard_python3/bundled-services/mail/django/main.py
@@ -15,8 +15,8 @@
 import os
 
 from django.conf import settings
-from django.urls import re_path
 from django.core.wsgi import get_wsgi_application
+from django.urls import re_path
 from django.http import HttpResponse
 from google.appengine.api import mail
 from google.appengine.api import wrap_wsgi_app

--- a/appengine/standard_python3/bundled-services/mail/django/main.py
+++ b/appengine/standard_python3/bundled-services/mail/django/main.py
@@ -15,7 +15,7 @@
 import os
 
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 from django.core.wsgi import get_wsgi_application
 from django.http import HttpResponse
 from google.appengine.api import mail
@@ -106,9 +106,9 @@ def receive_bounce(request):
 
 
 urlpatterns = [
-    url(r"^$", home_page),
-    url(r"^_ah/mail/.*$", receive_mail),
-    url(r"^_ah/bounce$", receive_bounce),
+    re_path(r"^$", home_page),
+    re_path(r"^_ah/mail/.*$", receive_mail),
+    re_path(r"^_ah/bounce$", receive_bounce),
 ]
 
 settings.configure(

--- a/appengine/standard_python3/bundled-services/mail/django/main.py
+++ b/appengine/standard_python3/bundled-services/mail/django/main.py
@@ -14,12 +14,11 @@
 
 import os
 
-from google.appengine.api import mail, wrap_wsgi_app
-
 from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 from django.http import HttpResponse
 from django.urls import re_path
+from google.appengine.api import mail, wrap_wsgi_app
 
 
 def home_page(request):

--- a/appengine/standard_python3/bundled-services/mail/django/main.py
+++ b/appengine/standard_python3/bundled-services/mail/django/main.py
@@ -14,12 +14,12 @@
 
 import os
 
+from google.appengine.api import mail, wrap_wsgi_app
+
 from django.conf import settings
 from django.core.wsgi import get_wsgi_application
-from django.urls import re_path
 from django.http import HttpResponse
-from google.appengine.api import mail
-from google.appengine.api import wrap_wsgi_app
+from django.urls import re_path
 
 
 def home_page(request):

--- a/appengine/standard_python3/bundled-services/mail/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/mail/django/requirements.txt
@@ -1,4 +1,6 @@
-Django==3.2.23
+Django==5.0; python_version >= "3.10"
+Django==4.2.8; python_version >= "3.8" and python_version < "3.10"
+Django==3.2.23; python_version < "3.8"
 django-environ==0.10.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.2.3


### PR DESCRIPTION
## Description

Removes deprecated usage of `url` in favor of `re_path`, updates Django versions. 

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved