### PR TITLE
fix(#10940): Replacing depracated before_first_request decorator

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/app.py
+++ b/cloud-sql/mysql/sqlalchemy/app.py
@@ -81,12 +81,13 @@ db = None
 # init_db lazily instantiates a database connection pool. Users of Cloud Run or
 # App Engine may wish to skip this lazy instantiation and connect as soon
 # as the function is loaded. This is primarily to help testing.
-@app.before_first_request
+@app.before_request
 def init_db() -> sqlalchemy.engine.base.Engine:
     """Initiates connection to database and its' structure."""
     global db
-    db = init_connection_pool()
-    migrate_db(db)
+    if db is None:
+        db = init_connection_pool()
+        migrate_db(db)
 
 
 @app.route("/", methods=["GET"])

--- a/cloud-sql/postgres/sqlalchemy/app.py
+++ b/cloud-sql/postgres/sqlalchemy/app.py
@@ -81,12 +81,13 @@ db = None
 # init_db lazily instantiates a database connection pool. Users of Cloud Run or
 # App Engine may wish to skip this lazy instantiation and connect as soon
 # as the function is loaded. This is primarily to help testing.
-@app.before_first_request
+@app.before_request
 def init_db() -> sqlalchemy.engine.base.Engine:
     """Initiates connection to database and its structure."""
     global db
-    db = init_connection_pool()
-    migrate_db(db)
+    if db is None:
+        db = init_connection_pool()
+        migrate_db(db)
 
 
 @app.route("/", methods=["GET"])

--- a/cloud-sql/sql-server/sqlalchemy/app.py
+++ b/cloud-sql/sql-server/sqlalchemy/app.py
@@ -73,11 +73,12 @@ db = None
 # init_db lazily instantiates a database connection pool. Users of Cloud Run or
 # App Engine may wish to skip this lazy instantiation and connect as soon
 # as the function is loaded. This is primarily to help testing.
-@app.before_first_request
+@app.before_request
 def init_db() -> sqlalchemy.engine.base.Engine:
     global db
-    db = init_connection_pool()
-    migrate_db(db)
+    if db is None:
+        db = init_connection_pool()
+        migrate_db(db)
 
 
 @app.route("/", methods=["GET"])

--- a/compute/managed-instances/demo/app.py
+++ b/compute/managed-instances/demo/app.py
@@ -39,11 +39,12 @@ _is_healthy = True
 _cpu_burner = None
 
 
-@app.before_first_request
+@app.before_request
 def init():
     """Initialize the application."""
     global _cpu_burner
-    _cpu_burner = CpuBurner()
+    if _cpu_burner is None:
+        _cpu_burner = CpuBurner()
 
 
 @app.route("/")


### PR DESCRIPTION
## Description

Fixes #10940

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved