### PR TITLE
docs(samples): Set the assessment.event.expected_action when sending a CreateAssessm…

### DIFF
--- a/recaptcha_enterprise/demosite/app/backend/create_recaptcha_assessment.py
+++ b/recaptcha_enterprise/demosite/app/backend/create_recaptcha_assessment.py
@@ -17,13 +17,14 @@ from google.cloud.recaptchaenterprise_v1 import Assessment
 
 
 def create_assessment(
-    project_id: str, recaptcha_site_key: str, token: str
+    project_id: str, recaptcha_site_key: str, token: str, expected_action: str
 ) -> Assessment:
     """Create an assessment to analyze the risk of a UI action.
     Args:
         project_id: Google Cloud Project ID
         recaptcha_site_key: Site key obtained by registering a domain/app to use recaptcha services.
         token: The token obtained from the client on passing the recaptchaSiteKey.
+        expected_action: The expected action for this type of event.
     Returns: Assessment response.
     """
 
@@ -34,6 +35,7 @@ def create_assessment(
     event = recaptchaenterprise_v1.Event()
     event.site_key = recaptcha_site_key
     event.token = token
+    event.expected_action = expected_action
 
     assessment = recaptchaenterprise_v1.Assessment()
     assessment.event = event

--- a/recaptcha_enterprise/demosite/app/urls.py
+++ b/recaptcha_enterprise/demosite/app/urls.py
@@ -68,6 +68,7 @@ def on_homepage_load() -> Response:
             context.get("project_id"),
             context.get("site_key"),
             json_data["token"],
+            recaptcha_action
         )
 
         # Check if the token is valid, score is above threshold score and the action equals expected.
@@ -114,6 +115,7 @@ def on_signup() -> Response:
             context.get("project_id"),
             context.get("site_key"),
             json_data["token"],
+            recaptcha_action
         )
 
         # Check if the token is valid, score is above threshold score and the action equals expected.
@@ -162,6 +164,7 @@ def on_login() -> Response:
             context.get("project_id"),
             context.get("site_key"),
             json_data["token"],
+            recaptcha_action
         )
 
         # Check if the token is valid, score is above threshold score and the action equals expected.
@@ -210,6 +213,7 @@ def on_store_checkout() -> Response:
             context.get("project_id"),
             context.get("site_key"),
             json_data["token"],
+            recaptcha_action
         )
 
         # Check if the token is valid, score is above threshold score and the action equals expected.
@@ -257,6 +261,7 @@ def on_comment_submit() -> Response:
             context.get("project_id"),
             context.get("site_key"),
             json_data["token"],
+            recaptcha_action
         )
 
         # Check if the token is valid, score is above threshold score and the action equals expected.


### PR DESCRIPTION
## Description

Demonstrate setting the [`assessment.event.expected_action`](https://cloud.google.com/recaptcha-enterprise/docs/reference/rpc/google.cloud.recaptchaenterprise.v1#event) during the `CreateAssessment` request, so the `action` from the generated `execute` token can be compared on the backend.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved