### PR TITLE
Fix: deprecated to run on 3.7 where at least one higher version is av…

### DIFF
--- a/appengine/standard_python3/bigquery/noxfile_config.py
+++ b/appengine/standard_python3/bigquery/noxfile_config.py
@@ -23,7 +23,7 @@
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # There's no google-cloud-bigquery package for Python 3.9.
-    "ignored_versions": ["2.7", "3.6", "3.9", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/bigquery-reservation/snippets/noxfile_config.py
+++ b/bigquery-reservation/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6"],
+    "ignored_versions": ["2.7", "3.6", "3.7"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/bigquery/bqml/noxfile_config.py
+++ b/bigquery/bqml/noxfile_config.py
@@ -23,7 +23,7 @@
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # Skipping for Python 3.9 due to pyarrow compilation failure.
-    "ignored_versions": ["2.7", "3.6", "3.9", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/bigquery/pandas-gbq-migration/noxfile_config.py
+++ b/bigquery/pandas-gbq-migration/noxfile_config.py
@@ -23,7 +23,7 @@
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # Skipping for Python 3.9 due to pyarrow compilation failure.
-    "ignored_versions": ["2.7", "3.6", "3.9", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/cloud-sql/mysql/client-side-encryption/noxfile_config.py
+++ b/cloud-sql/mysql/client-side-encryption/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.10", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/cloud-sql/postgres/client-side-encryption/noxfile_config.py
+++ b/cloud-sql/postgres/client-side-encryption/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.10", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/cloud-sql/sql-server/client-side-encryption/noxfile_config.py
+++ b/cloud-sql/sql-server/client-side-encryption/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.10", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/noxfile_config.py
+++ b/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/noxfile_config.py
@@ -32,7 +32,7 @@ _tmpdir = tempfile.TemporaryDirectory()
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # Skipping for Python 3.9 due to numpy compilation failure.
-    "ignored_versions": ["2.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/documentai/snippets/noxfile_config.py
+++ b/documentai/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6", "3.8", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/profiler/appengine/flexible/noxfile_config.py
+++ b/profiler/appengine/flexible/noxfile_config.py
@@ -23,7 +23,7 @@
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # 3.11 is currently unsupported
-    "ignored_versions": ["2.7", "3.11", "3.12"],
+    "ignored_versions": ["2.7", "3.7", "3.11", "3.12"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/profiler/quickstart/noxfile_config.py
+++ b/profiler/quickstart/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.11"],
+    "ignored_versions": ["2.7", "3.7", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/pubsub/streaming-analytics/noxfile_config.py
+++ b/pubsub/streaming-analytics/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6", "3.9", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.10", "3.11", "3.12"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,


### PR DESCRIPTION
…ailable

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved