### PR TITLE
Update example to update deprecated modules

### DIFF
--- a/composer/workflows/simple.py
+++ b/composer/workflows/simple.py
@@ -23,8 +23,8 @@ from airflow import models
 
 # [END composer_simple_define_dag]
 # [START composer_simple_operators]
-from airflow.operators import bash_operator
-from airflow.operators import python_operator
+from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
 
 # [END composer_simple_operators]
 
@@ -55,12 +55,12 @@ with models.DAG(
 
     # An instance of an operator is called a task. In this case, the
     # hello_python task calls the "greeting" Python function.
-    hello_python = python_operator.PythonOperator(
+    hello_python = PythonOperator(
         task_id="hello", python_callable=greeting
     )
 
     # Likewise, the goodbye_bash task calls a Bash script.
-    goodbye_bash = bash_operator.BashOperator(
+    goodbye_bash = BashOperator(
         task_id="bye", bash_command="echo Goodbye."
     )
     # [END composer_simple_operators]


### PR DESCRIPTION

The sample codes use the deprecated modules. For example,

```
from airflow.operators import bash_operator
from airflow.operators import python_operator
```

Those are [deprecated](https://airflow.apache.org/docs/apache-airflow/2.3.2/_api/airflow/operators/bash_operator/index.html).