### PR TITLE
build: Add setuptools to Dockerfile

### DIFF
--- a/.kokoro/docker/Dockerfile
+++ b/.kokoro/docker/Dockerfile
@@ -171,9 +171,9 @@ RUN python3.10 -m pip
 RUN python3.11 -m pip
 RUN python3.12 -m pip
 
-# Install "virtualenv", since the vast majority of users of this image
-# will want it.
-RUN pip install --no-cache-dir virtualenv
+# Install "setuptools" for Python 3.12+ (see https://docs.python.org/3/whatsnew/3.12.html#distutils)
+# Install "virtualenv", since the vast majority of users of this image will want it.
+RUN pip install --no-cache-dir setuptools virtualenv
 
 # Setup Cloud SDK
 ENV CLOUD_SDK_VERSION 389.0.0


### PR DESCRIPTION
Python 3.12 removed distutils ([details](https://docs.python.org/3/whatsnew/3.12.html#distutils)).

As a result, several 3.12 sample tests are failing. Any time a dependency wheel is built (like `appengine/flexible_python37_and_earlier/scipy` [here](https://btx-internal.corp.google.com/invocations/09d254c0-1f60-4041-96fb-d0f9c9dcf6f0/targets/cloud-devrel%2Fpython-docs-samples%2Fpython3.12%2Fpresubmit/log)), we get an error.

The release note mentions distutils is still available through setuptools. This PR adds setuptools to the build image.