### PR TITLE
fix: import log to destination project

### DIFF
--- a/logging/import-logs/README.md
+++ b/logging/import-logs/README.md
@@ -9,6 +9,19 @@ solution in [documentation].
 
 [documentation]: (LINK-TO-REFERENCE-ARCHITECTURE-ARTICLE)-->
 
+All logs will be imported to the project that runs Cloud Run job.
+Alternatively you can explicitly configure the project ID where you want logs to be imported.
+The logs will be imported with log name `imported_logs`.
+It means that the `logName` field of the imported logs will be:
+
+```text
+projects/PROJECT_ID/logs/imported_logs
+```
+
+where `PROJECT_ID` is the project ID of the project where you import the logs.
+
+The original log name will be stored in the user labels under the key `original_logName` (mind the casing).
+
 ## Requirements
 
 You have to grant the following permissions to a service account that you will
@@ -47,6 +60,7 @@ have to be configured when a new Cloud Run job for the solution is created:
 | END_DATE | A string in format `MM/DD/YYYY` that defines the last day of the import range |
 | LOG_ID | A string that identifies the particular log to be imported. See [documentation][logid] for more details. |
 | STORAGE_BUCKET_NAME | A name of the storage bucket where the exported logs are stored. |
+| PROJECT_ID | (Optional) If you want to explicitly define destination project other than one your import job is deployed |
 
 <!--Read [documentation] for more information about Cloud Run job setup.-->
 
@@ -94,33 +108,25 @@ nox -s py-3.11
 
 ## Importing log entries with timestamps older than 30 days
 
-The import logs implementation does not currently support logs with the timestamp older than 30 days
-because the incoming log entries must not be older than default retention period (see [documentation][retention]).
-To prevent such logs from being ignored the implementation returns errors if the timestamp is older than 29 days.
+The incoming log entries that are older than default retention period (i.e. 30 days) are not ingested.
+You can see [documentation][retention] for more details. The code takes a safety margin of an extra day
+to prevent importing old logs that cannot be ingested.
 To import the older logs you have to modified the [current] code by performing the following modifications:
 
-* remove the fencing condition [lines][code1]:
+* comment the fencing condition [lines][code1]:
 
-  <https://github.com/GoogleCloudPlatform/python-docs-samples/blob/95dd4f53ff96470a1f842d3134d56b017a85ac27/logging/import-logs/main.py#L91-L93>
+  <https://github.com/GoogleCloudPlatform/python-docs-samples/blob/86f12a752a4171e137adaa855c7247be9d5d39a2/logging/import-logs/main.py#L81-L83>
 
-* in [`import_logs`][code2] add the following block after the call to [`_patch_reserved_log_ids`][code3]:
-  
-  ```python
-  log.labels['original_timestamp'] = log.timestamp
-  log.timestamp = None
-  ```
-
-  to keep the original timestamp as a user metadata labeled `original_timestamp` and to ingest the log entry using _current_ timestamp.
+* uncomment [2 lines][code2] to keep the original timestamp as a user label and to reset the `timestamp` field of the imported log entries.
 
 > [!IMPORTANT]  
 >
