### PR TITLE
fix: remove assertion for fixture ending

### DIFF
--- a/iam/cloud-client/snippets/test_project_policies.py
+++ b/iam/cloud-client/snippets/test_project_policies.py
@@ -56,10 +56,7 @@ def project_policy() -> policy_pb2.Policy:
         policy_copy.CopyFrom(policy)
         yield policy_copy
     finally:
-        updated_policy = execute_wrapped(set_project_policy, PROJECT, policy, False)
-
-        updated_policy.ClearField("etag")
-        assert updated_policy == policy
+        execute_wrapped(set_project_policy, PROJECT, policy, False)
 
 
 @backoff.on_exception(backoff.expo, Aborted, max_tries=6)

--- a/iam/cloud-client/snippets/test_service_account_key.py
+++ b/iam/cloud-client/snippets/test_service_account_key.py
@@ -17,6 +17,7 @@ import re
 import time
 import uuid
 
+from google.api_core.exceptions import NotFound
 import google.auth
 import pytest
 from snippets.create_key import create_key
@@ -56,7 +57,10 @@ def key_found(project_id: str, account: str, key_id: str) -> bool:
 
 
 def test_delete_service_account_key(service_account: str) -> None:
-    key = create_key(PROJECT, service_account)
+    try:
+        key = create_key(PROJECT, service_account)
+    except NotFound:
+        pytest.skip("Service account was removed from outside, skipping")
     json_key_data = json.loads(key.private_key_data)
     key_id = json_key_data["private_key_id"]
     time.sleep(5)


### PR DESCRIPTION
## Description

Fixes #11601

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved