### PR TITLE
Don't pass the --setup_file option when a package is already installed in the custom image.

### DIFF
--- a/dataflow/flex-templates/pipeline_with_dependencies/Dockerfile
+++ b/dataflow/flex-templates/pipeline_with_dependencies/Dockerfile
@@ -59,13 +59,13 @@ RUN pip install -e .
 
 # For more informaiton, see: https://cloud.google.com/dataflow/docs/guides/templates/configuring-flex-templates
 ENV FLEX_TEMPLATE_PYTHON_PY_FILE="${WORKDIR}/main.py"
-ENV FLEX_TEMPLATE_PYTHON_SETUP_FILE="${WORKDIR}/setup.py"
 
-# To reduce pipeline submission time
-# do not use FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE directive here
-# to specify pipeline dependencies, because this image will be used
-# as custom sdk container image and it already installs the dependencies
-# from the requirements.txt.
+# Because this image will be used as custom sdk container image, and it already 
+# installs the dependencies from the requirements.txt, we can omit
+# the FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE directive here
+# to reduce pipeline submission time.
+# Similarly, since we already installed the pipeline package,
+# we don't have to specify the FLEX_TEMPLATE_PYTHON_SETUP_FILE="${WORKDIR}/setup.py" configuration option.
 
 # Optionally, verify that dependencies are not conflicting.
 # A conflict may or may not be significant for your pipeline.


### PR DESCRIPTION
## Description

Fixes https://stackoverflow.com/questions/78218949/how-to-pre-build-worker-container-dataflow-insights-sdk-worker-container-imag 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x ] Please **merge** this PR for me once it is approved