### PR TITLE
Update create_image_from_disk() to specify only the instance_name instead of the ful…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,61 +12,60 @@ Check out some of the samples found on this repository on the [Google Cloud Samp
 
 1. Install [`pip` and `virtualenv`][cloud_python_setup] if you do not already have them.
 
-1. Clone this repository:
+2. Clone this repository:
 
-    ```
-    git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
-    ```
+   ```
+   git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+   ```
 
-1. Obtain authentication credentials.
+3. Obtain authentication credentials.
 
-    Create local credentials by running the following command and following the
-    oauth2 flow (read more about the command [here][auth_command]):
+   Create local credentials by running the following command and following the
+   oauth2 flow (read more about the command [here][auth_command]):
 
-    ```
-    gcloud auth application-default login
-    ```
+   ```
+   gcloud auth application-default login
+   ```
 
-    Read more about [Google Cloud Platform Authentication][gcp_auth].
+   Read more about [Google Cloud Platform Authentication][gcp_auth].
 
 ## How to run a sample
 
 1. Change directory to one of the sample folders, e.g. `logging/cloud-client`:
 
-    ```
-    cd logging/cloud-client/
-    ```
+   ```
+   cd logging/cloud-client/
+   ```
 
-1. Create a virtualenv. Samples are compatible with Python 3.6+.
+2. Create a virtualenv. Samples are compatible with Python 3.6+.
 
-    ```
-    python3 -m venv env
-    source env/bin/activate
-    ```
+   ```
+   python3 -m venv env
+   source env/bin/activate
+   ```
 
-1. Install the dependencies needed to run the samples.
+3. Install the dependencies needed to run the samples.
 
-    ```
-    pip install -r requirements.txt
-    ```
+   ```
+   pip install -r requirements.txt
+   ```
 
-1. Run the sample:
+4. Run the sample:
 
-    ```
-    python snippets.py
-    ```
+   ```
+   python snippets.py
+   ```
 
 ## Contributing
 
 Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md).
 
-[slack_badge]: https://img.shields.io/badge/slack-Google%20Cloud%20Platform-E01563.svg	
+[slack_badge]: https://img.shields.io/badge/slack-Google%20Cloud%20Platform-E01563.svg
 [slack_link]: https://googlecloud-community.slack.com/
 [cloud]: https://cloud.google.com/
 [cloud_python_setup]: https://cloud.google.com/python/setup
 [auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
 [gcp_auth]: https://cloud.google.com/docs/authentication#projects_and_resources
-
 [py-2.7-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-2.7.svg
 [py-2.7-link]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-2.7.html
 [py-3.8-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-3.8.svg

--- a/README.md
+++ b/README.md
@@ -12,60 +12,61 @@ Check out some of the samples found on this repository on the [Google Cloud Samp
 
 1. Install [`pip` and `virtualenv`][cloud_python_setup] if you do not already have them.
 
-2. Clone this repository:
+1. Clone this repository:
 
-   ```
-   git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
-   ```
+    ```
+    git clone https://github.com/GoogleCloudPlatform/python-docs-samples.git
+    ```
 
-3. Obtain authentication credentials.
+1. Obtain authentication credentials.
 
-   Create local credentials by running the following command and following the
-   oauth2 flow (read more about the command [here][auth_command]):
+    Create local credentials by running the following command and following the
+    oauth2 flow (read more about the command [here][auth_command]):
 
-   ```
-   gcloud auth application-default login
-   ```
+    ```
+    gcloud auth application-default login
+    ```
 
-   Read more about [Google Cloud Platform Authentication][gcp_auth].
+    Read more about [Google Cloud Platform Authentication][gcp_auth].
 
 ## How to run a sample
 
 1. Change directory to one of the sample folders, e.g. `logging/cloud-client`:
 
-   ```
-   cd logging/cloud-client/
-   ```
+    ```
+    cd logging/cloud-client/
+    ```
 
-2. Create a virtualenv. Samples are compatible with Python 3.6+.
+1. Create a virtualenv. Samples are compatible with Python 3.6+.
 
-   ```
-   python3 -m venv env
-   source env/bin/activate
-   ```
+    ```
+    python3 -m venv env
+    source env/bin/activate
+    ```
 
-3. Install the dependencies needed to run the samples.
+1. Install the dependencies needed to run the samples.
 
-   ```
-   pip install -r requirements.txt
-   ```
+    ```
+    pip install -r requirements.txt
+    ```
 
-4. Run the sample:
+1. Run the sample:
 
-   ```
-   python snippets.py
-   ```
+    ```
+    python snippets.py
+    ```
 
 ## Contributing
 
 Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md).
 
-[slack_badge]: https://img.shields.io/badge/slack-Google%20Cloud%20Platform-E01563.svg
+[slack_badge]: https://img.shields.io/badge/slack-Google%20Cloud%20Platform-E01563.svg	
 [slack_link]: https://googlecloud-community.slack.com/
 [cloud]: https://cloud.google.com/
 [cloud_python_setup]: https://cloud.google.com/python/setup
 [auth_command]: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
 [gcp_auth]: https://cloud.google.com/docs/authentication#projects_and_resources
+
 [py-2.7-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-2.7.svg
 [py-2.7-link]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-2.7.html
 [py-3.8-shield]: https://storage.googleapis.com/cloud-devrel-public/python-docs-samples/badges/py-3.8.svg

--- a/compute/client_library/ingredients/images/create.py
+++ b/compute/client_library/ingredients/images/create.py
@@ -64,9 +64,8 @@ def create_image_from_disk(
     disk = disk_client.get(project=project_id, zone=zone, disk=source_disk_name)
 
     for disk_user in disk.users:
-        instance_name = disk_user.split("/")[-1]
         instance = instance_client.get(
-            project=project_id, zone=zone, instance=instance_name
+            project=project_id, zone=zone, instance=disk_user
         )
         if instance.status in STOPPED_MACHINE_STATUS:
             continue

--- a/compute/client_library/ingredients/images/create.py
+++ b/compute/client_library/ingredients/images/create.py
@@ -64,8 +64,9 @@ def create_image_from_disk(
     disk = disk_client.get(project=project_id, zone=zone, disk=source_disk_name)
 
     for disk_user in disk.users:
+        instance_name = disk_user.split("/")[-1]
         instance = instance_client.get(
-            project=project_id, zone=zone, instance=disk_user
+            project=project_id, zone=zone, instance=instance_name
         )
         if instance.status in STOPPED_MACHINE_STATUS:
             continue

--- a/compute/client_library/snippets/images/create.py
+++ b/compute/client_library/snippets/images/create.py
@@ -118,9 +118,8 @@ def create_image_from_disk(
     disk = disk_client.get(project=project_id, zone=zone, disk=source_disk_name)
 
     for disk_user in disk.users:
-        instance_name = disk_user.split("/")[-1]
         instance = instance_client.get(
-            project=project_id, zone=zone, instance=instance_name
+            project=project_id, zone=zone, instance=disk_user
         )
         if instance.status in STOPPED_MACHINE_STATUS:
             continue

--- a/compute/client_library/snippets/images/create.py
+++ b/compute/client_library/snippets/images/create.py
@@ -118,8 +118,9 @@ def create_image_from_disk(
     disk = disk_client.get(project=project_id, zone=zone, disk=source_disk_name)
 
     for disk_user in disk.users:
+        instance_name = disk_user.split("/")[-1]
         instance = instance_client.get(
-            project=project_id, zone=zone, instance=disk_user
+            project=project_id, zone=zone, instance=instance_name
         )
         if instance.status in STOPPED_MACHINE_STATUS:
             continue


### PR DESCRIPTION
## Description

Fixes #11111 

Updates the invocation of `instance_client.get()` to properly use the instance name of the disk's user rather than the entire path (which causes a ValueError)

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved