### PR TITLE
docs(samples): Fix Pub/Sub snippet for Dataflow runner

### DIFF
--- a/dataflow/snippets/tests/test_write_pubsub.py
+++ b/dataflow/snippets/tests/test_write_pubsub.py
@@ -85,9 +85,8 @@ def read_messages() -> None:
 
 
 def test_write_to_pubsub(setup_and_teardown: None) -> None:
-    with patch("sys.argv", [
-        "", '--streaming', f'--project={project_id}', f'--topic={topic_id}'
-    ]):
+    topic_path = publisher.topic_path(project_id, topic_id)
+    with patch("sys.argv", ["", '--streaming', f'--topic={topic_path}']):
         write_to_pubsub()
 
         # Read from Pub/Sub to verify the pipeline successfully wrote messages.

--- a/dataflow/snippets/write_pubsub.py
+++ b/dataflow/snippets/write_pubsub.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# [START dataflow_pubsub_write_with_attributes]i
+# [START dataflow_pubsub_write_with_attributes]
 import argparse
 from typing import Any, Dict, List
 
@@ -26,6 +26,8 @@ from typing_extensions import Self
 
 
 def item_to_message(item: Dict[str, Any]) -> PubsubMessage:
+    from apache_beam.io import PubsubMessage
+
     attributes = {
         'buyer': item['name'],
         'timestamp': str(item['ts'])
@@ -38,15 +40,13 @@ def item_to_message(item: Dict[str, Any]) -> PubsubMessage:
 def write_to_pubsub(argv: List[str] = None) -> None:
 
     # Parse the pipeline options passed into the application. Example:
-    #     --project=$PROJECT_ID --topic=$TOPIC_NAME --streaming
+    #     --topic=$TOPIC_PATH --streaming
     # For more information, see
     # https://beam.apache.org/documentation/programming-guide/#configuring-pipeline-options
     class MyOptions(PipelineOptions):
         @classmethod
-        # Define custom pipeline options that specify the project ID and Pub/Sub
-        # topic.
+        # Define a custom pipeline option to specify the Pub/Sub topic.
         def _add_argparse_args(cls: Self, parser: argparse.ArgumentParser) -> None:
-            parser.add_argument("--project", required=True)
             parser.add_argument("--topic", required=True)
 
     example_data = [
@@ -63,7 +63,7 @@ def write_to_pubsub(argv: List[str] = None) -> None:
             | "Create elements" >> beam.Create(example_data)
             | "Convert to Pub/Sub messages" >> beam.Map(item_to_message)
             | WriteToPubSub(
-                  topic=f'projects/{options.project}/topics/{options.topic}',
+                  topic=options.topic,
                   with_attributes=True)
         )
 

--- a/dataflow/snippets/write_pubsub.py
+++ b/dataflow/snippets/write_pubsub.py
@@ -26,6 +26,10 @@ from typing_extensions import Self
 
 
 def item_to_message(item: Dict[str, Any]) -> PubsubMessage:
+    # Re-import needed types. When using the Dataflow runner, this
+    # function executes on a worker, where the global namespace is not
+    # available. For more information, see:
+    # https://cloud.google.com/dataflow/docs/guides/common-errors#name-error
     from apache_beam.io import PubsubMessage
 
     attributes = {


### PR DESCRIPTION
## Description

Fixes two issues when running the `write_pubsub.py` snippet on the Dataflow runner: 

- The custom pipeline option named `pipeline` conflicts with the `DataflowRunner` pipeline options.
- The global namespace is not available inside the `Map` transform when running on the Dataflow worker. See [`NameError`](https://cloud.google.com/dataflow/docs/guides/common-errors#name-error) in the Dataflow troubleshooting guide.

(The current version of the snippet runs fine when using the DirectRunner; these issues are due to differences in the Dataflow
runtime environment.)

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved