### PR TITLE
docs: ContentSearchSpec

### DIFF
--- a/discoveryengine/search_sample.py
+++ b/discoveryengine/search_sample.py
@@ -46,7 +46,7 @@ def search_sample(
     # The full resource name of the search app serving config
     serving_config = f"projects/{project_id}/locations/{location}/collections/default_collection/engines/{engine_id}/servingConfigs/default_config"
 
-    # Optional: Configuration options for search. For unstructured data only (otherwise comment-out content_search_spec).
+    # Optional - only supported for unstructured data: Configuration options for search. 
     # Refer to the `ContentSearchSpec` reference for all supported fields:
     # https://cloud.google.com/python/docs/reference/discoveryengine/latest/google.cloud.discoveryengine_v1.types.SearchRequest.ContentSearchSpec
     content_search_spec = discoveryengine.SearchRequest.ContentSearchSpec(

--- a/discoveryengine/search_sample.py
+++ b/discoveryengine/search_sample.py
@@ -46,7 +46,7 @@ def search_sample(
     # The full resource name of the search app serving config
     serving_config = f"projects/{project_id}/locations/{location}/collections/default_collection/engines/{engine_id}/servingConfigs/default_config"
 
-    # Optional: Configuration options for search
+    # Optional: Configuration options for search. For unstructured data only (otherwise comment-out content_search_spec).
     # Refer to the `ContentSearchSpec` reference for all supported fields:
     # https://cloud.google.com/python/docs/reference/discoveryengine/latest/google.cloud.discoveryengine_v1.types.SearchRequest.ContentSearchSpec
     content_search_spec = discoveryengine.SearchRequest.ContentSearchSpec(


### PR DESCRIPTION
## Description

ContentSearchSpec only supports unstructured data. If structured data is referenced an exception is raised.

In the Google Cloud Docs, this is well documented under the [REST tab](https://cloud.google.com/generative-ai-app-builder/docs/preview-search-results#genappbuilder_search-rest).
==> Where it says: `CONTENT_SEARCH_SPEC: optional. For getting snippets, extractive answers, extractive segments, and search summaries. For unstructured data only.`

However, it's not well documented under the [Python Tab](https://cloud.google.com/generative-ai-app-builder/docs/preview-search-results#genappbuilder_search-python) (i.e. in the Python github example).