### PR TITLE
tests: Skip Document AI Warehouse Tests due to deprecation/failures

### DIFF
--- a/contentwarehouse/snippets/create_folder_link_document_sample_test.py
+++ b/contentwarehouse/snippets/create_folder_link_document_sample_test.py
@@ -24,6 +24,9 @@ location = "us"  # Format is 'us' or 'eu'
 user_id = "user:xxxx@example.com"  # Format is "user:xxxx@example.com"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_create_folder_link_document(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     create_folder_link_document_sample.create_folder_link_document(

--- a/contentwarehouse/snippets/create_get_delete_document_schema_test.py
+++ b/contentwarehouse/snippets/create_get_delete_document_schema_test.py
@@ -26,6 +26,9 @@ project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
 location = "us"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="create")
 def test_create_document_schema(request: pytest.fixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
@@ -41,6 +44,9 @@ def test_create_document_schema(request: pytest.fixture) -> None:
     request.config.cache.set("document_schema_id", document_schema_id)
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="get", depends=["create"])
 def test_get_document_schema(request: pytest.fixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
@@ -56,6 +62,9 @@ def test_get_document_schema(request: pytest.fixture) -> None:
     assert "display_name" in response
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="delete", depends=["get"])
 def test_delete_document_schema(request: pytest.fixture) -> None:
     project_number = test_utilities.get_project_number(project_id)

--- a/contentwarehouse/snippets/create_get_update_delete_document_test.py
+++ b/contentwarehouse/snippets/create_get_update_delete_document_test.py
@@ -37,6 +37,9 @@ user_id = os.environ["user_id"]
 reference_id = "001"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="create_schema")
 def test_create_document_schema(request: pytest.fixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
@@ -52,6 +55,9 @@ def test_create_document_schema(request: pytest.fixture) -> None:
     request.config.cache.set("document_schema_id", document_schema_id)
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="create_doc", depends=["create_schema"])
 def test_create_document(request: pytest.fixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
@@ -73,6 +79,9 @@ def test_create_document(request: pytest.fixture) -> None:
     request.config.cache.set("document_name", response.document.name)
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="get_doc", depends=["create_doc"])
 def test_get_document(request: pytest.fixture) -> None:
     document_name = request.config.cache.get("document_name", None)
@@ -92,6 +101,9 @@ def test_get_document(request: pytest.fixture) -> None:
     )
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="update_doc", depends=["get_doc"])
 def test_update_document(request: pytest.fixture) -> None:
     document_name = request.config.cache.get("document_name", None)
@@ -108,6 +120,9 @@ def test_update_document(request: pytest.fixture) -> None:
     assert "document" in response
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="delete_doc", depends=["update_doc"])
 def test_delete_document(request: pytest.fixture) -> None:
     document_name = request.config.cache.get("document_name", None)
@@ -119,6 +134,9 @@ def test_delete_document(request: pytest.fixture) -> None:
     assert response is None
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 @pytest.mark.dependency(name="delete_schema", depends=["delete_doc"])
 def test_delete_document_schema(request: pytest.fixture) -> None:
     project_number = test_utilities.get_project_number(project_id)

--- a/contentwarehouse/snippets/create_rule_set_sample_test.py
+++ b/contentwarehouse/snippets/create_rule_set_sample_test.py
@@ -23,6 +23,9 @@ project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
 location = "us"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_create_rule_set(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     create_rule_set_sample.create_rule_set(

--- a/contentwarehouse/snippets/fetch_acl_sample_test.py
+++ b/contentwarehouse/snippets/fetch_acl_sample_test.py
@@ -28,6 +28,9 @@ document_id = "2bq3m8uih3j78"
 user_id = "user:xxxx@example.com"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_fetch_project_acl(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     # TODO: Update when test project issue is resolved.
@@ -38,6 +41,9 @@ def test_fetch_project_acl(capsys: pytest.CaptureFixture) -> None:
         out, _ = capsys.readouterr()
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_fetch_document_acl(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     # Project can only support Document or Project ACLs

--- a/contentwarehouse/snippets/list_document_schema_test.py
+++ b/contentwarehouse/snippets/list_document_schema_test.py
@@ -23,6 +23,9 @@ project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
 location = "us"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_list_document_schemas() -> None:
     project_number = test_utilities.get_project_number(project_id)
 

--- a/contentwarehouse/snippets/list_document_schema_test.py
+++ b/contentwarehouse/snippets/list_document_schema_test.py
@@ -18,6 +18,7 @@ import os
 from contentwarehouse.snippets import list_document_schema_sample
 from contentwarehouse.snippets import test_utilities
 
+import pytest
 
 project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
 location = "us"

--- a/contentwarehouse/snippets/noxfile_config.py
+++ b/contentwarehouse/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6", "3.8", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.8", "3.9", "3.10", "3.11", "3.12"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/contentwarehouse/snippets/quickstart_sample_test.py
+++ b/contentwarehouse/snippets/quickstart_sample_test.py
@@ -24,6 +24,9 @@ location = "us"  # Format is 'us' or 'eu'
 user_id = "user:xxxx@example.com"  # Format is "user:xxxx@example.com"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_quickstart(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     quickstart_sample.quickstart(

--- a/contentwarehouse/snippets/search_documents_sample_test.py
+++ b/contentwarehouse/snippets/search_documents_sample_test.py
@@ -25,6 +25,9 @@ document_query_text = "document"
 user_id = "user:xxxx@example.com"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_search_documents(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     search_documents_sample.search_documents_sample(

--- a/contentwarehouse/snippets/set_acl_sample_test.py
+++ b/contentwarehouse/snippets/set_acl_sample_test.py
@@ -36,6 +36,9 @@ policy = {
 }
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_set_project_acl(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     # TODO(https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9821)
@@ -51,6 +54,9 @@ def test_set_project_acl(capsys: pytest.CaptureFixture) -> None:
         capsys.readouterr()
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_set_document_acl(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     # TODO(https://github.com/GoogleCloudPlatform/python-docs-samples/issues/9821)

--- a/contentwarehouse/snippets/update_document_schema_sample_test.py
+++ b/contentwarehouse/snippets/update_document_schema_sample_test.py
@@ -24,6 +24,9 @@ location = "us"
 document_schema_id = "0gc5eijqsb18g"
 
 
+@pytest.mark.skip(
+    "Document AI Warehouse is deprecated and will no longer be available on Google Cloud after January 16, 2025."
+)
 def test_update_document_schema_sample(capsys: pytest.CaptureFixture) -> None:
     project_number = test_utilities.get_project_number(project_id)
     update_document_schema_sample.update_document_schema(


### PR DESCRIPTION
## Description

Remove tests due to Document AI Warehouse Deprecation

https://cloud.google.com/document-warehouse/docs/release-notes