### PR TITLE
docs(samples): Add Dataflow to Pub/Sub snippet

### DIFF
--- a/dataflow/snippets/batch_write_storage.py
+++ b/dataflow/snippets/batch_write_storage.py
@@ -23,6 +23,7 @@ from apache_beam.options.pipeline_options import PipelineOptions
 
 from typing_extensions import Self
 
+
 def write_to_cloud_storage(argv : List[str] = None) -> None:
     # Parse the pipeline options passed into the application.
     class MyOptions(PipelineOptions):

--- a/dataflow/snippets/batch_write_storage.py
+++ b/dataflow/snippets/batch_write_storage.py
@@ -14,17 +14,20 @@
 #  limitations under the License.
 
 # [START dataflow_batch_write_to_storage]
+import argparse
+from typing import List, Self
+
 import apache_beam as beam
 from apache_beam.io.textio import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 
 
-def write_to_cloud_storage(argv=None):
+def write_to_cloud_storage(argv : List[str] = None) -> None:
     # Parse the pipeline options passed into the application.
     class MyOptions(PipelineOptions):
         @classmethod
         # Define a custom pipeline option that specfies the Cloud Storage bucket.
-        def _add_argparse_args(cls, parser):
+        def _add_argparse_args(cls: Self, parser: argparse.ArgumentParser) -> None:
             parser.add_argument("--output", required=True)
 
     wordsList = ["1", "2", "3", "4"]

--- a/dataflow/snippets/batch_write_storage.py
+++ b/dataflow/snippets/batch_write_storage.py
@@ -15,12 +15,13 @@
 
 # [START dataflow_batch_write_to_storage]
 import argparse
-from typing import List, Self
+from typing import List
 
 import apache_beam as beam
 from apache_beam.io.textio import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 
+from typing_extensions import Self
 
 def write_to_cloud_storage(argv : List[str] = None) -> None:
     # Parse the pipeline options passed into the application.

--- a/dataflow/snippets/noxfile_config.py
+++ b/dataflow/snippets/noxfile_config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/dataflow/snippets/noxfile_config.py
+++ b/dataflow/snippets/noxfile_config.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default TEST_CONFIG_OVERRIDE for python repos.
+
+# You can copy this file into your directory, then it will be imported from
+# the noxfile.py.
+
+# The source of truth:
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/noxfile_config.py
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.12"],
+    # Old samples are opted out of enforcing Python type hints
+    # All new samples should feature them
+    "enforce_type_hints": False,
+    # An envvar key for determining the project id to use. Change it
+    # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
+    # build specific Cloud project. You can also use your own string
+    # to use your own Cloud project.
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    # If you need to use a specific version of pip,
+    # change pip_version_override to the string representation
+    # of the version number, for example, "20.2.4"
+    "pip_version_override": None,
+    # A dictionary you want to inject into your test. Don't put any
+    # secrets here. These values will override predefined values.
+    "envs": {},
+}

--- a/dataflow/snippets/noxfile_config.py
+++ b/dataflow/snippets/noxfile_config.py
@@ -25,7 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.12"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
-    "enforce_type_hints": False,
+    "enforce_type_hints": True,
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/dataflow/snippets/tests/test_batch_write_storage.py
+++ b/dataflow/snippets/tests/test_batch_write_storage.py
@@ -26,7 +26,7 @@ storage_client = storage.Client()
 
 
 @pytest.fixture(scope="function")
-def setup_and_teardown():
+def setup_and_teardown() -> None:
     try:
         bucket = storage_client.create_bucket(bucket_name)
         yield
@@ -34,7 +34,7 @@ def setup_and_teardown():
         bucket.delete(force=True)
 
 
-def test_write_to_cloud_storage(setup_and_teardown):
+def test_write_to_cloud_storage(setup_and_teardown: None) -> None:
     sys.argv = ['', f'--output=gs://{bucket_name}/output/out-']
     write_to_cloud_storage()
 

--- a/dataflow/snippets/tests/test_write_pubsub.py
+++ b/dataflow/snippets/tests/test_write_pubsub.py
@@ -1,0 +1,54 @@
+# !/usr/bin/env python
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import os
+import sys
+import uuid
+
+from _pytest.capture import CaptureFixture
+from google.cloud import pubsub_v1
+
+import pytest
+
+from ..write_pubsub import write_to_pubsub
+
+
+topic_id = f'test-topic-{uuid.uuid4()}'
+project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
+
+publisher = pubsub_v1.PublisherClient()
+
+
+@pytest.fixture(scope="function")
+def setup_and_teardown():
+    topic_path = publisher.topic_path(project_id, topic_id)
+    try:
+        publisher.create_topic(request={"name": topic_path})
+        yield
+    finally:
+        publisher.delete_topic(request={"topic": topic_path})
+
+
+def test_write_to_pubsub(setup_and_teardown, capsys: CaptureFixture[str]):
+    sys.argv = [
+        '',
+        '--streaming',
+        f'--project={project_id}',
+        f'--topic={topic_id}'
+    ]
+    write_to_pubsub()
+
+    out, _ = capsys.readouterr()
+    assert 'Pipeline ran successfully' in out

--- a/dataflow/snippets/tests/test_write_pubsub.py
+++ b/dataflow/snippets/tests/test_write_pubsub.py
@@ -14,8 +14,8 @@
 #  limitations under the License.
 
 import os
-import sys
 import time
+from unittest.mock import patch
 import uuid
 
 from google.cloud import pubsub_v1
@@ -37,7 +37,7 @@ TIMEOUT = 60 * 5
 
 
 @pytest.fixture(scope="function")
-def setup_and_teardown():
+def setup_and_teardown() -> None:
     topic_path = publisher.topic_path(project_id, topic_id)
     subscription_path = subscriber.subscription_path(project_id, subscription_id)
 
@@ -53,7 +53,7 @@ def setup_and_teardown():
         publisher.delete_topic(request={"topic": topic_path})
 
 
-def read_messages():
+def read_messages() -> None:
     received_messages = []
     ack_ids = []
 
@@ -84,16 +84,13 @@ def read_messages():
     return received_messages
 
 
-def test_write_to_pubsub(setup_and_teardown):
-    sys.argv = [
-        '',
-        '--streaming',
-        f'--project={project_id}',
-        f'--topic={topic_id}'
-    ]
-    write_to_pubsub()
+def test_write_to_pubsub(setup_and_teardown: None) -> None:
+    with patch("sys.argv", [
+        "", '--streaming', f'--project={project_id}', f'--topic={topic_id}'
+    ]):
+        write_to_pubsub()
 
-    # Read from Pub/Sub to verify the pipeline successfully wrote messages.
-    # Duplicate reads are possible.
-    messages = read_messages()
-    assert (len(messages) >= NUM_MESSAGES)
+        # Read from Pub/Sub to verify the pipeline successfully wrote messages.
+        # Duplicate reads are possible.
+        messages = read_messages()
+        assert (len(messages) >= NUM_MESSAGES)

--- a/dataflow/snippets/write_pubsub.py
+++ b/dataflow/snippets/write_pubsub.py
@@ -59,7 +59,7 @@ def write_to_pubsub(argv=None):
         )
 
     print('Pipeline ran successfully.')
-# END [dataflow_pubsub_write_with_attributes]
+# [END dataflow_pubsub_write_with_attributes]
 
 
 if __name__ == "__main__":

--- a/dataflow/snippets/write_pubsub.py
+++ b/dataflow/snippets/write_pubsub.py
@@ -15,12 +15,14 @@
 
 # [START dataflow_pubsub_write_with_attributes]i
 import argparse
-from typing import Any, Dict, List, Self
+from typing import Any, Dict, List
 
 import apache_beam as beam
 from apache_beam.io import PubsubMessage
 from apache_beam.io import WriteToPubSub
 from apache_beam.options.pipeline_options import PipelineOptions
+
+from typing_extensions import Self
 
 
 def item_to_message(item: Dict[str, Any]) -> PubsubMessage:

--- a/dataflow/snippets/write_pubsub.py
+++ b/dataflow/snippets/write_pubsub.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# [START dataflow_pubsub_write_with_attributes]
+import apache_beam as beam
+from apache_beam.io import PubsubMessage
+from apache_beam.io import WriteToPubSub
+from apache_beam.options.pipeline_options import PipelineOptions
+
+
+def item_to_message(item):
+    attributes = {}
+    attributes['buyer'] = item['name']
+    attributes['timestamp'] = str(item['ts'])
+    data = bytes(item['product'], 'utf-8')
+
+    return PubsubMessage(data=data, attributes=attributes)
+
+
+def write_to_pubsub(argv=None):
+
+    # Parse the pipeline options passed into the application.
+    class MyOptions(PipelineOptions):
+        @classmethod
+        # Define custom pipeline options that specify the project ID and Pub/Sub
+        # topic.
+        def _add_argparse_args(cls, parser):
+            parser.add_argument("--project", required=True)
+            parser.add_argument("--topic", required=True)
+
+    example_data = [
+        {'name': 'Robert', 'product': 'TV', 'ts': 1613141590000},
+        {'name': 'Maria', 'product': 'Phone', 'ts': 1612718280000},
+        {'name': 'Juan', 'product': 'Laptop', 'ts': 1611618000000},
+        {'name': 'Rebeca', 'product': 'Video game', 'ts': 1610000000000}
+    ]
+    options = MyOptions()
+
+    topic_path = f'projects/{options.project}/topics/{options.topic}'
+
+    with beam.Pipeline(options=options) as pipeline:
+        (
+            pipeline
+            | "Create elements" >> beam.Create(example_data)
+            | "Convert to Pub/Sub messages" >> beam.Map(item_to_message)
+            | WriteToPubSub(topic=topic_path, with_attributes=True)
+        )
+
+    print('Pipeline ran successfully.')
+# END [dataflow_pubsub_write_with_attributes]
+
+
+if __name__ == "__main__":
+    write_to_pubsub()


### PR DESCRIPTION

## Description

Adds a snippet that shows how to write messages to Pub/Sub from Dataflow.

Bug: b/310239684
Doc bug: b/318728052 (Parent doc bug for context: b/309130866)

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved