### PR TITLE
chore: update cloud-sql/sqlserver deps

### DIFF
--- a/cloud-sql/sql-server/sqlalchemy/requirements-test.txt
+++ b/cloud-sql/sql-server/sqlalchemy/requirements-test.txt
@@ -1,3 +1,1 @@
 pytest==7.0.1
-google-auth==2.19.1
-Requests==2.31.0

--- a/cloud-sql/sql-server/sqlalchemy/requirements.txt
+++ b/cloud-sql/sql-server/sqlalchemy/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.1.0
 gunicorn==22.0.0
-python-tds==1.12.0
+python-tds==1.15.0
 pyopenssl==24.0.0
 SQLAlchemy==2.0.24
 cloud-sql-python-connector==1.2.4


### PR DESCRIPTION
These two deps are already part of `cloud-sql-python-connector` and not needed separately in requirements.

This is causing test failures in #11465 as it is overriding proper versions of `google-auth`