### PR TITLE
feat: add storagecontrol quickstart sample

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,6 +81,7 @@
 /firestore/**/*                        @GoogleCloudPlatform/cloud-native-db-dpes @GoogleCloudPlatform/python-samples-reviewers
 # ---* Cloud Storage
 /storage/**/*                          @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers
+/storagecontrol/**/*                   @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers
 /storagetransfer/**/*                  @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers
 # ---* Infra DB
 /cloud-sql/**/*                        @GoogleCloudPlatform/infra-db-sdk @GoogleCloudPlatform/python-samples-reviewers

--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -90,6 +90,8 @@ assign_issues_by:
       - GoogleCloudPlatform/api-spanner-python
   - labels:
       - "api: storage"
+      - "api: storagecontrol"
+      - "api: storagetransfer"
     to:
       - GoogleCloudPlatform/cloud-storage-dpes
   - labels:

--- a/storagecontrol/conftest.py
+++ b/storagecontrol/conftest.py
@@ -33,7 +33,7 @@ def bucket_name() -> str:
 @pytest.fixture(scope="function")
 def gcs_bucket(project_id: str, bucket_name: str) -> storage.Bucket:
     """
-    Yields and auto-cleans up a CGS bucket for use in Storage Control quickstart
+    Yields and auto-cleans up a GCS bucket for use in Storage Control quickstart
     """
 
     storage_client = storage.Client(project=project_id)

--- a/storagecontrol/conftest.py
+++ b/storagecontrol/conftest.py
@@ -1,0 +1,44 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import uuid
+
+from google.cloud import storage
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def project_id() -> str:
+    yield os.environ.get("BUILD_SPECIFIC_GCLOUD_PROJECT")
+
+
+@pytest.fixture(scope="function")
+def bucket_name() -> str:
+    yield f"storagecontrol-samples-{uuid.uuid4()}"
+
+
+@pytest.fixture(scope="function")
+def gcs_bucket(project_id: str, bucket_name: str) -> storage.Bucket:
+    """
+    Yields and auto-cleans up a CGS bucket for use in Storage Control quickstart
+    """
+
+    storage_client = storage.Client(project=project_id)
+    bucket = storage_client.create_bucket(bucket_name)
+
+    yield bucket
+
+    bucket.delete(force=True)

--- a/storagecontrol/noxfile_config.py
+++ b/storagecontrol/noxfile_config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/storagecontrol/noxfile_config.py
+++ b/storagecontrol/noxfile_config.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default TEST_CONFIG_OVERRIDE for python repos.
+
+# You can copy this file into your directory, then it will be imported from
+# the noxfile.py.
+
+# The source of truth:
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/noxfile_config.py
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    # Old samples are opted out of enforcing Python type hints
+    # All new samples should feature them
+    "enforce_type_hints": True,
+    # An envvar key for determining the project id to use. Change it
+    # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
+    # build specific Cloud project. You can also use your own string
+    # to use your own Cloud project.
+    "gcloud_project_env": "BUILD_SPECIFIC_GCLOUD_PROJECT",
+    # If you need to use a specific version of pip,
+    # change pip_version_override to the string representation
+    # of the version number, for example, "20.2.4"
+    "pip_version_override": None,
+    # A dictionary you want to inject into your test. Don't put any
+    # secrets here. These values will override predefined values.
+    "envs": {},
+}

--- a/storagecontrol/quickstart.py
+++ b/storagecontrol/quickstart.py
@@ -1,0 +1,42 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_quickstart_sample]
+from google.cloud import storage_control_v2
+
+
+def storage_control_quickstart(bucket_name: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-bucket-name"
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+    # The storage layout path uses the global access pattern, in which
+    # the “_” denotes this bucket exists in the global namespace.
+    layout_path = storage_control_v2.StorageControlClient.storage_layout_path(
+        project="_", bucket=bucket_name
+    )
+    request = storage_control_v2.GetStorageLayoutRequest(
+        name=layout_path,
+    )
+    response = storage_control_client.get_storage_layout(request=request)
+
+    print(f"Performed get_storage_layout request for {response.name}")
+
+    # [END storage_control_quickstart_sample]
+
+
+if __name__ == "__main__":
+    storage_control_quickstart(bucket_name=sys.argv[1])

--- a/storagecontrol/quickstart_test.py
+++ b/storagecontrol/quickstart_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.cloud.storage import Bucket
+from google.cloud import storage
 
 import pytest
 
@@ -20,7 +20,7 @@ import quickstart
 
 
 def test_storage_control_quickstart(
-    capsys: pytest.LogCaptureFixture, gcs_bucket: Bucket
+    capsys: pytest.LogCaptureFixture, gcs_bucket: storage.Bucket
 ) -> None:
     bucket_name = gcs_bucket.name
     quickstart.storage_control_quickstart(bucket_name=bucket_name)

--- a/storagecontrol/quickstart_test.py
+++ b/storagecontrol/quickstart_test.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.cloud.storage import Bucket
+
+import pytest
+
+import quickstart
+
+
+def test_storage_control_quickstart(
+    capsys: pytest.LogCaptureFixture, gcs_bucket: Bucket
+) -> None:
+    bucket_name = gcs_bucket.name
+    quickstart.storage_control_quickstart(bucket_name=bucket_name)
+
+    out, _ = capsys.readouterr()
+    layout_name = f"projects/_/buckets/{bucket_name}/storageLayout"
+    assert layout_name in out

--- a/storagecontrol/requirements-test.txt
+++ b/storagecontrol/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest==6.2.4
+google-cloud-storage==2.16.0

--- a/storagecontrol/requirements.txt
+++ b/storagecontrol/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-storage-control==0.1.0


### PR DESCRIPTION
This adds a quickstart sample for the StorageControl API gapic library
## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [x] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved