### PR TITLE
feat(generative-ai): Add samples for the Inference API reference doc

### DIFF
--- a/generative_ai/inference/inference_api_test.py
+++ b/generative_ai/inference/inference_api_test.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import non_stream_multimodality_basic
+import non_stream_text_basic
+import stream_multimodality_basic
+import stream_text_basic
+
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+REGION = "us-central1"
+MODEL_ID = "gemini-1.5-pro-preview-0409"
+
+
+def test_non_stream_text_basic() -> None:
+    response = non_stream_text_basic.generate_content(PROJECT_ID, REGION, MODEL_ID)
+    assert response
+
+
+def test_non_stream_multi_modality_basic() -> None:
+    response = non_stream_multimodality_basic.generate_content(
+        PROJECT_ID, REGION, MODEL_ID
+    )
+    assert response
+
+
+def test_stream_text_basic() -> None:
+    responses = stream_text_basic.generate_content(PROJECT_ID, REGION, MODEL_ID)
+    assert responses
+
+
+def test_stream_multi_modality_basic() -> None:
+    responses = stream_multimodality_basic.generate_content(
+        PROJECT_ID, REGION, MODEL_ID
+    )
+    assert responses

--- a/generative_ai/inference/non_stream_multimodality_basic.py
+++ b/generative_ai/inference/non_stream_multimodality_basic.py
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+    # [START generativeaionvertexai_non_stream_multimodality_basic]
+    import vertexai
+
+    from vertexai.generative_models import GenerativeModel, Part
+
+    vertexai.init(project=PROJECT_ID, location=REGION)
+
+    model = GenerativeModel(MODEL_ID)
+    response = model.generate_content(
+        [
+            Part.from_uri(
+                "gs://cloud-samples-data/generative-ai/video/animals.mp4", "video/mp4"
+            ),
+            Part.from_uri(
+                "gs://cloud-samples-data/generative-ai/image/character.jpg",
+                "image/jpeg",
+            ),
+            "Are these video and image correlated?",
+        ]
+    )
+
+    print(response)
+    # [END generativeaionvertexai_non_stream_multimodality_basic]
+
+    return response

--- a/generative_ai/inference/non_stream_text_basic.py
+++ b/generative_ai/inference/non_stream_text_basic.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+    # [START generativeaionvertexai_non_stream_text_basic]
+    import vertexai
+
+    from vertexai.generative_models import GenerativeModel
+
+    vertexai.init(project=PROJECT_ID, location=REGION)
+
+    model = GenerativeModel(MODEL_ID)
+    response = model.generate_content("Write a story about a magic backpack.")
+
+    print(response)
+    # [END generativeaionvertexai_non_stream_text_basic]
+
+    return response

--- a/generative_ai/inference/stream_multimodality_basic.py
+++ b/generative_ai/inference/stream_multimodality_basic.py
@@ -1,0 +1,43 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+    # [START generativeaionvertexai_stream_multimodality_basic]
+    import vertexai
+
+    from vertexai.generative_models import GenerativeModel, Part
+
+    vertexai.init(project=PROJECT_ID, location=REGION)
+
+    model = GenerativeModel(MODEL_ID)
+    responses = model.generate_content(
+        [
+            Part.from_uri(
+                "gs://cloud-samples-data/generative-ai/video/animals.mp4", "video/mp4"
+            ),
+            Part.from_uri(
+                "gs://cloud-samples-data/generative-ai/image/character.jpg",
+                "image/jpeg",
+            ),
+            "Are these video and image correlated?",
+        ],
+        stream=True,
+    )
+
+    for response in responses:
+        print(response)
+    # [END generativeaionvertexai_stream_multimodality_basic]
+
+    return responses

--- a/generative_ai/inference/stream_text_basic.py
+++ b/generative_ai/inference/stream_text_basic.py
@@ -1,0 +1,33 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+    # [START generativeaionvertexai_stream_text_basic]
+    import vertexai
+
+    from vertexai.generative_models import GenerativeModel
+
+    vertexai.init(project=PROJECT_ID, location=REGION)
+
+    model = GenerativeModel(MODEL_ID)
+    responses = model.generate_content(
+        "Write a story about a magic backpack.", stream=True
+    )
+
+    for response in responses:
+        print(response)
+    # [END generativeaionvertexai_stream_text_basic]
+
+    return responses


### PR DESCRIPTION
## Description

Add samples for the Inference API reference doc: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#python_2

- non_stream_text_basic
- non_stream_multimodality_basic
- stream_text_basic
- stream_multimodality_basic

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved