### PR TITLE
fix: include setuptools for 3.12 tests

### DIFF
--- a/appengine/flexible/numpy/requirements-test.txt
+++ b/appengine/flexible/numpy/requirements-test.txt
@@ -1,1 +1,2 @@
-pytest==7.0.1
+pytest==8.1.1
+setuptools==69.2.0

--- a/appengine/flexible/scipy/requirements-test.txt
+++ b/appengine/flexible/scipy/requirements-test.txt
@@ -1,1 +1,2 @@
-pytest==7.0.1
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/custom-containers/miniconda/requirements-test.txt
+++ b/dataflow/custom-containers/miniconda/requirements-test.txt
@@ -1,4 +1,5 @@
-google-api-python-client==2.87.0
-google-cloud-storage==2.9.0
-pytest-xdist==3.3.0
-pytest==6.2.4
+google-api-python-client==2.125.0
+google-cloud-storage==2.16.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/custom-containers/minimal/requirements-test.txt
+++ b/dataflow/custom-containers/minimal/requirements-test.txt
@@ -1,4 +1,5 @@
-google-api-python-client==2.87.0
-google-cloud-storage==2.9.0
-pytest-xdist==3.3.0
-pytest==7.0.1
+google-api-python-client==2.125.0
+google-cloud-storage==2.16.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/custom-containers/ubuntu/requirements-test.txt
+++ b/dataflow/custom-containers/ubuntu/requirements-test.txt
@@ -1,4 +1,5 @@
-google-api-python-client==2.87.0
-google-cloud-storage==2.9.0
-pytest-xdist==3.3.0
-pytest==7.0.1
+google-api-python-client==2.125.0
+google-cloud-storage==2.16.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/extensible-templates/requirements-test.txt
+++ b/dataflow/extensible-templates/requirements-test.txt
@@ -1,6 +1,7 @@
-google-api-python-client==2.87.0
-google-cloud-bigquery==3.11.4
-google-cloud-storage==2.9.0
-pytest-xdist==3.3.0
-pytest==7.0.1
-pyyaml==6.0
+google-api-python-client==2.125.0
+google-cloud-bigquery==3.20.1
+google-cloud-storage==2.16.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+pyyaml==6.0.1
+setuptools==69.2.0

--- a/dataflow/gpu-examples/pytorch-minimal/requirements-test.txt
+++ b/dataflow/gpu-examples/pytorch-minimal/requirements-test.txt
@@ -1,4 +1,5 @@
-google-api-python-client==2.87.0
-google-cloud-storage==2.9.0
-pytest-xdist==3.3.0
-pytest==7.0.1
+google-api-python-client==2.125.0
+google-cloud-storage==2.16.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/requirements-test.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/requirements-test.txt
@@ -1,3 +1,4 @@
-google-api-python-client==2.87.0
-google-cloud-storage==2.9.0
-pytest==7.3.1
+google-api-python-client==2.125.0
+google-cloud-storage==2.16.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/gpu-examples/tensorflow-landsat/requirements-test.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat/requirements-test.txt
@@ -1,3 +1,4 @@
-google-api-python-client==2.87.0
-google-cloud-storage==2.9.0
-pytest==7.3.1
+google-api-python-client==2.125.0
+google-cloud-storage==2.16.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/gpu-examples/tensorflow-minimal/requirements-test.txt
+++ b/dataflow/gpu-examples/tensorflow-minimal/requirements-test.txt
@@ -1,3 +1,4 @@
-google-api-python-client==2.87.0
-google-cloud-storage==2.9.0
-pytest==7.3.1
+google-api-python-client==2.125.0
+google-cloud-storage==2.16.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/dataflow/gpu-examples/tensorflow-minimal/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-minimal/requirements.txt
@@ -1,2 +1,2 @@
-apache-beam[gcp]==2.46.0
-tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu
+apache-beam[gcp]==2.55.0
+tensorflow==2.16.1  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu

--- a/datastore/cloud-ndb/requirements-test.txt
+++ b/datastore/cloud-ndb/requirements-test.txt
@@ -1,3 +1,2 @@
-backoff==2.2.1; python_version < "3.7"
-backoff==2.2.1; python_version >= "3.7"
-pytest==7.0.1
+backoff==2.2.1
+setuptools==69.2.0

--- a/dialogflow/requirements-test.txt
+++ b/dialogflow/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==7.2.1
-flaky==3.7.0
+flaky==3.8.1
+pytest==8.1.1
+setuptools==69.2.0

--- a/dns/api/requirements-test.txt
+++ b/dns/api/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==7.0.1
-flaky==3.7.0
+flaky==3.8.1
+pytest==8.1.1
+setuptools==69.2.0

--- a/endpoints/getting-started/requirements-test.txt
+++ b/endpoints/getting-started/requirements-test.txt
@@ -1,1 +1,2 @@
-pytest==7.0.1
+pytest==8.1.1
+setuptools==69.2.0

--- a/language/snippets/classify_text/requirements-test.txt
+++ b/language/snippets/classify_text/requirements-test.txt
@@ -1,1 +1,2 @@
-pytest==7.2.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/ml_engine/online_prediction/requirements-test.txt
+++ b/ml_engine/online_prediction/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==7.0.1
-flaky==3.7.0
+pytest==8.1.1
+flaky==3.8.1
+setuptools==69.2.0

--- a/ml_engine/online_prediction/requirements.txt
+++ b/ml_engine/online_prediction/requirements.txt
@@ -1,5 +1,4 @@
-tensorflow==2.12.0; python_version > "3.7"
-tensorflow==2.7.4; python_version <= "3.7"
-google-api-python-client==2.87.0
-google-auth==2.19.1
-google-auth-httplib2==0.1.0
+tensorflow==2.16.1
+google-api-python-client==2.125.0
+google-auth==2.29.0
+google-auth-httplib2==0.2.0

--- a/people-and-planet-ai/geospatial-classification/requirements-test.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements-test.txt
@@ -1,2 +1,3 @@
-pytest==7.3.1
-pytest-xdist==3.3.0
+pytest==8.1.1
+pytest-xdist==3.5.0
+setuptools==69.2.0

--- a/people-and-planet-ai/geospatial-classification/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements.txt
@@ -1,5 +1,5 @@
-earthengine-api==0.1.358
-folium==0.14.0
-google-cloud-aiplatform==1.25.0
-pandas==2.0.1
-tensorflow==2.12.0
+earthengine-api==0.1.397
+folium==0.16.0
+google-cloud-aiplatform==1.46.0
+pandas==2.2.1
+tensorflow==2.16.1

--- a/people-and-planet-ai/image-classification/requirements-test.txt
+++ b/people-and-planet-ai/image-classification/requirements-test.txt
@@ -1,3 +1,4 @@
-google-cloud-storage==2.9.0
-pytest-xdist==3.3.0
-pytest==7.2.2
+google-cloud-storage==2.16.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/people-and-planet-ai/image-classification/requirements.txt
+++ b/people-and-planet-ai/image-classification/requirements.txt
@@ -1,5 +1,4 @@
 pillow==9.5.0; python_version < '3.8'
-pillow==10.0.1; python_version >= '3.8'
-apache-beam[gcp]==2.46.0
-google-cloud-aiplatform==1.25.0
-google-cloud-bigquery==3.11.4 # Indirect dependency, but there is a version conflict that causes pip to hang unless we constraint this.
+pillow==10.3.0; python_version >= '3.8'
+apache-beam[gcp]==2.55.0
+google-cloud-aiplatform==1.46.0

--- a/people-and-planet-ai/land-cover-classification/requirements-test.txt
+++ b/people-and-planet-ai/land-cover-classification/requirements-test.txt
@@ -1,7 +1,8 @@
 # Requirements to run tests.
-apache-beam[interactive]==2.46.0
-importnb==2023.1.7
-ipykernel==6.23.3
-nbclient==0.8.0
-pytest-xdist==3.3.0
-pytest==7.2.2
+apache-beam[interactive]==2.55.0
+importnb==2023.11.1
+ipykernel==6.29.4
+nbclient==0.10.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/people-and-planet-ai/land-cover-classification/requirements.txt
+++ b/people-and-planet-ai/land-cover-classification/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements to run the notebooks.
-apache-beam[gcp]==2.46.0
-earthengine-api==0.1.358
-folium==0.14.0
-google-cloud-aiplatform==1.25.0
-imageio==2.29.0
-plotly==5.15.0
-tensorflow==2.12.0
+apache-beam[gcp]==2.55.0
+earthengine-api==0.1.397
+folium==0.16.0
+google-cloud-aiplatform==1.46.0
+imageio==2.34.0
+plotly==5.20.0
+tensorflow==2.16.1

--- a/people-and-planet-ai/timeseries-classification/requirements-test.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements-test.txt
@@ -1,3 +1,4 @@
-google-api-python-client==2.87.0
-pytest-xdist==3.3.0
-pytest==7.3.1
+google-api-python-client==2.125.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/people-and-planet-ai/timeseries-classification/requirements.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements.txt
@@ -1,7 +1,7 @@
-Flask==3.0.0
-apache-beam[gcp]==2.46.0
-google-cloud-aiplatform==1.25.0
-gunicorn==20.1.0
-pandas==2.0.1
-tensorflow==2.12.0
-Werkzeug==3.0.1
+Flask==3.0.2
+apache-beam[gcp]==2.55.0
+google-cloud-aiplatform==1.46.0
+gunicorn==21.2.0
+pandas==2.2.1
+tensorflow==2.16.1
+Werkzeug==3.0.2

--- a/people-and-planet-ai/weather-forecasting/serving/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/serving/requirements.txt
@@ -1,6 +1,6 @@
-Flask==3.0.0
-gunicorn==20.1.0
-Werkzeug==3.0.1
+Flask==3.0.2
+gunicorn==21.2.0
+Werkzeug==3.0.2
 
 # Local packages.
 ./weather-data

--- a/people-and-planet-ai/weather-forecasting/tests/dataset_tests/requirements-test.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/dataset_tests/requirements-test.txt
@@ -1,4 +1,5 @@
-ipykernel==6.23.3
-nbclient==0.8.0
-pytest-xdist==3.3.0
-pytest==7.2.0
+ipykernel==6.29.4
+nbclient==0.10.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/people-and-planet-ai/weather-forecasting/tests/dataset_tests/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/dataset_tests/requirements.txt
@@ -1,4 +1,4 @@
 ../../serving/weather-data
-apache-beam[gcp,interactive]==2.43.0
-build==0.10.0
-plotly==5.15.0
+apache-beam[gcp,interactive]==2.55.0
+build==1.2.1
+plotly==5.20.0

--- a/people-and-planet-ai/weather-forecasting/tests/overview_tests/requirements-test.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/overview_tests/requirements-test.txt
@@ -1,4 +1,5 @@
-ipykernel==6.23.3
-nbclient==0.8.0
-pytest-xdist==3.3.0
-pytest==7.2.0
+ipykernel==6.29.4
+nbclient==0.10.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/people-and-planet-ai/weather-forecasting/tests/overview_tests/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/overview_tests/requirements.txt
@@ -1,2 +1,2 @@
 ../../serving/weather-data
-folium==0.14.0
+folium==0.16.0

--- a/people-and-planet-ai/weather-forecasting/tests/predictions_tests/requirements-test.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/predictions_tests/requirements-test.txt
@@ -1,4 +1,5 @@
-ipykernel==6.23.3
-nbclient==0.8.0
-pytest-xdist==3.3.0
-pytest==7.2.0
+ipykernel==6.29.4
+nbclient==0.10.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/people-and-planet-ai/weather-forecasting/tests/predictions_tests/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/predictions_tests/requirements.txt
@@ -1,3 +1,3 @@
 ../../serving/weather-data
 ../../serving/weather-model
-plotly==5.15.0
+plotly==5.20.0

--- a/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements-test.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements-test.txt
@@ -1,5 +1,6 @@
 ../../serving/weather-data
-ipykernel==6.23.3
-nbclient==0.8.0
-pytest-xdist==3.3.0
-pytest==7.2.0
+ipykernel==6.29.4
+nbclient==0.10.0
+pytest-xdist==3.5.0
+pytest==8.1.1
+setuptools==69.2.0

--- a/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
@@ -1,3 +1,3 @@
 ../../serving/weather-model
-build==0.10.0
-google-cloud-aiplatform==1.25.0
+build==1.2.1
+google-cloud-aiplatform==1.46.0

--- a/pubsub/streaming-analytics/requirements-test.txt
+++ b/pubsub/streaming-analytics/requirements-test.txt
@@ -1,1 +1,2 @@
-pytest==7.0.1
+pytest==8.1.1
+setuptools==69.2.0

--- a/pubsub/streaming-analytics/requirements.txt
+++ b/pubsub/streaming-analytics/requirements.txt
@@ -1,1 +1,1 @@
-apache-beam[gcp,test]==2.42.0
+apache-beam[gcp,test]==2.55.0

--- a/service_extensions/callouts/add_header/requirements-test.txt
+++ b/service_extensions/callouts/add_header/requirements-test.txt
@@ -1,1 +1,2 @@
-pytest==7.4.2
+pytest==8.1.1
+setuptools==69.2.0

--- a/service_extensions/callouts/add_header/requirements.txt
+++ b/service_extensions/callouts/add_header/requirements.txt
@@ -1,2 +1,2 @@
-grpcio==1.59.0
-grpcio-tools==1.59.0
+grpcio==1.62.1
+grpcio-tools==1.62.1

--- a/trace/trace-python-sample-opentelemetry/requirements-test.txt
+++ b/trace/trace-python-sample-opentelemetry/requirements-test.txt
@@ -1,1 +1,2 @@
-pytest==7.0.1
+pytest==8.1.1
+setuptools==69.2.0


### PR DESCRIPTION
distutils was [removed](https://docs.python.org/3/whatsnew/3.12.html#distutils) in the 3.12 release. Some sample tests are failing due to missing this dependency.