### PR TITLE
fix(healthcare): don't store DICOM instance for each DICOMweb test

### DIFF
--- a/healthcare/api-client/v1/dicom/dicomweb.py
+++ b/healthcare/api-client/v1/dicom/dicomweb.py
@@ -29,18 +29,15 @@ def dicomweb_store_instance(project_id, location, dataset_id, dicom_store_id, dc
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Imports a module to allow authentication using Application Default Credentials (ADC)
+    import google.auth
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    # Gets credentials from the environment. google.auth.default() returns credentials and the
+    # associated project ID, but in this sample, the project ID is passed in manually.
+    credentials, _ = google.auth.default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
@@ -85,18 +82,15 @@ def dicomweb_search_instance(project_id, location, dataset_id, dicom_store_id):
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Imports a module to allow authentication using Application Default Credentials (ADC)
+    import google.auth
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    # Gets credentials from the environment. google.auth.default() returns credentials and the
+    # associated project ID, but in this sample, the project ID is passed in manually.
+    credentials, _ = google.auth.default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
@@ -143,18 +137,15 @@ def dicomweb_retrieve_study(
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Imports a module to allow authentication using Application Default Credentials (ADC)
+    import google.auth
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    # Gets credentials from the environment. google.auth.default() returns credentials and the
+    # associated project ID, but in this sample, the project ID is passed in manually.
+    credentials, _ = google.auth.default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
@@ -202,18 +193,15 @@ def dicomweb_search_studies(project_id, location, dataset_id, dicom_store_id):
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Imports a module to allow authentication using Application Default Credentials (ADC)
+    import google.auth
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    # Gets credentials from the environment. google.auth.default() returns credentials and the
+    # associated project ID, but in this sample, the project ID is passed in manually.
+    credentials, _ = google.auth.default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
@@ -271,18 +259,15 @@ def dicomweb_retrieve_instance(
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Imports a module to allow authentication using Application Default Credentials (ADC)
+    import google.auth
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    # Gets credentials from the environment. google.auth.default() returns credentials and the
+    # associated project ID, but in this sample, the project ID is passed in manually.
+    credentials, _ = google.auth.default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
@@ -346,18 +331,15 @@ def dicomweb_retrieve_rendered(
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Imports a module to allow authentication using Application Default Credentials (ADC)
+    import google.auth
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    # Gets credentials from the environment. google.auth.default() returns credentials and the
+    # associated project ID, but in this sample, the project ID is passed in manually.
+    credentials, _ = google.auth.default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"
@@ -414,18 +396,15 @@ def dicomweb_delete_study(project_id, location, dataset_id, dicom_store_id, stud
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
 
-    # Imports a module to allow authentication using a service account
-    from google.oauth2 import service_account
+    # Imports a module to allow authentication using Application Default Credentials (ADC)
+    import google.auth
 
-    # Gets credentials from the environment.
-    credentials = service_account.Credentials.from_service_account_file(
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
-    )
-    scoped_credentials = credentials.with_scopes(
-        ["https://www.googleapis.com/auth/cloud-platform"]
-    )
+    # Gets credentials from the environment. google.auth.default() returns credentials and the
+    # associated project ID, but in this sample, the project ID is passed in manually.
+    credentials, _ = google.auth.default()
+
     # Creates a requests Session object with the credentials.
-    session = requests.AuthorizedSession(scoped_credentials)
+    session = requests.AuthorizedSession(credentials)
 
     # URL to the Cloud Healthcare API endpoint and version
     base_url = "https://healthcare.googleapis.com/v1"

--- a/healthcare/api-client/v1/dicom/dicomweb.py
+++ b/healthcare/api-client/v1/dicom/dicomweb.py
@@ -23,8 +23,6 @@ def dicomweb_store_instance(project_id, location, dataset_id, dicom_store_id, dc
 
     See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/dicom
     before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
@@ -76,8 +74,6 @@ def dicomweb_search_instance(project_id, location, dataset_id, dicom_store_id):
 
     See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/dicom
     before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
@@ -131,8 +127,6 @@ def dicomweb_retrieve_study(
 
     See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/dicom
     before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
@@ -187,8 +181,6 @@ def dicomweb_search_studies(project_id, location, dataset_id, dicom_store_id):
 
     See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/dicom
     before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
@@ -253,8 +245,6 @@ def dicomweb_retrieve_instance(
 
     See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/dicom
     before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
@@ -325,8 +315,6 @@ def dicomweb_retrieve_rendered(
 
     See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/dicom
     before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests
@@ -390,8 +378,6 @@ def dicomweb_delete_study(project_id, location, dataset_id, dicom_store_id, stud
 
     See https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/healthcare/api-client/v1/dicom
     before running the sample."""
-    # Imports Python's built-in "os" module
-    import os
 
     # Imports the google.auth.transport.requests transport
     from google.auth.transport import requests

--- a/healthcare/api-client/v1/dicom/dicomweb_test.py
+++ b/healthcare/api-client/v1/dicom/dicomweb_test.py
@@ -140,10 +140,6 @@ def test_dicomweb_store_instance(test_dataset, test_dicom_store, capsys):
 
 
 def test_dicomweb_search_instance_studies(test_dataset, test_dicom_store, capsys):
-    dicomweb.dicomweb_store_instance(
-        project_id, location, dataset_id, dicom_store_id, dcm_file
-    )
-
     dicomweb.dicomweb_search_instance(project_id, location, dataset_id, dicom_store_id)
 
     dicomweb.dicomweb_search_studies(project_id, location, dataset_id, dicom_store_id)
@@ -158,10 +154,6 @@ def test_dicomweb_search_instance_studies(test_dataset, test_dicom_store, capsys
 
 def test_dicomweb_retrieve_study(test_dataset, test_dicom_store, capsys):
     try:
-        dicomweb.dicomweb_store_instance(
-            project_id, location, dataset_id, dicom_store_id, dcm_file
-        )
-
         dicomweb.dicomweb_retrieve_study(
             project_id, location, dataset_id, dicom_store_id, study_uid
         )
@@ -181,10 +173,6 @@ def test_dicomweb_retrieve_study(test_dataset, test_dicom_store, capsys):
 
 def test_dicomweb_retrieve_instance(test_dataset, test_dicom_store, capsys):
     try:
-        dicomweb.dicomweb_store_instance(
-            project_id, location, dataset_id, dicom_store_id, dcm_file
-        )
-
         dicomweb.dicomweb_retrieve_instance(
             project_id,
             location,
@@ -210,10 +198,6 @@ def test_dicomweb_retrieve_instance(test_dataset, test_dicom_store, capsys):
 
 def test_dicomweb_retrieve_rendered(test_dataset, test_dicom_store, capsys):
     try:
-        dicomweb.dicomweb_store_instance(
-            project_id, location, dataset_id, dicom_store_id, dcm_file
-        )
-
         dicomweb.dicomweb_retrieve_rendered(
             project_id,
             location,
@@ -238,10 +222,6 @@ def test_dicomweb_retrieve_rendered(test_dataset, test_dicom_store, capsys):
 
 
 def test_dicomweb_delete_study(test_dataset, test_dicom_store, capsys):
-    dicomweb.dicomweb_store_instance(
-        project_id, location, dataset_id, dicom_store_id, dcm_file
-    )
-
     dicomweb.dicomweb_delete_study(
         project_id, location, dataset_id, dicom_store_id, study_uid
     )


### PR DESCRIPTION
## Description

Only store DICOM instance once for all DICOMweb tests. Previously, storing a duplicate instance returned a 200, but it now returns a 409, causing tests to fail.

Also update auth to use ADC, remove unnecessary credentials scope, and fix lint issue.

Fixes:

* #11331
* #11322
* #11319

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] Please **merge** this PR for me once it is approved