-> 1. After this change the logs should be queried using the `timestamp` field.
+> 1. To query the imported logs by timestamp you will have to use the label `original_timestamp` instead of the `timestamp` field.
 > 1. If the same log entry is imported multiple times, the query response may include more than one line.
 
 After applying the changes, [build](#build) a custom container image and use it when creating an import job.
 
 [retention]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.timestamp
 [current]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/e2709a218072c86ec1a9b9101db45057ebfdbff0/logging/import-logs/main.py
-[code1]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/95dd4f53ff96470a1f842d3134d56b017a85ac27/logging/import-logs/main.py#L91-L93
-[code2]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/95dd4f53ff96470a1f842d3134d56b017a85ac27/logging/import-logs/main.py#L196
-[code3]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/95dd4f53ff96470a1f842d3134d56b017a85ac27/logging/import-logs/main.py#L206
+[code1]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/86f12a752a4171e137adaa855c7247be9d5d39a2/logging/import-logs/main.py#L81-L83
+[code2]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/86f12a752a4171e137adaa855c7247be9d5d39a2/logging/import-logs/main.py#L188-L189

--- a/logging/import-logs/README.md
+++ b/logging/import-logs/README.md
@@ -129,4 +129,4 @@ After applying the changes, [build](#build) a custom container image and use it 
 [retention]: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.timestamp
 [current]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/e2709a218072c86ec1a9b9101db45057ebfdbff0/logging/import-logs/main.py
 [code1]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/86f12a752a4171e137adaa855c7247be9d5d39a2/logging/import-logs/main.py#L81-L83
-[code2]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/86f12a752a4171e137adaa855c7247be9d5d39a2/logging/import-logs/main.py#L188-L189
+[code2]: https://github.com/GoogleCloudPlatform/python-docs-samples/blob/86f12a752a4171e137adaa855c7247be9d5d39a2/logging/import-logs/main.py#L186-L187

--- a/logging/import-logs/main.py
+++ b/logging/import-logs/main.py
@@ -77,7 +77,7 @@ def _is_valid_import_range() -> bool:
     if START_DATE > END_DATE:
         eprint("Start date of the import time range should be earlier than end date")
         return False
-    # comment the following 3 lines if you import range includes dates older than 29 days from now
+    # comment the following 3 lines if import range includes dates older than 29 days from now
     if (date.today() - START_DATE).days > 29:
         eprint("Import range includes dates older than 29 days from today.")
         return False

--- a/logging/import-logs/main.py
+++ b/logging/import-logs/main.py
@@ -183,8 +183,8 @@ def _patch_entry(log: dict, project_id: str) -> None:
         log["labels"] = labels
     labels["original_logName"] = log_name
     # uncomment the following 2 lines if import range includes dates older than 29 days from now
-    # labels['original_timestamp'] = log['timestamp']
-    # log['timestamp'] = None
+    # labels["original_timestamp"] = log["timestamp"]
+    # log["timestamp"] = None
 
 
 def import_logs(

--- a/logging/import-logs/main.py
+++ b/logging/import-logs/main.py
@@ -59,7 +59,7 @@ def _day(blob_name: str) -> int:
     """Parse day number from Blob's path
 
     Use the known Blob path convention to parse the day part from the path.
-    The path convetion is <LOG_ID>/YYYY/MM/DD/<OBJECT_NAME>
+    The path convention is <LOG_ID>/YYYY/MM/DD/<OBJECT_NAME>
     """
     # calculated in function to allow test to set LOG_ID
     offset = len(LOG_ID) + 1 + 4 + 1 + 2 + 1

--- a/logging/import-logs/main_test.py
+++ b/logging/import-logs/main_test.py
@@ -33,6 +33,7 @@ import main
 TEST_LOG_ID = "test-log"
 TEST_BUCKET = "test-bucket"
 TEST_BUCKET_NAME = f"gs://{TEST_BUCKET}"
+TEST_PROJECT_ID = "test-project-id"
 
 
 def _setup_environment(
@@ -56,8 +57,10 @@ def _setup_environment(
 @pytest.mark.parametrize(
     "start_date, end_date, expected_validity",
     [
-        (date.today() - timedelta(days=29), date.today() - timedelta(days=10), True),
-        (date.today() - timedelta(days=10), date.today() - timedelta(days=29), False),
+        (date.today() - timedelta(days=29),
+         date.today() - timedelta(days=10), True),
+        (date.today() - timedelta(days=10),
+         date.today() - timedelta(days=29), False),
         (date.today() - timedelta(days=30), date.today(), False),
         ("07/01/2023", "06/01/2023", False),
     ],
@@ -124,7 +127,8 @@ def test_import_range_validation(
             date(2001, 1, 22),
             date(2001, 2, 1),
         ),
-        (date(2001, 5, 5), date(2002, 2, 2), 1, 2, date(2001, 9, 19), date(2002, 2, 2)),
+        (date(2001, 5, 5), date(2002, 2, 2), 1,
+         2, date(2001, 9, 19), date(2002, 2, 2)),
     ],
     ids=[
         "simple single range",
@@ -161,61 +165,104 @@ def test_calc_import_range(
 
 
 TEST_FILES_JUN_2001 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JUL_2001 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_AUG_2001 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAY_2002 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JAN_2003 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_FEB_2003 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAR_2003 = [
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(
+        name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
 ]
 
 
@@ -248,7 +295,8 @@ def _args_based_list_blobs_return(*_args: str, **kwargs: TypedDict) -> List[str]
 @pytest.mark.parametrize(
     "first_day, last_day, expected_paths",
     [
-        (date(2001, 6, 1), date(2001, 6, 30), [f.name for f in TEST_FILES_JUN_2001]),
+        (date(2001, 6, 1), date(2001, 6, 30), [
+         f.name for f in TEST_FILES_JUN_2001]),
         (
             date(2001, 6, 2),
             date(2001, 6, 3),
@@ -275,7 +323,8 @@ def test_list_log_files(first_day: str, last_day: str, expected_paths: List) -> 
     _setup_environment()
 
     mocked_client = MagicMock(spec=storage.Client)
-    mocked_client.list_blobs = MagicMock(side_effect=_args_based_list_blobs_return)
+    mocked_client.list_blobs = MagicMock(
+        side_effect=_args_based_list_blobs_return)
 
     paths = main.list_log_files(first_day, last_day, mocked_client)
 
@@ -296,7 +345,8 @@ TEST_LOG_SIZE = sys.getsizeof(json.loads(TEST_CONTENT["file4.json"]))
 
 def _args_based_blob_return(*args: Tuple, **_kwargs: TypedDict) -> str:
     mocked_blob = MagicMock(spec=storage.Blob)
-    mocked_blob.download_as_string = MagicMock(return_value=TEST_CONTENT.get(args[0]))
+    mocked_blob.download_as_string = MagicMock(
+        return_value=TEST_CONTENT.get(args[0]))
     return mocked_blob
 
 
@@ -315,7 +365,8 @@ def _calc_args_size(*args: Tuple) -> int:
         (
             TEST_LOG_FILES[:2],
             (TEST_LOG_SIZE + 10),
-            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE],
+            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE,
+                TEST_LOG_SIZE, TEST_LOG_SIZE],
         ),
         (
             TEST_LOG_FILES[:3],
@@ -339,6 +390,7 @@ def test_import_logs(
     mocked_bucket.blob = MagicMock(side_effect=_args_based_blob_return)
     mocked_logging_client = MagicMock(spec=logging_v2.Client)
     mocked_logging_client.logging_api = MagicMock()
+    mocked_logging_client.project = TEST_PROJECT_ID
     mocked_write_entries = mocked_logging_client.logging_api.write_entries = MagicMock()
 
     main.import_logs(log_files, mocked_storage_client, mocked_logging_client)

--- a/logging/import-logs/main_test.py
+++ b/logging/import-logs/main_test.py
@@ -57,10 +57,8 @@ def _setup_environment(
 @pytest.mark.parametrize(
     "start_date, end_date, expected_validity",
     [
-        (date.today() - timedelta(days=29),
-         date.today() - timedelta(days=10), True),
-        (date.today() - timedelta(days=10),
-         date.today() - timedelta(days=29), False),
+        (date.today() - timedelta(days=29), date.today() - timedelta(days=10), True),
+        (date.today() - timedelta(days=10), date.today() - timedelta(days=29), False),
         (date.today() - timedelta(days=30), date.today(), False),
         ("07/01/2023", "06/01/2023", False),
     ],
@@ -127,8 +125,7 @@ def test_import_range_validation(
             date(2001, 1, 22),
             date(2001, 2, 1),
         ),
-        (date(2001, 5, 5), date(2002, 2, 2), 1,
-         2, date(2001, 9, 19), date(2002, 2, 2)),
+        (date(2001, 5, 5), date(2002, 2, 2), 1, 2, date(2001, 9, 19), date(2002, 2, 2)),
     ],
     ids=[
         "simple single range",
@@ -165,104 +162,61 @@ def test_calc_import_range(
 
 
 TEST_FILES_JUN_2001 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/06/04/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JUL_2001 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/07/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_AUG_2001 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2001/08/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAY_2002 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2002/05/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_JAN_2003 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/01/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_FEB_2003 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/02/03/file2.json", bucket=TEST_BUCKET),
 ]
 TEST_FILES_MAR_2003 = [
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
-    storage.Blob(
-        name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/01/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/02/file2.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file1.json", bucket=TEST_BUCKET),
+    storage.Blob(name=f"{TEST_LOG_ID}/2003/03/03/file2.json", bucket=TEST_BUCKET),
 ]
 
 
@@ -295,8 +249,7 @@ def _args_based_list_blobs_return(*_args: str, **kwargs: TypedDict) -> List[str]
 @pytest.mark.parametrize(
     "first_day, last_day, expected_paths",
     [
-        (date(2001, 6, 1), date(2001, 6, 30), [
-         f.name for f in TEST_FILES_JUN_2001]),
+        (date(2001, 6, 1), date(2001, 6, 30), [f.name for f in TEST_FILES_JUN_2001]),
         (
             date(2001, 6, 2),
             date(2001, 6, 3),
@@ -323,8 +276,7 @@ def test_list_log_files(first_day: str, last_day: str, expected_paths: List) -> 
     _setup_environment()
 
     mocked_client = MagicMock(spec=storage.Client)
-    mocked_client.list_blobs = MagicMock(
-        side_effect=_args_based_list_blobs_return)
+    mocked_client.list_blobs = MagicMock(side_effect=_args_based_list_blobs_return)
 
     paths = main.list_log_files(first_day, last_day, mocked_client)
 
@@ -345,8 +297,7 @@ TEST_LOG_SIZE = sys.getsizeof(json.loads(TEST_CONTENT["file4.json"]))
 
 def _args_based_blob_return(*args: Tuple, **_kwargs: TypedDict) -> str:
     mocked_blob = MagicMock(spec=storage.Blob)
-    mocked_blob.download_as_string = MagicMock(
-        return_value=TEST_CONTENT.get(args[0]))
+    mocked_blob.download_as_string = MagicMock(return_value=TEST_CONTENT.get(args[0]))
     return mocked_blob
 
 
@@ -365,8 +316,7 @@ def _calc_args_size(*args: Tuple) -> int:
         (
             TEST_LOG_FILES[:2],
             (TEST_LOG_SIZE + 10),
-            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE,
-                TEST_LOG_SIZE, TEST_LOG_SIZE],
+            [TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE, TEST_LOG_SIZE],
         ),
         (
             TEST_LOG_FILES[:3],


### PR DESCRIPTION
## Description

Patch logName of imported logs to use destination project.
Store original logName in user labels.
Refactor method comments.
Refactor handling partial errors of type WriteLogEntriesPartialErrors.
