### PR TITLE
feat: Update embedding tuning sample to use new preview parameters.

### DIFF
--- a/generative_ai/embedding_model_tuning.py
+++ b/generative_ai/embedding_model_tuning.py
@@ -16,12 +16,12 @@
 import re
 
 from google.cloud.aiplatform import initializer as aiplatform_init
-from vertexai.language_models import TextEmbeddingModel
+from vertexai.preview.language_models import TextEmbeddingModel
 
 
 def tune_embedding_model(
     api_endpoint: str,
-    base_model_name: str = "textembedding-gecko@003",
+    base_model_name: str = "text-embedding-004",
     task_type: str = "DEFAULT",
     queries_path: str = "gs://embedding-customization-pipeline/dataset/queries.jsonl",
     corpus_path: str = "gs://embedding-customization-pipeline/dataset/corpus.jsonl",
@@ -29,6 +29,8 @@ def tune_embedding_model(
     test_label_path: str = "gs://embedding-customization-pipeline/dataset/test.tsv",
     batch_size: int = 128,
     train_steps: int = 1000,
+    output_dimensionality: int = 768,
+    learning_rate_multiplier: float = 1.0
 ):  # noqa: ANN201
     match = re.search(r"^(\w+-\w+)", api_endpoint)
     location = match.group(1) if match else "us-central1"
@@ -42,6 +44,8 @@ def tune_embedding_model(
         batch_size=batch_size,
         train_steps=train_steps,
         tuned_model_location=location,
+        output_dimensionality=output_dimensionality,
+        learning_rate_multiplier=learning_rate_multiplier,
     )
     return tuning_job
 

--- a/generative_ai/requirements.txt
+++ b/generative_ai/requirements.txt
@@ -2,7 +2,7 @@ pandas==1.3.5; python_version == '3.7'
 pandas==2.0.1; python_version > '3.7'
 pillow==9.5.0; python_version < '3.8'
 pillow==10.3.0; python_version >= '3.8'
-google-cloud-aiplatform[pipelines,rapid_evaluation,reasoningengine]==1.50.0
+google-cloud-aiplatform[pipelines,rapid_evaluation,reasoningengine]==1.51.0
 google-auth==2.29.0
 anthropic[vertex]==0.25.6
 langchain-core==0.1.52


### PR DESCRIPTION
## Description

BUG: b/340594864

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] ~**Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))~ -- ` SKIPPED: 3.9 tests are disabled for this sample`
- [x] **Tests** pass:   `nox -s py-3.11` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved