### PR TITLE
chore: update embedding sample to be more developer friendly

### DIFF
--- a/generative_ai/embedding.py
+++ b/generative_ai/embedding.py
@@ -16,13 +16,12 @@
 from vertexai.language_models import TextEmbeddingModel
 
 
-def text_embedding() -> list:
+def text_embedding(text: str = "What is life?") -> list:
     """Text embedding with a Large Language Model."""
     model = TextEmbeddingModel.from_pretrained("textembedding-gecko@001")
-    embeddings = model.get_embeddings(["What is life?"])
-    for embedding in embeddings:
-        vector = embedding.values
-        print(f"Length of Embedding Vector: {len(vector)}")
+    embeddings = model.get_embeddings([text])
+    vector = embeddings[0].values
+    print(f"Length of Embedding Vector: {len(vector)}")
     return vector
 
 


### PR DESCRIPTION
Note: I am a Googler on a different team that noticed this sample was slightly confusing when I tried to use it so putting this PR up as a potential improvement. 

As a developer wanting to copy/paste this sample into my workload I would expect it to take in an input string and then get the embedding for it? This is what the notebook example for this already does... https://github.com/GoogleCloudPlatform/vertex-ai-samples/blob/main/notebooks/official/generative_ai/text_embedding_new_api.ipynb