### PR TITLE
[issue-9643 fix] added ttl to secrets tests and samples

### DIFF
--- a/secretmanager/snippets/create_secret.py
+++ b/secretmanager/snippets/create_secret.py
@@ -47,7 +47,7 @@ def create_secret(
         new_secret = create_secret("my-project", "my-new-secret")
 
         # Create a secret with a TTL of 30 days
-        new_secret_with_ttl = create_secret("my-project", "my-timed-secret", "P30D")
+        new_secret_with_ttl = create_secret("my-project", "my-timed-secret", "7776000s")
     """
 
     # Import the Secret Manager client library.

--- a/secretmanager/snippets/create_secret.py
+++ b/secretmanager/snippets/create_secret.py
@@ -23,7 +23,9 @@ from google.cloud import secretmanager
 
 
 # [START secretmanager_create_secret]
-def create_secret(project_id: str, secret_id: str, ttl: Optional[str] = None) -> secretmanager.Secret:
+def create_secret(
+    project_id: str, secret_id: str, ttl: Optional[str] = None
+) -> secretmanager.Secret:
     """
     Create a new secret with the given name. A secret is a logical wrapper
     around a collection of secret versions. Secret versions hold the actual

--- a/secretmanager/snippets/create_secret.py
+++ b/secretmanager/snippets/create_secret.py
@@ -28,6 +28,24 @@ def create_secret(project_id: str, secret_id: str, ttl: Optional[str] = None) ->
     Create a new secret with the given name. A secret is a logical wrapper
     around a collection of secret versions. Secret versions hold the actual
     secret material.
+
+     Args:
+        project_id (str): The project ID where the secret is to be created.
+        secret_id (str): The ID to assign to the new secret. This ID must be unique within the project.
+        ttl (Optional[str]): An optional string that specifies the secret's time-to-live in seconds with
+                             format (e.g., "900s" for 15 minutes). If specified, the secret
+                             versions will be automatically deleted upon reaching the end of the TTL period.
+
+    Returns:
+        secretmanager.Secret: An object representing the newly created secret, containing details like the
+                              secret's name, replication settings, and optionally its TTL.
+
+    Example:
+        # Create a secret with automatic replication and no TTL
+        new_secret = create_secret("my-project", "my-new-secret")
+
+        # Create a secret with a TTL of 30 days
+        new_secret_with_ttl = create_secret("my-project", "my-timed-secret", "P30D")
     """
 
     # Import the Secret Manager client library.

--- a/secretmanager/snippets/create_secret.py
+++ b/secretmanager/snippets/create_secret.py
@@ -17,12 +17,13 @@ command line application and sample code for creating a new secret.
 """
 
 import argparse
+from typing import Optional
 
 from google.cloud import secretmanager
 
 
 # [START secretmanager_create_secret]
-def create_secret(project_id: str, secret_id: str) -> secretmanager.CreateSecretRequest:
+def create_secret(project_id: str, secret_id: str, ttl: Optional[str] = None) -> secretmanager.Secret:
     """
     Create a new secret with the given name. A secret is a logical wrapper
     around a collection of secret versions. Secret versions hold the actual
@@ -43,7 +44,7 @@ def create_secret(project_id: str, secret_id: str) -> secretmanager.CreateSecret
         request={
             "parent": parent,
             "secret_id": secret_id,
-            "secret": {"replication": {"automatic": {}}},
+            "secret": {"replication": {"automatic": {}}, "ttl": ttl},
         }
     )
 
@@ -60,6 +61,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("project_id", help="id of the GCP project")
     parser.add_argument("secret_id", help="id of the secret to create")
+    parser.add_argument("ttl", help="time to live for secrets, f.e. '600s' ")
     args = parser.parse_args()
 
-    create_secret(args.project_id, args.secret_id)
+    create_secret(args.project_id, args.secret_id, args.ttl)

--- a/secretmanager/snippets/create_secret_with_user_managed_replication.py
+++ b/secretmanager/snippets/create_secret_with_user_managed_replication.py
@@ -24,7 +24,7 @@ from google.cloud import secretmanager
 
 
 def create_ummr_secret(
-    project_id: str, secret_id: str, locations: typing.List[str]
+    project_id: str, secret_id: str, locations: typing.List[str], ttl: typing.Optional[str] = None
 ) -> secretmanager.CreateSecretRequest:
     """
     Create a new secret with the given name. A secret is a logical wrapper
@@ -49,7 +49,8 @@ def create_ummr_secret(
             "secret": {
                 "replication": {
                     "user_managed": {"replicas": [{"location": x} for x in locations]}
-                }
+                },
+                "ttl": ttl,
             },
         }
     )

--- a/secretmanager/snippets/create_secret_with_user_managed_replication.py
+++ b/secretmanager/snippets/create_secret_with_user_managed_replication.py
@@ -25,11 +25,36 @@ from google.cloud import secretmanager
 
 def create_ummr_secret(
     project_id: str, secret_id: str, locations: typing.List[str], ttl: typing.Optional[str] = None
-) -> secretmanager.CreateSecretRequest:
+) -> secretmanager.Secret:
     """
     Create a new secret with the given name. A secret is a logical wrapper
     around a collection of secret versions. Secret versions hold the actual
     secret material.
+
+    Args:
+        project_id (str): The project ID where the secret is to be created.
+        secret_id (str): The unique identifier for the new secret within the project.
+        locations (List[str]): A list of Google Cloud locations where the secret should be replicated.
+        ttl (Optional[str]): An optional string that specifies the secret's time-to-live in seconds with
+                             format (e.g., "900s" for 15 minutes). If specified, the secret versions will be
+                             automatically deleted upon reaching the end of the TTL period.
+
+    Returns:
+        secretmanager.Secret: An object representing the newly created secret. This object includes information like the
+                              secret's name and its replication configuration. If TTL is provided, it also configures how long
+                              secret versions remain before being automatically deleted.
+
+    Example:
+        # Create a secret with user-managed replication across two locations without TTL
+        new_secret = create_ummr_secret("my-project", "my-new-secret", ["us-east1", "europe-west1"])
+
+        # Create a secret with a TTL of 30 days and user-managed replication across three locations
+        new_secret_with_ttl = create_ummr_secret("my-project", "my-timed-secret", ["us-east1", "us-west1", "asia-east1"], "P30D")
+
+    Note:
+        This function requires that the `secretmanager` API is enabled on the cloud project and that the caller has the
+        necessary permissions to create secrets. Ensure that `secretmanager.SecretManagerServiceClient` and the `secretmanager`
+        library are correctly configured and authenticated. The specified locations must be valid Google Cloud locations.
     """
 
     # Import the Secret Manager client library.

--- a/secretmanager/snippets/create_secret_with_user_managed_replication.py
+++ b/secretmanager/snippets/create_secret_with_user_managed_replication.py
@@ -52,7 +52,7 @@ def create_ummr_secret(
         new_secret = create_ummr_secret("my-project", "my-new-secret", ["us-east1", "europe-west1"])
 
         # Create a secret with a TTL of 30 days and user-managed replication across three locations
-        new_secret_with_ttl = create_ummr_secret("my-project", "my-timed-secret", ["us-east1", "us-west1", "asia-east1"], "P30D")
+        new_secret_with_ttl = create_ummr_secret("my-project", "my-timed-secret", ["us-east1", "us-west1"], "7776000s")
 
     Note:
         This function requires that the `secretmanager` API is enabled on the cloud project and that the caller has the

--- a/secretmanager/snippets/create_secret_with_user_managed_replication.py
+++ b/secretmanager/snippets/create_secret_with_user_managed_replication.py
@@ -24,7 +24,10 @@ from google.cloud import secretmanager
 
 
 def create_ummr_secret(
-    project_id: str, secret_id: str, locations: typing.List[str], ttl: typing.Optional[str] = None
+    project_id: str,
+    secret_id: str,
+    locations: typing.List[str],
+    ttl: typing.Optional[str] = None,
 ) -> secretmanager.Secret:
     """
     Create a new secret with the given name. A secret is a logical wrapper

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -123,7 +123,10 @@ def secret_id(
 
 @pytest.fixture()
 def secret(
-    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str, ttl: Optional[str]
+    client: secretmanager.SecretManagerServiceClient,
+    project_id: str,
+    secret_id: str,
+    ttl: Optional[str],
 ) -> Iterator[Tuple[str, str, str]]:
     print(f"creating secret {secret_id}")
 
@@ -193,14 +196,20 @@ def test_add_secret_version(secret: Tuple[str, str, str]) -> None:
 
 
 def test_create_secret(
-    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str, ttl: Optional[str]
+    client: secretmanager.SecretManagerServiceClient,
+    project_id: str,
+    secret_id: str,
+    ttl: Optional[str],
 ) -> None:
     secret = create_secret(project_id, secret_id, ttl)
     assert secret_id in secret.name
 
 
 def test_create_secret_with_user_managed_replication(
-    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str, ttl: Optional[str]
+    client: secretmanager.SecretManagerServiceClient,
+    project_id: str,
+    secret_id: str,
+    ttl: Optional[str],
 ) -> None:
     locations = ["us-east1", "us-east4", "us-west1"]
     secret = create_ummr_secret(project_id, secret_id, locations, ttl)

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -63,6 +63,11 @@ def iam_user() -> str:
     return "serviceAccount:" + os.environ["GCLOUD_SECRETS_SERVICE_ACCOUNT"]
 
 
+@pytest.fixture()
+def ttl() -> Optional[str]:
+    return "300s"
+
+
 @retry.Retry()
 def retry_client_create_secret(
     client: secretmanager.SecretManagerServiceClient,
@@ -118,7 +123,7 @@ def secret_id(
 
 @pytest.fixture()
 def secret(
-    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str
+    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str, ttl: Optional[str]
 ) -> Iterator[Tuple[str, str, str]]:
     print(f"creating secret {secret_id}")
 
@@ -129,7 +134,7 @@ def secret(
         request={
             "parent": parent,
             "secret_id": secret_id,
-            "secret": {"replication": {"automatic": {}}},
+            "secret": {"replication": {"automatic": {}}, "ttl": ttl},
         },
     )
 
@@ -188,17 +193,17 @@ def test_add_secret_version(secret: Tuple[str, str, str]) -> None:
 
 
 def test_create_secret(
-    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str
+    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str, ttl: Optional[str]
 ) -> None:
-    secret = create_secret(project_id, secret_id)
+    secret = create_secret(project_id, secret_id, ttl)
     assert secret_id in secret.name
 
 
 def test_create_secret_with_user_managed_replication(
-    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str
+    client: secretmanager.SecretManagerServiceClient, project_id: str, secret_id: str, ttl: Optional[str]
 ) -> None:
     locations = ["us-east1", "us-east4", "us-west1"]
-    secret = create_ummr_secret(project_id, secret_id, locations)
+    secret = create_ummr_secret(project_id, secret_id, locations, ttl)
     assert secret_id in secret.name
 
 


### PR DESCRIPTION
## Description

Fixes #9643

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved