### PR TITLE
Update `generative-ai/function-calling` code sample to remove role from FunctionResponse

### DIFF
--- a/generative_ai/function_calling.py
+++ b/generative_ai/function_calling.py
@@ -85,7 +85,6 @@ def generate_function_call(prompt: str, project_id: str, location: str) -> tuple
             user_prompt_content,  # User prompt
             response_function_call_content,  # Function call response
             Content(
-                role="user",
                 parts=[
                     Part.from_function_response(
                         name="get_current_weather",


### PR DESCRIPTION
## Description

Fixes #11323 to remove the role from the `FunctionResponse` turn since Gemini does not validate the `role` field nor use the `role` field.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] ~~These samples need a new **API enabled** in testing projects to pass (let us know which ones)~~
- [ ] ~~These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)~~
- [ ] ~~This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample~~
- [ ] ~~This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample~~
- [X] Please **merge** this PR for me once it is approved