### PR TITLE
fix: Pin Gemini Function Calling code samples to `gemini-1.0-pro-001`

### DIFF
--- a/generative_ai/function_calling.py
+++ b/generative_ai/function_calling.py
@@ -29,7 +29,7 @@ def generate_function_call(prompt: str, project_id: str, location: str) -> tuple
     vertexai.init(project=project_id, location=location)
 
     # Initialize Gemini model
-    model = GenerativeModel("gemini-1.0-pro")
+    model = GenerativeModel("gemini-1.0-pro-002")
 
     # Specify a function declaration and parameters for an API request
     get_current_weather_func = FunctionDeclaration(

--- a/generative_ai/function_calling.py
+++ b/generative_ai/function_calling.py
@@ -29,7 +29,7 @@ def generate_function_call(prompt: str, project_id: str, location: str) -> tuple
     vertexai.init(project=project_id, location=location)
 
     # Initialize Gemini model
-    model = GenerativeModel("gemini-1.0-pro-002")
+    model = GenerativeModel("gemini-1.0-pro-001")
 
     # Specify a function declaration and parameters for an API request
     get_current_weather_func = FunctionDeclaration(

--- a/generative_ai/function_calling_chat.py
+++ b/generative_ai/function_calling_chat.py
@@ -64,7 +64,7 @@ def generate_function_call_chat(project_id: str, location: str) -> tuple:
 
     # Initialize Gemini model
     model = GenerativeModel(
-        "gemini-1.0-pro-002",
+        "gemini-1.0-pro-001",
         generation_config=GenerationConfig(temperature=0),
         tools=[retail_tool],
     )

--- a/generative_ai/function_calling_chat.py
+++ b/generative_ai/function_calling_chat.py
@@ -16,6 +16,7 @@
 import vertexai
 from vertexai.generative_models import (
     FunctionDeclaration,
+    GenerationConfig,
     GenerativeModel,
     Part,
     Tool,
@@ -63,7 +64,9 @@ def generate_function_call_chat(project_id: str, location: str) -> tuple:
 
     # Initialize Gemini model
     model = GenerativeModel(
-        "gemini-1.0-pro-002", generation_config={"temperature": 0}, tools=[retail_tool]
+        "gemini-1.0-pro-002",
+        generation_config=GenerationConfig(temperature=0),
+        tools=[retail_tool]
     )
 
     # Start a chat session

--- a/generative_ai/function_calling_chat.py
+++ b/generative_ai/function_calling_chat.py
@@ -63,7 +63,7 @@ def generate_function_call_chat(project_id: str, location: str) -> tuple:
 
     # Initialize Gemini model
     model = GenerativeModel(
-        "gemini-1.0-pro", generation_config={"temperature": 0}, tools=[retail_tool]
+        "gemini-1.0-pro-002", generation_config={"temperature": 0}, tools=[retail_tool]
     )
 
     # Start a chat session

--- a/generative_ai/function_calling_chat.py
+++ b/generative_ai/function_calling_chat.py
@@ -66,7 +66,7 @@ def generate_function_call_chat(project_id: str, location: str) -> tuple:
     model = GenerativeModel(
         "gemini-1.0-pro-002",
         generation_config=GenerationConfig(temperature=0),
-        tools=[retail_tool]
+        tools=[retail_tool],
     )
 
     # Start a chat session

--- a/generative_ai/imagen/generate_image.py
+++ b/generative_ai/imagen/generate_image.py
@@ -22,7 +22,6 @@ from vertexai.preview import vision_models
 def generate_image(
     project_id: str, output_file: str, prompt: str
 ) -> vision_models.ImageGenerationResponse:
-
     # [START generativeaionvertexai_imagen_generate_image]
 
     import vertexai


### PR DESCRIPTION
## Description

Fixes #11366. (`generative_ai.function_calling_chat_test`)
Fixes #11367. (`generative_ai.function_calling_test`)

These code samples were referring to `gemini-1.0-pro`, which was leading to some flaky behavior (i.e., Function Calling was returning inaccurate function names) in these tests. This PR fixes that flakiness by pinning to `gemini-1.0-pro-001`.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] ~These samples need a new **API enabled** in testing projects to pass (let us know which ones)~
- [ ] ~These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)~
- [ ] ~This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample~
- [ ] ~This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner] https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample~
- [x] Please **merge** this PR for me once it is approved