### PR TITLE
fix: making tests more resistant to concurent running tests

### DIFF
--- a/iam/cloud-client/snippets/test_roles.py
+++ b/iam/cloud-client/snippets/test_roles.py
@@ -14,6 +14,8 @@
 
 import re
 
+import backoff
+from google.api_core.exceptions import Aborted, InvalidArgument
 import google.auth
 from google.cloud.iam_admin_v1 import GetRoleRequest, IAMClient, ListRolesRequest, Role
 import pytest
@@ -67,6 +69,7 @@ def test_list_roles(capsys: "pytest.CaptureFixture[str]", iam_role: str) -> None
     assert re.search(iam_role, out)
 
 
+@backoff.on_exception(backoff.expo, Aborted, max_tries=3)
 def test_edit_role(iam_role: str) -> None:
     client = IAMClient()
     name = f"projects/{PROJECT}/roles/{iam_role}"
@@ -79,6 +82,7 @@ def test_edit_role(iam_role: str) -> None:
     assert updated_role.title == title
 
 
+@backoff.on_exception(backoff.expo, InvalidArgument, max_tries=3)
 def test_disable_role(capsys: "pytest.CaptureFixture[str]", iam_role: str) -> None:
     disable_role(PROJECT, iam_role)
     client = IAMClient()

--- a/iam/cloud-client/snippets/test_service_account.py
+++ b/iam/cloud-client/snippets/test_service_account.py
@@ -16,7 +16,7 @@ import re
 import uuid
 
 import backoff
-from google.api_core.exceptions import InvalidArgument
+from google.api_core.exceptions import InvalidArgument, NotFound
 import google.auth
 from google.iam.v1 import policy_pb2
 import pytest
@@ -92,7 +92,7 @@ def test_service_account_set_policy(service_account: str) -> None:
 
     try:
         new_policy = set_service_account_iam_policy(PROJECT, service_account, policy)
-    except InvalidArgument:
+    except (InvalidArgument, NotFound):
         pytest.skip("Service account was removed from outside, skipping")
 
     binding_found = False
@@ -108,7 +108,7 @@ def test_service_account_rename(service_account: str) -> None:
     new_name = "New Name"
     try:
         account = rename_service_account(PROJECT, service_account, new_name)
-    except InvalidArgument:
+    except (InvalidArgument, NotFound):
         pytest.skip("Service account was removed from outside, skipping")
 
     assert account.display_name == new_name


### PR DESCRIPTION
## Description

Fixes #11735
#11734

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved