### PR TITLE
Updated variable name REGION  to location

### DIFF
--- a/generative_ai/gemini_tuning.py
+++ b/generative_ai/gemini_tuning.py
@@ -21,6 +21,7 @@ def gemini_tuning_basic(project_id: str) -> sft.SupervisedTuningJob:
     # [START generativeaionvertexai_tuning_basic]
 
     import time
+
     import vertexai
     from vertexai.preview.tuning import sft
 
@@ -51,6 +52,7 @@ def gemini_tuning_advanced(project_id: str) -> sft.SupervisedTuningJob:
     # [START generativeaionvertexai_tuning_advanced]
 
     import time
+
     import vertexai
     from vertexai.preview.tuning import sft
 
@@ -83,7 +85,7 @@ def gemini_tuning_advanced(project_id: str) -> sft.SupervisedTuningJob:
 
 
 def get_tuning_job(
-    project_id: str, location: str, tuning_job_id: str
+    project_id: str, LOCATION: str, tuning_job_id: str
 ) -> sft.SupervisedTuningJob:
     # [START generativeaionvertexai_get_tuning_job]
     import vertexai
@@ -91,13 +93,13 @@ def get_tuning_job(
 
     # TODO(developer): Update and un-comment below lines
     # project_id = "PROJECT_ID"
-    # location = "us-central1"
+    # LOCATION = "us-central1"
     # tuning_job_id = "TUNING_JOB_ID"
 
     vertexai.init(project=project_id, location="us-central1")
 
     response = sft.SupervisedTuningJob(
-        f"projects/{project_id}/locations/{location}/tuningJobs/{tuning_job_id}"
+        f"projects/{project_id}/locations/{LOCATION}/tuningJobs/{tuning_job_id}"
     )
 
     print(response)
@@ -127,20 +129,20 @@ def list_tuning_jobs(
     return responses
 
 
-def cancel_tuning_job(project_id: str, location: str, tuning_job_id: str) -> None:
+def cancel_tuning_job(project_id: str, LOCATION: str, tuning_job_id: str) -> None:
     # [START generativeaionvertexai_cancel_tuning_job]
     import vertexai
     from vertexai.preview.tuning import sft
 
     # TODO(developer): Update and un-comment below lines
     # project_id = "PROJECT_ID"
-    # location = "us-central1"
+    # LOCATION = "us-central1"
     # tuning_job_id = "TUNING_JOB_ID"
 
     vertexai.init(project=project_id, location="us-central1")
 
     job = sft.SupervisedTuningJob(
-        f"projects/{project_id}/locations/{location}/tuningJobs/{tuning_job_id}"
+        f"projects/{project_id}/locations/{LOCATION}/tuningJobs/{tuning_job_id}"
     )
     job.cancel()
     # [END generativeaionvertexai_cancel_tuning_job]

--- a/generative_ai/gemini_tuning_test.py
+++ b/generative_ai/gemini_tuning_test.py
@@ -18,7 +18,7 @@ import gemini_tuning
 import pytest
 
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-location = "us-central1"
+LOCATION = "us-central1"
 MODEL_ID = "gemini-1.5-pro-preview-0409"
 TUNING_JOB_ID = "4982013113894174720"
 
@@ -34,7 +34,7 @@ def test_gemini_tuning() -> None:
 
 def test_get_tuning_job() -> None:
     response = gemini_tuning.get_tuning_job(
-        PROJECT_ID, location, TUNING_JOB_ID)
+        PROJECT_ID, LOCATION, TUNING_JOB_ID)
     assert response
 
 
@@ -45,4 +45,4 @@ def test_list_tuning_jobs() -> None:
 
 @pytest.mark.skip(reason="Skip due to tuning taking a long time.")
 def test_cancel_tuning_job() -> None:
-    gemini_tuning.cancel_tuning_job(PROJECT_ID, location, TUNING_JOB_ID)
+    gemini_tuning.cancel_tuning_job(PROJECT_ID, LOCATION, TUNING_JOB_ID)

--- a/generative_ai/gemini_tuning_test.py
+++ b/generative_ai/gemini_tuning_test.py
@@ -14,12 +14,11 @@
 
 import os
 
+import gemini_tuning
 import pytest
 
-import gemini_tuning
-
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-REGION = "us-central1"
+location = "us-central1"
 MODEL_ID = "gemini-1.5-pro-preview-0409"
 TUNING_JOB_ID = "4982013113894174720"
 
@@ -34,7 +33,8 @@ def test_gemini_tuning() -> None:
 
 
 def test_get_tuning_job() -> None:
-    response = gemini_tuning.get_tuning_job(PROJECT_ID, REGION, TUNING_JOB_ID)
+    response = gemini_tuning.get_tuning_job(
+        PROJECT_ID, location, TUNING_JOB_ID)
     assert response
 
 
@@ -45,4 +45,4 @@ def test_list_tuning_jobs() -> None:
 
 @pytest.mark.skip(reason="Skip due to tuning taking a long time.")
 def test_cancel_tuning_job() -> None:
-    gemini_tuning.cancel_tuning_job(PROJECT_ID, REGION, TUNING_JOB_ID)
+    gemini_tuning.cancel_tuning_job(PROJECT_ID, location, TUNING_JOB_ID)


### PR DESCRIPTION
## Description

Updated variable name REGION  to location 

Samples for the Tuning API reference doc: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/tuning#python

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved