### PR TITLE
Standardize the location parameter

### DIFF
--- a/generative_ai/gemini_tuning.py
+++ b/generative_ai/gemini_tuning.py
@@ -136,7 +136,7 @@ def cancel_tuning_job(project_id: str, LOCATION: str, tuning_job_id: str) -> Non
 
     # TODO(developer): Update and un-comment below lines
     # project_id = "PROJECT_ID"
-    # LOCATION = "us-central1"
+    # location = "us-central1"
     # tuning_job_id = "TUNING_JOB_ID"
 
     vertexai.init(project=project_id, location="us-central1")

--- a/generative_ai/gemini_tuning.py
+++ b/generative_ai/gemini_tuning.py
@@ -21,6 +21,7 @@ def gemini_tuning_basic(project_id: str) -> sft.SupervisedTuningJob:
     # [START generativeaionvertexai_tuning_basic]
 
     import time
+
     import vertexai
     from vertexai.preview.tuning import sft
 
@@ -51,6 +52,7 @@ def gemini_tuning_advanced(project_id: str) -> sft.SupervisedTuningJob:
     # [START generativeaionvertexai_tuning_advanced]
 
     import time
+
     import vertexai
     from vertexai.preview.tuning import sft
 
@@ -83,7 +85,7 @@ def gemini_tuning_advanced(project_id: str) -> sft.SupervisedTuningJob:
 
 
 def get_tuning_job(
-    project_id: str, location: str, tuning_job_id: str
+    project_id: str, LOCATION: str, tuning_job_id: str
 ) -> sft.SupervisedTuningJob:
     # [START generativeaionvertexai_get_tuning_job]
     import vertexai
@@ -97,7 +99,7 @@ def get_tuning_job(
     vertexai.init(project=project_id, location="us-central1")
 
     response = sft.SupervisedTuningJob(
-        f"projects/{project_id}/locations/{location}/tuningJobs/{tuning_job_id}"
+        f"projects/{project_id}/locations/{LOCATION}/tuningJobs/{tuning_job_id}"
     )
 
     print(response)
@@ -127,20 +129,20 @@ def list_tuning_jobs(
     return responses
 
 
-def cancel_tuning_job(project_id: str, location: str, tuning_job_id: str) -> None:
+def cancel_tuning_job(project_id: str, LOCATION: str, tuning_job_id: str) -> None:
     # [START generativeaionvertexai_cancel_tuning_job]
     import vertexai
     from vertexai.preview.tuning import sft
 
     # TODO(developer): Update and un-comment below lines
     # project_id = "PROJECT_ID"
-    # location = "us-central1"
+    # LOCATION = "us-central1"
     # tuning_job_id = "TUNING_JOB_ID"
 
     vertexai.init(project=project_id, location="us-central1")
 
     job = sft.SupervisedTuningJob(
-        f"projects/{project_id}/locations/{location}/tuningJobs/{tuning_job_id}"
+        f"projects/{project_id}/locations/{LOCATION}/tuningJobs/{tuning_job_id}"
     )
     job.cancel()
     # [END generativeaionvertexai_cancel_tuning_job]

--- a/generative_ai/gemini_tuning.py
+++ b/generative_ai/gemini_tuning.py
@@ -85,7 +85,7 @@ def gemini_tuning_advanced(project_id: str) -> sft.SupervisedTuningJob:
 
 
 def get_tuning_job(
-    project_id: str, LOCATION: str, tuning_job_id: str
+    project_id: str, location: str, tuning_job_id: str
 ) -> sft.SupervisedTuningJob:
     # [START generativeaionvertexai_get_tuning_job]
     import vertexai
@@ -99,7 +99,7 @@ def get_tuning_job(
     vertexai.init(project=project_id, location="us-central1")
 
     response = sft.SupervisedTuningJob(
-        f"projects/{project_id}/locations/{LOCATION}/tuningJobs/{tuning_job_id}"
+        f"projects/{project_id}/locations/{location}/tuningJobs/{tuning_job_id}"
     )
 
     print(response)
@@ -129,7 +129,7 @@ def list_tuning_jobs(
     return responses
 
 
-def cancel_tuning_job(project_id: str, LOCATION: str, tuning_job_id: str) -> None:
+def cancel_tuning_job(project_id: str, location: str, tuning_job_id: str) -> None:
     # [START generativeaionvertexai_cancel_tuning_job]
     import vertexai
     from vertexai.preview.tuning import sft
@@ -142,7 +142,7 @@ def cancel_tuning_job(project_id: str, LOCATION: str, tuning_job_id: str) -> Non
     vertexai.init(project=project_id, location="us-central1")
 
     job = sft.SupervisedTuningJob(
-        f"projects/{project_id}/locations/{LOCATION}/tuningJobs/{tuning_job_id}"
+        f"projects/{project_id}/locations/{location}/tuningJobs/{tuning_job_id}"
     )
     job.cancel()
     # [END generativeaionvertexai_cancel_tuning_job]

--- a/generative_ai/gemini_tuning_test.py
+++ b/generative_ai/gemini_tuning_test.py
@@ -14,8 +14,9 @@
 
 import os
 
-import gemini_tuning
 import pytest
+
+import gemini_tuning
 
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
 LOCATION = "us-central1"

--- a/generative_ai/gemini_tuning_test.py
+++ b/generative_ai/gemini_tuning_test.py
@@ -14,12 +14,11 @@
 
 import os
 
+import gemini_tuning
 import pytest
 
-import gemini_tuning
-
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-REGION = "us-central1"
+LOCATION = "us-central1"
 MODEL_ID = "gemini-1.5-pro-preview-0409"
 TUNING_JOB_ID = "4982013113894174720"
 
@@ -34,7 +33,8 @@ def test_gemini_tuning() -> None:
 
 
 def test_get_tuning_job() -> None:
-    response = gemini_tuning.get_tuning_job(PROJECT_ID, REGION, TUNING_JOB_ID)
+    response = gemini_tuning.get_tuning_job(
+        PROJECT_ID, LOCATION, TUNING_JOB_ID)
     assert response
 
 
@@ -45,4 +45,4 @@ def test_list_tuning_jobs() -> None:
 
 @pytest.mark.skip(reason="Skip due to tuning taking a long time.")
 def test_cancel_tuning_job() -> None:
-    gemini_tuning.cancel_tuning_job(PROJECT_ID, REGION, TUNING_JOB_ID)
+    gemini_tuning.cancel_tuning_job(PROJECT_ID, LOCATION, TUNING_JOB_ID)

--- a/generative_ai/inference/inference_api_test.py
+++ b/generative_ai/inference/inference_api_test.py
@@ -21,29 +21,28 @@ import stream_text_basic
 
 
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-REGION = "us-central1"
 MODEL_ID = "gemini-1.5-pro-preview-0409"
 
 
 def test_non_stream_text_basic() -> None:
-    response = non_stream_text_basic.generate_content(PROJECT_ID, REGION, MODEL_ID)
+    response = non_stream_text_basic.generate_content(PROJECT_ID, MODEL_ID)
     assert response
 
 
 def test_non_stream_multi_modality_basic() -> None:
     response = non_stream_multimodality_basic.generate_content(
-        PROJECT_ID, REGION, MODEL_ID
+        PROJECT_ID, MODEL_ID
     )
     assert response
 
 
 def test_stream_text_basic() -> None:
-    responses = stream_text_basic.generate_content(PROJECT_ID, REGION, MODEL_ID)
+    responses = stream_text_basic.generate_content(PROJECT_ID, MODEL_ID)
     assert responses
 
 
 def test_stream_multi_modality_basic() -> None:
     responses = stream_multimodality_basic.generate_content(
-        PROJECT_ID, REGION, MODEL_ID
+        PROJECT_ID, MODEL_ID
     )
     assert responses

--- a/generative_ai/inference/non_stream_multimodality_basic.py
+++ b/generative_ai/inference/non_stream_multimodality_basic.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+def generate_content(PROJECT_ID: str, MODEL_ID: str) -> object:
     # [START generativeaionvertexai_non_stream_multimodality_basic]
     import vertexai
 
     from vertexai.generative_models import GenerativeModel, Part
 
-    vertexai.init(project=PROJECT_ID, location=REGION)
+    vertexai.init(project=PROJECT_ID, location="us-central1")
 
     model = GenerativeModel(MODEL_ID)
     response = model.generate_content(

--- a/generative_ai/inference/non_stream_text_basic.py
+++ b/generative_ai/inference/non_stream_text_basic.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+def generate_content(PROJECT_ID: str, MODEL_ID: str) -> object:
     # [START generativeaionvertexai_non_stream_text_basic]
     import vertexai
 
     from vertexai.generative_models import GenerativeModel
 
-    vertexai.init(project=PROJECT_ID, location=REGION)
+    vertexai.init(project=PROJECT_ID, location="us-central1")
 
     model = GenerativeModel(MODEL_ID)
     response = model.generate_content("Write a story about a magic backpack.")

--- a/generative_ai/inference/stream_multimodality_basic.py
+++ b/generative_ai/inference/stream_multimodality_basic.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+def generate_content(PROJECT_ID: str, MODEL_ID: str) -> object:
     # [START generativeaionvertexai_stream_multimodality_basic]
     import vertexai
 
     from vertexai.generative_models import GenerativeModel, Part
 
-    vertexai.init(project=PROJECT_ID, location=REGION)
+    vertexai.init(project=PROJECT_ID, location="us-central1")
 
     model = GenerativeModel(MODEL_ID)
     responses = model.generate_content(

--- a/generative_ai/inference/stream_text_basic.py
+++ b/generative_ai/inference/stream_text_basic.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 
-def generate_content(PROJECT_ID: str, REGION: str, MODEL_ID: str) -> object:
+def generate_content(PROJECT_ID: str, MODEL_ID: str) -> object:
     # [START generativeaionvertexai_stream_text_basic]
     import vertexai
 
     from vertexai.generative_models import GenerativeModel
 
-    vertexai.init(project=PROJECT_ID, location=REGION)
+    vertexai.init(project=PROJECT_ID, location="us-central1")
 
     model = GenerativeModel(MODEL_ID)
     responses = model.generate_content(

--- a/generative_ai/multimodal_embedding_image.py
+++ b/generative_ai/multimodal_embedding_image.py
@@ -19,7 +19,6 @@ from vertexai.vision_models import MultiModalEmbeddingResponse
 
 def get_image_embeddings(
     project_id: str,
-    location: str,
     image_path: str,
     contextual_text: Optional[str] = None,
 ) -> MultiModalEmbeddingResponse:
@@ -27,7 +26,6 @@ def get_image_embeddings(
 
     Args:
         project_id: Google Cloud Project ID, used to initialize vertexai
-        location: Google Cloud Region, used to initialize vertexai
         image_path: Path to image (local or Google Cloud Storage) to generate embeddings for.
         contextual_text: Text to generate embeddings for.
     """
@@ -35,8 +33,8 @@ def get_image_embeddings(
     import vertexai
     from vertexai.vision_models import Image, MultiModalEmbeddingModel
 
-    # TODO(developer): Update values for project_id, location, image_path & contextual_text
-    vertexai.init(project=project_id, location=location)
+    # TODO(developer): Update values for project_id, image_path & contextual_text
+    vertexai.init(project=project_id, location="us-central1")
 
     model = MultiModalEmbeddingModel.from_pretrained("multimodalembedding")
     image = Image.load_from_file(image_path)

--- a/generative_ai/multimodal_embedding_image_test.py
+++ b/generative_ai/multimodal_embedding_image_test.py
@@ -19,14 +19,12 @@ from google.api_core.exceptions import ResourceExhausted
 import multimodal_embedding_image
 
 _PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-_LOCATION = "us-central1"
 
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
 def test_multimodal_embedding_image() -> None:
     embeddings = multimodal_embedding_image.get_image_embeddings(
         project_id=_PROJECT_ID,
-        location=_LOCATION,
         image_path="gs://cloud-samples-data/vertex-ai/llm/prompts/landmark1.png",
         contextual_text="Colosseum",
     )

--- a/generative_ai/multimodal_embedding_image_video_text.py
+++ b/generative_ai/multimodal_embedding_image_video_text.py
@@ -19,7 +19,6 @@ from vertexai.vision_models import MultiModalEmbeddingResponse, VideoSegmentConf
 
 def get_image_video_text_embeddings(
     project_id: str,
-    location: str,
     image_path: str,
     video_path: str,
     contextual_text: Optional[str] = None,
@@ -44,9 +43,9 @@ def get_image_video_text_embeddings(
 
     from vertexai.vision_models import Image, MultiModalEmbeddingModel, Video
 
-    # TODO(developer): Update values for project_id, location,
+    # TODO(developer): Update values for project_id,
     #            image_path, video_path, contextual_text, video_segment_config
-    vertexai.init(project=project_id, location=location)
+    vertexai.init(project=project_id, location="us-central1")
 
     model = MultiModalEmbeddingModel.from_pretrained("multimodalembedding")
     image = Image.load_from_file(image_path)

--- a/generative_ai/multimodal_embedding_image_video_text_test.py
+++ b/generative_ai/multimodal_embedding_image_video_text_test.py
@@ -19,14 +19,12 @@ from google.api_core.exceptions import ResourceExhausted
 import multimodal_embedding_image_video_text
 
 _PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-_LOCATION = "us-central1"
 
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
 def test_multimodal_embedding_image_video_text() -> None:
     embeddings = multimodal_embedding_image_video_text.get_image_video_text_embeddings(
         project_id=_PROJECT_ID,
-        location=_LOCATION,
         image_path="gs://cloud-samples-data/vertex-ai/llm/prompts/landmark1.png",
         video_path="gs://cloud-samples-data/vertex-ai-vision/highway_vehicles.mp4",
         contextual_text="Cars on Highway",

--- a/generative_ai/multimodal_embedding_video.py
+++ b/generative_ai/multimodal_embedding_video.py
@@ -41,7 +41,7 @@ def get_video_embeddings(
 
     from vertexai.vision_models import MultiModalEmbeddingModel, Video
 
-    # TODO(developer): Update values for project_id, location,
+    # TODO(developer): Update values for project_id,
     #               video_path, contextual_text, dimension, video_segment_config
     vertexai.init(project=project_id, location="us-central1")
 

--- a/generative_ai/multimodal_embedding_video.py
+++ b/generative_ai/multimodal_embedding_video.py
@@ -19,7 +19,6 @@ from vertexai.vision_models import MultiModalEmbeddingResponse, VideoSegmentConf
 
 def get_video_embeddings(
     project_id: str,
-    location: str,
     video_path: str,
     contextual_text: Optional[str] = None,
     dimension: Optional[int] = 1408,
@@ -44,7 +43,7 @@ def get_video_embeddings(
 
     # TODO(developer): Update values for project_id, location,
     #               video_path, contextual_text, dimension, video_segment_config
-    vertexai.init(project=project_id, location=location)
+    vertexai.init(project=project_id, location="us-central1")
 
     model = MultiModalEmbeddingModel.from_pretrained("multimodalembedding")
     video = Video.load_from_file(video_path)

--- a/generative_ai/multimodal_embedding_video_test.py
+++ b/generative_ai/multimodal_embedding_video_test.py
@@ -19,14 +19,12 @@ from google.api_core.exceptions import ResourceExhausted
 import multimodal_embedding_video
 
 _PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-_LOCATION = "us-central1"
 
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
 def test_multimodal_embedding_video() -> None:
     embeddings = multimodal_embedding_video.get_video_embeddings(
         project_id=_PROJECT_ID,
-        location=_LOCATION,
         video_path="gs://cloud-samples-data/vertex-ai-vision/highway_vehicles.mp4",
         contextual_text="Cars on Highway",
     )


### PR DESCRIPTION
## Description

- Sets location = "us-central1" while initializing vertex.
- Renames REGION to LOCATION.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.8` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved