### PR TITLE
fix: run/service-auth - ensure token decoded before use

### DIFF
--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -70,7 +70,7 @@ def services():
 
     token = subprocess.run(
         ["gcloud", "auth", "print-identity-token"], stdout=subprocess.PIPE, check=True
-    ).stdout.strip()
+    ).stdout.strip().decode()
 
     yield endpoint_url, token
 

--- a/run/service-auth/receive_test.py
+++ b/run/service-auth/receive_test.py
@@ -66,7 +66,7 @@ def services():
         ],
         stdout=subprocess.PIPE,
         check=True,
-    ).stdout.strip()
+    ).stdout.strip().decode()
 
     token = subprocess.run(
         ["gcloud", "auth", "print-identity-token"], stdout=subprocess.PIPE, check=True
@@ -92,8 +92,8 @@ def services():
 
 
 def test_auth(services):
-    url = services[0].decode()
-    token = services[1].decode()
+    url = services[0]
+    token = services[1]
 
     req = request.Request(url)
     try:


### PR DESCRIPTION
## Description

Fixes #11115

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved