### PR TITLE
nitpick: Update documentation and naming in read_table_list function

### DIFF
--- a/composer/workflows/bq_copy_across_locations.py
+++ b/composer/workflows/bq_copy_across_locations.py
@@ -93,7 +93,7 @@ def read_table_list(table_list_file):
     the DAG dynamically.
     :param table_list_file: (String) The file location of the table list file,
     e.g. '/home/airflow/framework/table_list.csv'
-    :return table_list: (List) List of tuples containing the source and
+    :return table_list: (List) List of dictionaries containing the source and
     target tables.
     """
     table_list = []
@@ -104,8 +104,8 @@ def read_table_list(table_list_file):
             next(csv_reader)  # skip the headers
             for row in csv_reader:
                 logger.info(row)
-                table_tuple = {"table_source": row[0], "table_dest": row[1]}
-                table_list.append(table_tuple)
+                table_locations = {"table_source": row[0], "table_dest": row[1]}
+                table_list.append(table_locations)
             return table_list
     except OSError as e:
         logger.error("Error opening table_list_file %s: " % str(table_list_file), e)


### PR DESCRIPTION
Correct the documentation of the function to correctly specify its return value, and update a locally scoped variable to not refer to its type but instead its semantic meaning.

## Description

Fixes #11427 

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved