### PR TITLE
henrylee's dump vertexai.__version__

### DIFF
--- a/generative_ai/embedding_model_tuning_test.py
+++ b/generative_ai/embedding_model_tuning_test.py
@@ -21,6 +21,7 @@ import google.auth
 from google.cloud import aiplatform
 from google.cloud.aiplatform import initializer as aiplatform_init
 from google.cloud.aiplatform import pipeline_jobs
+import vertexai
 
 
 import embedding_model_tuning
@@ -34,6 +35,8 @@ def dispose(job: pipeline_jobs.PipelineJob) -> None:
 
 
 def test_tune_embedding_model() -> None:
+    if vertexai.__version__:
+        raise ValueError(f"vertexai: {vertexai.__version__}")
     credentials, _ = google.auth.default(  # Set explicit credentials with Oauth scopes.
         scopes=["https://www.googleapis.com/auth/cloud-platform"]
     )


### PR DESCRIPTION
Do not review this pull request.

I dumped the vertex ai python sdk version (also called google-cloud-aiplatform).

> raise ValueError(f"vertexai: {vertexai.version}")
> > ValueError: vertexai: 1.47.0

Is there a way to trigger a Python package installation on go/kokoro? i.e.,

!pip3 install --quiet --force-reinstall --upgrade google-cloud-aiplatform
