### PR TITLE
Add Gemma Flex Template example

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -168,7 +168,7 @@ test_prog="${PROJECT_ROOT}/.kokoro/tests/run_single_test.sh"
 
 btlr_args=(
     "run"
-    "--max-cmd-duration=60m"
+    "--max-cmd-duration=70m"
     "**/requirements.txt"
 )
 

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -168,7 +168,7 @@ test_prog="${PROJECT_ROOT}/.kokoro/tests/run_single_test.sh"
 
 btlr_args=(
     "run"
-    "--max-cmd-duration=70m"
+    "--max-cmd-duration=60m"
     "**/requirements.txt"
 )
 

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -164,34 +164,7 @@ def pubsub_wait_for_messages(subscription_path: str) -> list[str]:
     subscriber = pubsub.SubscriberClient()
     with subscriber:
         response = subscriber.pull(subscription=subscription_path, max_messages=10)
-
         messages = [m.message.data.decode("utf-8") for m in response.received_messages]
-        if not messages:
-            raise ValueError("pubsub_wait_for_messages no messages received")
-
-        print(f"pubsub_receive got {len(messages)} message(s)")
-        for msg in messages:
-            print(f"- {repr(msg)}")
-
-        ack_ids = [m.ack_id for m in response.received_messages]
-        subscriber.acknowledge(subscription=subscription_path, ack_ids=ack_ids)
-        print(f"pubsub_receive ack messages")
-    return messages
-
-
-
-@retry.Retry(retry.if_exception_type(ValueError), timeout=TIMEOUT_SEC)
-def pubsub_wait_for_messages_raw(subscription_path: str) -> list[str]:
-    # Let the test decode content itself
-    from google.cloud import pubsub
-
-    subscriber = pubsub.SubscriberClient()
-    with subscriber:
-        print(f"pulling from subscription_path")
-        response = subscriber.pull(subscription=subscription_path, max_messages=10)
-
-        # Do not decode, let calling test do this.
-        messages = [m.message.data for m in response.received_messages]
         if not messages:
             raise ValueError("pubsub_wait_for_messages no messages received")
 

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -794,6 +794,7 @@ class Utils:
         parameters: dict[str, str] = {},
         project: str = PROJECT,
         region: str = REGION,
+        additional_experiments: dict[str,str] = {},
     ) -> str:
         import yaml
 
@@ -814,6 +815,11 @@ class Utils:
             f"--parameters={name}={value}"
             for name, value in {
                 **parameters,
+            }.items()
+        ] + [
+            f"--additional-experiments={name}={value}"
+            for name, value in {
+                **additional_experiments,
             }.items()
         ]
         logging.info(f"{cmd}")

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -831,7 +831,7 @@ class Utils:
         logging.info(f">> {Utils.dataflow_job_url(job_id, project, region)}")
         yield job_id
 
-        Utils.dataflow_jobs_cancel(job_id)
+        Utils.dataflow_jobs_cancel(job_id, region=region)
 
     @staticmethod
     def dataflow_extensible_template_run(

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -850,7 +850,7 @@ class Utils:
             f"--project={project}",
             f"--region={region}",
             f"--staging-location=gs://{bucket_name}/staging",
-            f"--temp-location'gs://{bucket_name}/staging",
+            f"--temp-location=gs://{bucket_name}/staging",
         ] + [
             f"--parameters={name}={value}"
             for name, value in {

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -163,7 +163,12 @@ def pubsub_wait_for_messages(subscription_path: str) -> list[str]:
 
     subscriber = pubsub.SubscriberClient()
     with subscriber:
+        print(f"pulling from subscription_path")
         response = subscriber.pull(subscription=subscription_path, max_messages=10)
+
+        print("Raw data received:")
+        print([str(m.message.data) for m in response.received_messages])
+
         messages = [m.message.data.decode("utf-8") for m in response.received_messages]
         if not messages:
             raise ValueError("pubsub_wait_for_messages no messages received")

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -850,6 +850,7 @@ class Utils:
             f"--project={project}",
             f"--region={region}",
             f"--staging-location=gs://{bucket_name}/staging",
+            f"--temp-location'gs://{bucket_name}/staging",
         ] + [
             f"--parameters={name}={value}"
             for name, value in {

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -166,10 +166,33 @@ def pubsub_wait_for_messages(subscription_path: str) -> list[str]:
         print(f"pulling from subscription_path")
         response = subscriber.pull(subscription=subscription_path, max_messages=10)
 
-        print("Raw data received:")
-        print([str(m.message.data) for m in response.received_messages])
-
         messages = [m.message.data.decode("utf-8") for m in response.received_messages]
+        if not messages:
+            raise ValueError("pubsub_wait_for_messages no messages received")
+
+        print(f"pubsub_receive got {len(messages)} message(s)")
+        for msg in messages:
+            print(f"- {repr(msg)}")
+
+        ack_ids = [m.ack_id for m in response.received_messages]
+        subscriber.acknowledge(subscription=subscription_path, ack_ids=ack_ids)
+        print(f"pubsub_receive ack messages")
+    return messages
+
+
+
+@retry.Retry(retry.if_exception_type(ValueError), timeout=TIMEOUT_SEC)
+def pubsub_wait_for_messages_raw(subscription_path: str) -> list[str]:
+    # Let the test decode content itself
+    from google.cloud import pubsub
+
+    subscriber = pubsub.SubscriberClient()
+    with subscriber:
+        print(f"pulling from subscription_path")
+        response = subscriber.pull(subscription=subscription_path, max_messages=10)
+
+        # Do not decode, let calling test do this.
+        messages = [m.message.data for m in response.received_messages]
         if not messages:
             raise ValueError("pubsub_wait_for_messages no messages received")
 

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -163,7 +163,6 @@ def pubsub_wait_for_messages(subscription_path: str) -> list[str]:
 
     subscriber = pubsub.SubscriberClient()
     with subscriber:
-        print(f"pulling from subscription_path")
         response = subscriber.pull(subscription=subscription_path, max_messages=10)
 
         messages = [m.message.data.decode("utf-8") for m in response.received_messages]

--- a/dataflow/conftest.py
+++ b/dataflow/conftest.py
@@ -855,7 +855,6 @@ class Utils:
             f"--gcs-location={template_path}",
             f"--project={project}",
             f"--region={region}",
-            f"--staging-location=gs://{bucket_name}/staging",
             f"--temp-location=gs://{bucket_name}/staging",
         ] + [
             f"--parameters={name}={value}"

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -26,14 +26,14 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
-RUN pip install --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt 
-
-RUN git clone https://github.com/google/gemma_pytorch.git
-RUN pip install ./gemma_pytorch
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt \
+    && git clone https://github.com/google/gemma_pytorch.git \
+    && pip install --no-cache-dir ./gemma_pytorch
 
 # Copy SDK entrypoint binary from Apache Beam image, which makes it possible to
-# use the image as SDK container image.
+# use the image as SDK container image. The Beam version should match the 
+# version specified in requirements.txt
 COPY --from=apache/beam_python3.10_sdk:2.56.0 /opt/apache/beam /opt/apache/beam
 
 # Copy Flex Template launcher binary from the launcher image, which makes it

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && apt-get install -y --no-install-recommends wget \
     && apt-get install -y --no-install-recommends git \
-    && && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
 RUN pip install --upgrade pip \

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -18,11 +18,12 @@ FROM ${SERVING_BUILD_IMAGE}
 
 WORKDIR /workspace
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends apt-utils
-RUN apt-get install -y --no-install-recommends curl
-RUN apt-get install -y --no-install-recommends wget
-RUN apt-get install -y --no-install-recommends git
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends apt-utils \
+    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends wget \
+    && apt-get install -y --no-install-recommends git \
+    && && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
 RUN pip install --upgrade pip \
@@ -31,8 +32,12 @@ RUN pip install --upgrade pip \
 RUN git clone https://github.com/google/gemma_pytorch.git
 RUN pip install ./gemma_pytorch
 
-# Copy files from official SDK image, including script/dependencies.
+# Copy SDK entrypoint binary from Apache Beam image, which makes it possible to
+# use the image as SDK container image.
 COPY --from=apache/beam_python3.10_sdk:2.56.0 /opt/apache/beam /opt/apache/beam
+
+# Copy Flex Template launcher binary from the launcher image, which makes it
+# possible to use the image as a Flex Template base image.
 COPY --from=gcr.io/dataflow-templates-base/python310-template-launcher-base:latest /opt/google/dataflow/python_template_launcher /opt/google/dataflow/python_template_launcher
 
 # Copy the model directory downloaded from Kaggle and the pipeline code.

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir --upgrade pip \
     && git clone https://github.com/google/gemma_pytorch.git \
-    && pip install --no-cache-dir -r requirements.txt
+    && pip install --no-cache-dir -r requirements.txt ./pytorch_gemma
 
 # Copy SDK entrypoint binary from Apache Beam image, which makes it possible to
 # use the image as SDK container image.

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -19,21 +19,17 @@ FROM ${SERVING_BUILD_IMAGE}
 WORKDIR /workspace
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends apt-utils \
-    && apt-get install -y --no-install-recommends curl \
-    && apt-get install -y --no-install-recommends wget \
-    && apt-get install -y --no-install-recommends git \
+    && apt-get install -y --no-install-recommends apt-utils curl wget git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt \
     && git clone https://github.com/google/gemma_pytorch.git \
-    && pip install --no-cache-dir ./gemma_pytorch
+    && pip install --no-cache-dir -r requirements.txt
 
 # Copy SDK entrypoint binary from Apache Beam image, which makes it possible to
-# use the image as SDK container image. The Beam version should match the 
-# version specified in requirements.txt
+# use the image as SDK container image.
+# The Beam version should match the version specified in requirements.txt
 COPY --from=apache/beam_python3.10_sdk:2.56.0 /opt/apache/beam /opt/apache/beam
 
 # Copy Flex Template launcher binary from the launcher image, which makes it

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -12,7 +12,7 @@
 
 # This uses Ubuntu with Python 3.10 and comes with CUDA drivers for
 # GPU use.
-ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.1.2-cuda11.8-cudnn8-runtime
+ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.3.1-cuda11.8-cudnn8-runtime
 
 FROM ${SERVING_BUILD_IMAGE}
 

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir --upgrade pip \
     && git clone https://github.com/google/gemma_pytorch.git \
-    && pip install --no-cache-dir -r requirements.txt ./pytorch_gemma
+    && pip install --no-cache-dir -r requirements.txt ./gemma_pytorch
 
 # Copy SDK entrypoint binary from Apache Beam image, which makes it possible to
 # use the image as SDK container image.

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -10,7 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This uses Ubuntu with Python 3.10
+# This uses Ubuntu with Python 3.10 and comes with CUDA drivers for
+# GPU use.
 ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.1.2-cuda11.8-cudnn8-runtime
 
 FROM ${SERVING_BUILD_IMAGE}

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This uses Ubuntu with Python 3.10
+ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.1.2-cuda11.8-cudnn8-runtime
+
+FROM ${SERVING_BUILD_IMAGE}
+
+WORKDIR /workspace
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends apt-utils
+RUN apt-get install -y --no-install-recommends curl
+RUN apt-get install -y --no-install-recommends wget
+RUN apt-get install -y --no-install-recommends git
+
+COPY requirements.txt requirements.txt
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt 
+
+RUN git clone https://github.com/google/gemma_pytorch.git
+RUN pip install ./gemma_pytorch
+
+# Copy files from official SDK image, including script/dependencies.
+COPY --from=apache/beam_python3.10_sdk:2.56.0 /opt/apache/beam /opt/apache/beam
+COPY --from=gcr.io/dataflow-templates-base/python310-template-launcher-base:latest /opt/google/dataflow/python_template_launcher /opt/google/dataflow/python_template_launcher
+
+# Copy the model directory downloaded from Kaggle and the pipeline code.
+COPY pytorch_model pytorch_model
+COPY custom_model_gemma.py custom_model_gemma.py
+
+ENV FLEX_TEMPLATE_PYTHON_PY_FILE="custom_model_gemma.py"
+
+# Set the entrypoint to Apache Beam SDK launcher.
+ENTRYPOINT ["/opt/apache/beam/boot"]

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -1,10 +1,10 @@
-# RunInference on Dataflow Streaming with Gemma and Flex Templates
+# RunInference on Dataflow streaming with Gemma and Flex Templates
 
 Gemma is a family of lightweight, state-of-the art open models built from research and technology used to create the Gemini models.
 You can use Gemma models in your Apache Beam inference pipelines with the `RunInference` transform.
 
 This example demonstrates how to use a Gemma model running on Pytorch in a streaming Dataflow pipeline that has Pub/Sub sources and sinks. This pipeline
-is deployed using flex templates.
+is deployed by using Flex Templates.
 
 For more information about using RunInference, see [Get started with AI/ML pipelines](https://beam.apache.org/documentation/ml/overview/) in the Apache Beam documentation.
 
@@ -14,7 +14,7 @@ Follow the steps in this section to create the necessary environment to run this
 
 ### Enable Google Cloud services
 
-This workflow uses multiple Google Cloud Platform products, including Dataflow, Pub/Sub, Google Cloud Storage, and Artifact Registry. Before you start the workflow, create a Google Cloud project that has the following services enabled:
+This workflow uses multiple Google Cloud products, including Dataflow, Pub/Sub, Google Cloud Storage, and Artifact Registry. Before you start the workflow, create a Google Cloud project that has the following services enabled:
 
 * Dataflow
 * Pub/Sub
@@ -27,7 +27,7 @@ Your Google Cloud project also needs to have Nvidia L4 GPU quota. For more infor
 
 ### Create a custom container
 
-To build a custom container, use Docker. This repository contains a Dockerfile that you can use to build your custom container. To build and push a container to Artifact Registry by using DockerFollow, follow the instructions in the [Build and push the image](https://cloud.google.com/dataflow/docs/guides/build-container-image#build_and_push_the_image) section of the "Build custom container images for Dataflow" page in the Google Cloud documentation.
+To build a custom container, use Docker. This repository contains a Dockerfile that you can use to build your custom container. To build and push a container to Artifact Registry by using DockerFollow, follow the instructions in the [Build and push the image](https://cloud.google.com/dataflow/docs/guides/build-container-image#build_and_push_the_image) section of "Build custom container images for Dataflow" in the Google Cloud documentation.
 
 ### Create Pub/Sub topics for input and output
 
@@ -56,23 +56,23 @@ Install Apache Beam and the dependencies required to run the pipeline in your lo
 pip install -U -r requirements.txt
 ```
 
-This example also requires having access to the base class for the Pytorch implementation of Gemma.
+This example also requires access to the base class for the PyTorch implementation of Gemma.
 ```
 git clone https://github.com/google/gemma_pytorch.git
 pip install ./gemma_pytorch
 ```
 
-## Code Overview
+## Code overview
 
 This section provides details about the custom model handler and the formatting `DoFn` used in this example.
 
 ### Custom model handler
-This notebook defines a custom model handler that loads the model by constructing a configuration object and loading the model's checkpoint from the local filesystem.
-This approach differs from Pytorch model loading process followed in the Beam Pytorch model handler, which is why a custom implementation is necessary. 
+This notebook defines a custom model handler that loads the model. The model handler constructs a configuration object and loads the model's checkpoint from the local filesystem.
+Because this approach differs from the PyTorch model loading process followed in the Beam PyTorch model handler, a custom implementation is necessary. 
 
 To customize the behavior of the handler, implement the following methods: `load_model`, `validate_inference_args`, and `share_model_across_processes`.
 
-The Pytorch implementation of the Gemma models has a `generate` method
+The PyTorch implementation of the Gemma models has a `generate` method
 that generates text based on a prompt. To route the prompts correctly, use this function in the `run_inference` function.
 
 ```py
@@ -159,7 +159,11 @@ class FormatOutput(beam.DoFn):
 ```
 
 ## Build the Flex Template
-Run the following code from the directory to build the Dataflow flex template. Replace `$TEMPLATE_FILE` with a GCS path written as a `.json` file. Set `SDK_CONTAINER_IMAGE` to the name Docker image created earlier and `$PROJECT` is the GCP project you created earlier. 
+Run the following code from the directory to build the Dataflow flex template.
+
+- Replace `$TEMPLATE_FILE` with a Google Cloud Storage path written as a JSON file.
+- Set `SDK_CONTAINER_IMAGE` to the name of the Docker image created previously.
+- `$PROJECT` is the Google Cloud project that you created previously. 
 
 ```sh
 gcloud dataflow flex-template build $TEMPLATE_FILE \
@@ -170,7 +174,7 @@ gcloud dataflow flex-template build $TEMPLATE_FILE \
 ```
 
 ## Start the pipeline
-Run the following code from the directory to start the Dataflow streaming pipeline. Replace `$TEMPLATE_FILE`, `$REGION`, `$GCS_BUCKET`, `$INPUT_SUBSCRIPTION`, `$OUTPUT_TOPIC`, `$SDK_CONTAINER_IMAGE`, and `$PROJECT` with the Google Cloud Project resources you created earlier. It may take around 15 minutes for the worker to start up and begin accepting messages from the input Pub/Sub topic. 
+To start the Dataflow streaming job, run the following code from the directory. Replace `$TEMPLATE_FILE`, `$REGION`, `$GCS_BUCKET`, `$INPUT_SUBSCRIPTION`, `$OUTPUT_TOPIC`, `$SDK_CONTAINER_IMAGE`, and `$PROJECT` with the Google Cloud project resources you created previously. It might take as much as 15 minutes for the worker to start up and to begin accepting messages from the input Pub/Sub topic. 
 
 ```sh
 gcloud dataflow flex-template run "gemma-flex-`date +%Y%m%d-%H%M%S`" \
@@ -188,7 +192,7 @@ gcloud dataflow flex-template run "gemma-flex-`date +%Y%m%d-%H%M%S`" \
 
 ## Send a prompt to the model and check the response
 
-In the Google Cloud console, navigate to the Pub/Sub topics page, and then select your input topic. On the **Messages** tab, click **Publish Message**. Add a message into the pipeline for the Dataflow job to pick up and pass through the model. The Dataflow job outputs the response to the Pub/Sub sink topic. To check the response from the model, you can manually pull messages from the destination topic. For more information, see [Publish messages](https://cloud.google.com/pubsub/docs/publisher#publish-messages) in the Google Cloud documentation.
+In the Google Cloud console, navigate to the Pub/Sub topics page, and then select your input topic. On the **Messages** tab, click **Publish Message**. Add a message for the Dataflow job to pick up and pass through the model. The Dataflow job outputs the response to the Pub/Sub sink topic. To check the response from the model, you can manually pull messages from the destination topic. For more information, see [Publish messages](https://cloud.google.com/pubsub/docs/publisher#publish-messages) in the Google Cloud documentation.
 
 ## Clean up resources
 

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -1,6 +1,6 @@
 # RunInference on Dataflow streaming with Gemma and Flex Templates
 
-Gemma is a family of lightweight, state-of-the art open models built from research and technology used to create the Gemini models.
+Gemma is a family of lightweight, state-of-the-art open models built from research and technology used to create the Gemini models.
 You can use Gemma models in your Apache Beam inference pipelines with the `RunInference` transform.
 
 This example demonstrates how to use a Gemma model running on Pytorch in a streaming Dataflow pipeline that has Pub/Sub sources and sinks. This pipeline

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -153,8 +153,8 @@ gcloud dataflow flex-template run "gemma-flex-`date +%Y%m%d-%H%M%S`" \
   --parameters messages_subscription=$INPUT_SUBSCRIPTION \
   --parameters responses_topic=$OUTPUT_TOPIC \
   --parameters device="GPU" \
-  --sdk_container_image=$SDK_CONTAINER_IMAGE \
-  --dataflow_service_options="worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx" \
+  --parameters sdk_container_image=$SDK_CONTAINER_IMAGE \
+  --additional-experiments "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx" \
   --project $PROJECT \
   --worker-machine-type "g2-standard-4"
 ```

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -154,7 +154,7 @@ gcloud dataflow flex-template run "gemma-flex-`date +%Y%m%d-%H%M%S`" \
   --parameters responses_topic=$OUTPUT_TOPIC \
   --parameters device="GPU" \
   --parameters sdk_container_image=$SDK_CONTAINER_IMAGE \
-  --additional-experiments "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx" \
+  --additional-experiments "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver" \
   --project $PROJECT \
   --worker-machine-type "g2-standard-4"
 ```

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -27,7 +27,7 @@ Your Google Cloud project also needs to have Nvidia L4 GPU quota. For more infor
 
 ### Create a custom container
 
-To build a custom container, use Docker. This repository contains a Dockerfile that you can use to build your custom container. To build and push a container to Artifact Registry by using DockerFollow, follow the instructions in the [Build and push the image](https://cloud.google.com/dataflow/docs/guides/build-container-image#build_and_push_the_image) section of "Build custom container images for Dataflow" in the Google Cloud documentation.
+To build a custom container, use Docker. This repository contains a Dockerfile that you can use to build your custom container. To build and push a container to Artifact Registry by using Docker or Cloud Build, follow the instructions in the [Build and push the image](https://cloud.google.com/dataflow/docs/guides/build-container-image#build_and_push_the_image) section of "Build custom container images for Dataflow" in the Google Cloud documentation.
 
 ### Create Pub/Sub topics for input and output
 
@@ -113,6 +113,8 @@ class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
             self._device = torch.device('cpu')
         self._env_vars = {}
 
+    # This allows us to load a large model only once per worker VM, 
+    # which decreases the pipeline memory requirements.
     def share_model_across_processes(self) -> bool:
         return True
 

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -67,7 +67,7 @@ pip install ./gemma_pytorch
 This section provides details about the custom model handler and the formatting `DoFn` used in this example.
 
 ### Custom model handler
-This notebook defines a custom model handler that loads the model. The model handler constructs a configuration object and loads the model's checkpoint from the local filesystem.
+This example defines a custom model handler that loads the model. The model handler constructs a configuration object and loads the model's checkpoint from the local filesystem.
 Because this approach differs from the PyTorch model loading process followed in the Beam PyTorch model handler, a custom implementation is necessary. 
 
 To customize the behavior of the handler, implement the following methods: `load_model`, `validate_inference_args`, and `share_model_across_processes`.

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -1,0 +1,201 @@
+# RunInference on Dataflow Streaming with Gemma and Flex Templates
+
+Gemma is a family of lightweight, state-of-the art open models built from research and technology used to create the Gemini models.
+You can use Gemma models in your Apache Beam inference pipelines with the `RunInference` transform.
+
+This example demonstrates how to use a Gemma model running on Pytorch in a streaming Dataflow pipeline that has Pub/Sub sources and sinks. This pipeline
+is deployed using flex templates.
+
+For more information about using RunInference, see [Get started with AI/ML pipelines](https://beam.apache.org/documentation/ml/overview/) in the Apache Beam documentation.
+
+## Before you begin
+
+Follow the steps in this section to create the necessary environment to run this workflow.
+
+### Enable Google Cloud services
+
+This workflow uses multiple Google Cloud Platform products, including Dataflow, Pub/Sub, Google Cloud Storage, and Artifact Registry. Before you start the workflow, create a Google Cloud project that has the following services enabled:
+
+* Dataflow
+* Pub/Sub
+* Google Cloud Storage
+* Artifact Registry
+
+Using these services incurs billing charges.
+
+Your Google Cloud project also needs to have Nvidia L4 GPU quota. For more information, see [GPU quota](https://cloud.google.com/compute/resource-usage#gpu_quota) in the Google Cloud documentation.
+
+### Create a custom container
+
+To build a custom container, use Docker. This repository contains a Dockerfile that you can use to build your custom container. To build and push a container to Artifact Registry by using DockerFollow, follow the instructions in the [Build and push the image](https://cloud.google.com/dataflow/docs/guides/build-container-image#build_and_push_the_image) section of the "Build custom container images for Dataflow" page in the Google Cloud documentation.
+
+### Create Pub/Sub topics for input and output
+
+To create your Pub/Sub source and sink, follow the instructions in [Create a Pub/Sub topic](https://cloud.google.com/pubsub/docs/create-topic#pubsub_create_topic-Console) in the Google Cloud documentation. For this example, create two topics, one input topic and one output topic. For input, the topic must have a subscription that you can provide to the Gemma model. 
+
+### Download and save the model
+
+Save a version of the Gemma 2B model. Downloaded the model from [Kaggle](https://www.kaggle.com/models/google/gemma/pyTorch/1.1-2b-it). This download is a `.tar.gz` archive. Extract the archive into a directory and name it `pytorch_model`. 
+
+### Optional: Create a new virtual environment
+
+The Python major and minor version contained in the custom container must match the environment used for job submission. For this example, use Python version 3.10.
+
+```
+python3.10 -m venv /tmp/venv
+source /tmp/venv/bin/activate
+```
+
+For more information, see [venv — Creation of virtual environments](https://docs.python.org/3/library/venv.html).
+
+### Install dependencies
+
+Install Apache Beam and the dependencies required to run the pipeline in your local environment. 
+
+```
+pip install -U -r requirements.txt
+```
+
+This example also requires having access to the base class for the Pytorch implementation of Gemma.
+```
+git clone https://github.com/google/gemma_pytorch.git
+pip install ./gemma_pytorch
+```
+
+## Code Overview
+
+This section provides details about the custom model handler and the formatting `DoFn` used in this example.
+
+### Custom model handler
+This notebook defines a custom model handler that loads the model by constructing a configuration object and loading the model's checkpoint from the local filesystem.
+This approach differs from Pytorch model loading process followed in the Beam Pytorch model handler, which is why a custom implementation is necessary. 
+
+To customize the behavior of the handler, implement the following methods: `load_model`, `validate_inference_args`, and `share_model_across_processes`.
+
+The Pytorch implementation of the Gemma models has a `generate` method
+that generates text based on a prompt. To route the prompts correctly, use this function in the `run_inference` function.
+
+```py
+class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
+                                            GemmaForCausalLM]):
+    def __init__(self,
+                 model_variant: str,
+                 checkpoint_path: str,
+                 tokenizer_path: str,
+                 device: Optional[str] = 'cpu'):
+        """ Implementation of the ModelHandler interface for Gemma-on-Pytorch
+        using text as input.
+
+        Example Usage::
+
+          pcoll | RunInference(GemmaPytorchHandler())
+
+        Args:
+          model_variant: The Gemma model name.
+          checkpoint_path: the path to a local copy of gemma model weights.
+          tokenizer_path: the path to a local copy of the gemma tokenizer
+          device: optional. the device to run inference on. can be either
+            'cpu' or 'gpu', defaults to cpu. 
+        """
+        model_config = get_config_for_2b(
+        ) if "2b" in model_variant else get_config_for_7b()
+        model_config.tokenizer = tokenizer_path
+        model_config.quant = 'quant' in model_variant
+        model_config.tokenizer = tokenizer_path
+
+        self._model_config = model_config
+        self._checkpoint_path = checkpoint_path
+        if device == 'GPU':
+            logging.info("Device is set to CUDA")
+            self._device = torch.device('cuda')
+        else:
+            logging.info("Device is set to CPU")
+            self._device = torch.device('cpu')
+        self._env_vars = {}
+
+    def share_model_across_processes(self) -> bool:
+        return True
+
+    def load_model(self) -> GemmaForCausalLM:
+        """Loads and initializes a model for processing."""
+        torch.set_default_dtype(self._model_config.get_dtype())
+        model = GemmaForCausalLM(self._model_config)
+        model.load_weights(self._checkpoint_path)
+        model = model.to(self._device).eval()
+        return model
+
+    def run_inference(
+        self,
+        batch: Sequence[str],
+        model: GemmaForCausalLM,
+        inference_args: Optional[Dict[str, Any]] = None
+    ) -> Iterable[PredictionResult]:
+        """Runs inferences on a batch of text strings.
+
+        Args:
+          batch: A sequence of examples as text strings.
+          model: The Gemma model being used.
+          inference_args: Any additional arguments for an inference.
+
+        Returns:
+          An Iterable of type PredictionResult.
+        """
+        # Loop each text string, and use a tuple to store the inference results.
+        predictions = []
+        result = model.generate(prompts=batch, device=self._device)
+        predictions.append(result)
+        return [PredictionResult(x, y) for x, y in zip(batch, predictions)]
+
+```
+
+### Formatting DoFn
+
+The output from a keyed model handler is a tuple of the form `(key, PredictionResult)`. To format that output into a string before sending it to the answer Pub/Sub topic, use an extra `DoFn`.
+
+```py
+class FormatOutput(beam.DoFn):
+  def process(self, element, *args, **kwargs):
+    yield "Key : {key}, Input: {input}, Output: {output}".format(key=element[0], input=element[1].example, output=element[1].inference)
+```
+
+## Build the Flex Template
+Run the following code from the directory to build the Dataflow flex template. Replace `$TEMPLATE_FILE` with a GCS path written as a `.json` file. Set `SDK_CONTAINER_IMAGE` to the name Docker image created earlier and `$PROJECT` is the GCP project you created earlier. 
+
+```sh
+gcloud dataflow flex-template build $TEMPLATE_FILE \
+  --image $SDK_CONTAINER_IMAGE \
+  --sdk-language "PYTHON" \
+  --metadata-file metadata.json \
+  --project $PROJECT
+```
+
+## Start the pipeline
+Run the following code from the directory to start the Dataflow streaming pipeline. Replace `$TEMPLATE_FILE`, `$REGION`, `$GCS_BUCKET`, `$INPUT_SUBSCRIPTION`, `$OUTPUT_TOPIC`, `$SDK_CONTAINER_IMAGE`, and `$PROJECT` with the Google Cloud Project resources you created earlier. It may take around 15 minutes for the worker to start up and begin accepting messages from the input Pub/Sub topic. 
+
+```sh
+gcloud dataflow flex-template run "gemma-flex-`date +%Y%m%d-%H%M%S`" \
+  --template-file-gcs-location $TEMPLATE_FILE \
+  --region $REGION \
+  --staging-location $GCS_BUCKET \
+  --parameters messages_subscription=$INPUT_SUBSCRIPTION \
+  --parameters responses_topic=$OUTPUT_TOPIC \
+  --parameters device="GPU" \
+  --parameters sdk_container_image=$SDK_CONTAINER_IMAGE \
+  --parameters dataflow_service_options="worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx" \
+  --project $PROJECT \
+  --worker-machine-type "g2-standard-4"
+```
+
+## Send a prompt to the model and check the response
+
+In the Google Cloud console, navigate to the Pub/Sub topics page, and then select your input topic. On the **Messages** tab, click **Publish Message**. Add a message into the pipeline for the Dataflow job to pick up and pass through the model. The Dataflow job outputs the response to the Pub/Sub sink topic. To check the response from the model, you can manually pull messages from the destination topic. For more information, see [Publish messages](https://cloud.google.com/pubsub/docs/publisher#publish-messages) in the Google Cloud documentation.
+
+## Clean up resources
+
+To avoid incurring charges to your Google Cloud account for the resources used in this example, clean up the resources that you created.
+
+
+*   Cancel the streaming Dataflow job.
+*   Delete the Pub/Sub topic and subscriptions.
+*   Delete the custom container from Artifact Registry.
+*   Empty the `tmp` directory of your Google Cloud Storage bucket.

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -113,11 +113,6 @@ class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
             self._device = torch.device('cpu')
         self._env_vars = {}
 
-    # This allows us to load a large model only once per worker VM, 
-    # which decreases the pipeline memory requirements.
-    def share_model_across_processes(self) -> bool:
-        return True
-
     def load_model(self) -> GemmaForCausalLM:
         """Loads and initializes a model for processing."""
         torch.set_default_dtype(self._model_config.get_dtype())
@@ -125,29 +120,6 @@ class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
         model.load_weights(self._checkpoint_path)
         model = model.to(self._device).eval()
         return model
-
-    def run_inference(
-        self,
-        batch: Sequence[str],
-        model: GemmaForCausalLM,
-        inference_args: Optional[Dict[str, Any]] = None
-    ) -> Iterable[PredictionResult]:
-        """Runs inferences on a batch of text strings.
-
-        Args:
-          batch: A sequence of examples as text strings.
-          model: The Gemma model being used.
-          inference_args: Any additional arguments for an inference.
-
-        Returns:
-          An Iterable of type PredictionResult.
-        """
-        # Loop each text string, and use a tuple to store the inference results.
-        predictions = []
-        result = model.generate(prompts=batch, device=self._device)
-        predictions.append(result)
-        return [PredictionResult(x, y) for x, y in zip(batch, predictions)]
-
 ```
 
 ### Formatting DoFn

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -171,6 +171,7 @@ To avoid incurring charges to your Google Cloud account for the resources used i
 
 
 *   Cancel the streaming Dataflow job.
+*   **Optional**: Archive the streaming Dataflow job.
 *   Delete the Pub/Sub topic and subscriptions.
 *   Delete the custom container from Artifact Registry.
 *   Delete the created GCS bucket.

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -10,7 +10,7 @@ For more information about using RunInference, see [Get started with AI/ML pipel
 
 ## Before you begin
 
-Make sure you have followed the [Dataflow setup instructions](../../README.md).
+Make sure you have followed the [Dataflow setup instructions](/dataflow/README.md).
 
 Follow the steps in this section to create the necessary environment to run this workflow.
 

--- a/dataflow/gemma-flex-template/README.md
+++ b/dataflow/gemma-flex-template/README.md
@@ -121,9 +121,11 @@ class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
 The output from a keyed model handler is a tuple of the form `(key, PredictionResult)`. To format that output into a string before sending it to the answer Pub/Sub topic, use an extra `DoFn`.
 
 ```py
-class FormatOutput(beam.DoFn):
-  def process(self, element, *args, **kwargs):
-    yield "Key : {key}, Input: {input}, Output: {output}".format(key=element[0], input=element[1].example, output=element[1].inference)
+| "Format output" >> beam.Map(
+    lambda response: json.dumps(
+        {"input": response.example, "outputs": response.inference}
+    )
+)
 ```
 
 ## Build the Flex Template

--- a/dataflow/gemma-flex-template/custom_model_gemma.py
+++ b/dataflow/gemma-flex-template/custom_model_gemma.py
@@ -22,7 +22,6 @@ from apache_beam.ml.inference.base import ModelHandler
 from apache_beam.ml.inference.base import PredictionResult
 from apache_beam.ml.inference.base import RunInference
 from apache_beam.options.pipeline_options import PipelineOptions
-from apache_beam.options.pipeline_options import SetupOptions
 
 from gemma.config import get_config_for_2b
 from gemma.config import get_config_for_7b

--- a/dataflow/gemma-flex-template/custom_model_gemma.py
+++ b/dataflow/gemma-flex-template/custom_model_gemma.py
@@ -14,11 +14,7 @@
 
 import logging
 
-from typing import Any
-from typing import Dict
-from typing import Iterable
-from typing import Optional
-from typing import Sequence
+from typing import Any, Dict, Iterable, Optional, Sequence
 
 import apache_beam as beam
 from apache_beam.ml.inference.base import ModelHandler
@@ -178,5 +174,5 @@ if __name__ == "__main__":
                 handler)  # Send the prompts to the model and get responses.
             |
             "Format Output" >> beam.ParDo(FormatOutput())  # Format the output.
-            | "Publish Result" >> beam.io.gcp.pubsub.WriteStringsToPubSub(
-                topic=args.responses_topic))
+            | "Publish Result" >>
+            beam.io.gcp.pubsub.WriteToPubSub(topic=args.responses_topic))

--- a/dataflow/gemma-flex-template/custom_model_gemma.py
+++ b/dataflow/gemma-flex-template/custom_model_gemma.py
@@ -72,6 +72,9 @@ class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
         self._env_vars = {}
 
     def share_model_across_processes(self) -> bool:
+        """Allows us to load a model only once per worker VM, decreasing
+        pipeline memory requirements.
+        """
         return True
 
     def load_model(self) -> GemmaForCausalLM:

--- a/dataflow/gemma-flex-template/custom_model_gemma.py
+++ b/dataflow/gemma-flex-template/custom_model_gemma.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-
 from collections.abc import Iterable, Sequence
+import logging
 from typing import Any, Optional
 
 import apache_beam as beam

--- a/dataflow/gemma-flex-template/custom_model_gemma.py
+++ b/dataflow/gemma-flex-template/custom_model_gemma.py
@@ -1,0 +1,179 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import Optional
+from typing import Sequence
+
+import apache_beam as beam
+from apache_beam.ml.inference.base import ModelHandler
+from apache_beam.ml.inference.base import PredictionResult
+from apache_beam.ml.inference.base import RunInference
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
+
+import torch
+
+from gemma.config import get_config_for_2b
+from gemma.config import get_config_for_7b
+from gemma.model import GemmaForCausalLM
+
+
+class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
+                                            GemmaForCausalLM]):
+    def __init__(self,
+                 model_variant: str,
+                 checkpoint_path: str,
+                 tokenizer_path: str,
+                 device: Optional[str] = 'cpu'):
+        """ Implementation of the ModelHandler interface for Gemma-on-Pytorch
+        using text as input.
+
+        Example Usage::
+
+          pcoll | RunInference(GemmaPytorchHandler())
+
+        Args:
+          model_variant: The Gemma model name.
+          checkpoint_path: the path to a local copy of gemma model weights.
+          tokenizer_path: the path to a local copy of the gemma tokenizer
+          device: optional. the device to run inference on. can be either
+            'cpu' or 'gpu', defaults to cpu. 
+        """
+        model_config = get_config_for_2b(
+        ) if "2b" in model_variant else get_config_for_7b()
+        model_config.tokenizer = tokenizer_path
+        model_config.quant = 'quant' in model_variant
+        model_config.tokenizer = tokenizer_path
+
+        self._model_config = model_config
+        self._checkpoint_path = checkpoint_path
+        if device == 'GPU':
+            logging.info("Device is set to CUDA")
+            self._device = torch.device('cuda')
+        else:
+            logging.info("Device is set to CPU")
+            self._device = torch.device('cpu')
+        self._env_vars = {}
+
+    def share_model_across_processes(self) -> bool:
+        return True
+
+    def load_model(self) -> GemmaForCausalLM:
+        """Loads and initializes a model for processing."""
+        torch.set_default_dtype(self._model_config.get_dtype())
+        model = GemmaForCausalLM(self._model_config)
+        model.load_weights(self._checkpoint_path)
+        model = model.to(self._device).eval()
+        return model
+
+    def run_inference(
+        self,
+        batch: Sequence[str],
+        model: GemmaForCausalLM,
+        inference_args: Optional[Dict[str, Any]] = None
+    ) -> Iterable[PredictionResult]:
+        """Runs inferences on a batch of text strings.
+
+        Args:
+          batch: A sequence of examples as text strings.
+          model: The Gemma model being used.
+          inference_args: Any additional arguments for an inference.
+
+        Returns:
+          An Iterable of type PredictionResult.
+        """
+        # Loop each text string, and use a tuple to store the inference results.
+        predictions = []
+        result = model.generate(prompts=batch, device=self._device)
+        predictions.append(result)
+        return [PredictionResult(x, y) for x, y in zip(batch, predictions)]
+
+
+class FormatOutput(beam.DoFn):
+    def process(self, element, *args, **kwargs):
+        yield "Input: {input}, Output: {output}".format(
+            input=element.example, output=element.inference)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--messages_subscription",
+        required=True,
+        help="Pub/Sub subscription for input text messages",
+    )
+    parser.add_argument(
+        "--responses_topic",
+        required=True,
+        help="Pub/Sub topic for output text responses",
+    )
+    parser.add_argument(
+        "--model_variant",
+        required=False,
+        default="gemma-2b-it",
+        help="name of the gemma variant being used",
+    )
+    parser.add_argument(
+        "--checkpoint_path",
+        required=False,
+        default="pytorch_model/gemma-2b-it.ckpt",
+        help="path to the Gemma model weights in the custom worker container",
+    )
+    parser.add_argument(
+        "--tokenizer_path",
+        required=False,
+        default="pytorch_model/tokenizer.model",
+        help="path to the Gemma tokenizer in the custom worker container",
+    )
+    parser.add_argument(
+        "--device",
+        required=False,
+        default="cpu",
+        help="device to run the model on",
+    )
+
+    args, beam_args = parser.parse_known_args()
+
+    config = get_config_for_2b()
+
+    logging.getLogger().setLevel(logging.INFO)
+    beam_options = PipelineOptions(
+        beam_args,
+        streaming=True,
+    )
+    beam_options.view_as(SetupOptions).save_main_session = True
+
+    handler = GemmaPytorchModelHandler(model_variant=args.model_variant,
+                                       checkpoint_path=args.checkpoint_path,
+                                       tokenizer_path=args.tokenizer_path,
+                                       device=args.device)
+
+    with beam.Pipeline(options=beam_options) as p:
+        _ = (
+            p | "Read Topic" >>
+            beam.io.ReadFromPubSub(subscription=args.messages_subscription)
+            | "Parse" >> beam.Map(lambda x: x.decode("utf-8"))
+            | "RunInference-Gemma" >> RunInference(
+                handler)  # Send the prompts to the model and get responses.
+            |
+            "Format Output" >> beam.ParDo(FormatOutput())  # Format the output.
+            | "Publish Result" >> beam.io.gcp.pubsub.WriteStringsToPubSub(
+                topic=args.responses_topic))

--- a/dataflow/gemma-flex-template/custom_model_gemma.py
+++ b/dataflow/gemma-flex-template/custom_model_gemma.py
@@ -27,11 +27,11 @@ from apache_beam.ml.inference.base import RunInference
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
 
-import torch
-
 from gemma.config import get_config_for_2b
 from gemma.config import get_config_for_7b
 from gemma.model import GemmaForCausalLM
+
+import torch
 
 
 class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
@@ -53,7 +53,7 @@ class GemmaPytorchModelHandler(ModelHandler[str, PredictionResult,
           checkpoint_path: the path to a local copy of gemma model weights.
           tokenizer_path: the path to a local copy of the gemma tokenizer
           device: optional. the device to run inference on. can be either
-            'cpu' or 'gpu', defaults to cpu. 
+            'cpu' or 'gpu', defaults to cpu.
         """
         model_config = get_config_for_2b(
         ) if "2b" in model_variant else get_config_for_7b()

--- a/dataflow/gemma-flex-template/custom_model_gemma.py
+++ b/dataflow/gemma-flex-template/custom_model_gemma.py
@@ -14,8 +14,8 @@
 
 import logging
 
-from typing import Any, Optional
 from collections.abc import Iterable, Sequence
+from typing import Any, Optional
 
 import apache_beam as beam
 from apache_beam.ml.inference.base import ModelHandler

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -46,7 +46,7 @@ from conftest import Utils
 
 import pytest
 
-DATAFLOW_MACHINE_TYPE = "e2-standard-4"
+DATAFLOW_MACHINE_TYPE = "g2-standard-4"
 GEMMA_GCS = "gs://perm-dataflow-gemma-example-testdata/pytorch_model"
 NAME = "dataflow/gemma-flex-template/streaming"
 
@@ -117,10 +117,13 @@ def dataflow_job(
         parameters={
             "messages_subscription": messages_subscription,
             "responses_topic": responses_topic,
-            "device": "CPU",
+            "device": "GPU",
             "sdk_container_image": f"gcr.io/{project}/{flex_template_image}",
             "machine_type": f"{DATAFLOW_MACHINE_TYPE}",
         },
+        additional_experiments={
+            "worker_accelerator" : "type:nvidia-l4;count:1;install-nvidia-driver:5xx",
+        }
     )
 
 

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -53,6 +53,7 @@ NAME = "dataflow/gemma-flex-template/streaming"
 # There are limited resources in us-central1, so change to a known good region.
 REGION = "us-west1"
 
+
 @pytest.fixture(scope="session")
 def test_name() -> str:
     # Many fixtures expect a fixture called `test_name`, so be sure to define it!

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -56,9 +56,11 @@ def test_name() -> str:
     # Many fixtures expect a fixture called `test_name`, so be sure to define it!
     return "dataflow/gemma-flex-template"
 
+
 @pytest.fixture(scope="session")
 def bucket_name(utils: Utils) -> str:
     yield from utils.storage_bucket(NAME)
+
 
 @pytest.fixture(scope="session")
 def messages_topic(pubsub_topic: Callable[[str], str]) -> str:
@@ -81,6 +83,7 @@ def responses_subscription(pubsub_subscription: Callable[[str, str], str],
                            responses_topic: str) -> str:
     return pubsub_subscription("responses", responses_topic)
 
+
 @pytest.fixture(scope="session")
 def flex_template_image(utils: Utils) -> str:
     #conftest.run_cmd("gsutil", "cp", "-r", GEMMA_GCS, ".")
@@ -88,19 +91,22 @@ def flex_template_image(utils: Utils) -> str:
 
 
 @pytest.fixture(scope="session")
-def flex_template_path(utils: Utils, bucket_name: str, flex_template_image: str) -> str:
-    yield from utils.dataflow_flex_template_build(bucket_name, flex_template_image)
+def flex_template_path(utils: Utils, bucket_name: str,
+                       flex_template_image: str) -> str:
+    yield from utils.dataflow_flex_template_build(bucket_name,
+                                                  flex_template_image)
+
 
 @pytest.fixture(scope="session")
 def dataflow_job(
-    utils: Utils,
-    project: str,
-    location: str,
-    bucket_name: str,
-    flex_template_image: str,
-    flex_template_path: str,
-    messages_subscription: str,
-    responses_topic: str,
+        utils: Utils,
+        project: str,
+        location: str,
+        bucket_name: str,
+        flex_template_image: str,
+        flex_template_path: str,
+        messages_subscription: str,
+        responses_topic: str,
 ) -> str:
     yield from utils.dataflow_flex_template_run(
         job_name=NAME,
@@ -108,14 +114,22 @@ def dataflow_job(
         bucket_name=bucket_name,
         project=project,
         region=location,
-        parameters={"messages_subscription": messages_subscription,
-                    "responses_topic": responses_topic,
-                    "device": "CPU",
-                    "sdk_container_image": f"gcr.io/{project}/{flex_template_image}",
-                    "machine_type": f"{DATAFLOW_MACHINE_TYPE}",
-                    "dataflow_service_options": "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx",
-                    },
+        parameters={
+            "messages_subscription":
+            messages_subscription,
+            "responses_topic":
+            responses_topic,
+            "device":
+            "CPU",
+            "sdk_container_image":
+            f"gcr.io/{project}/{flex_template_image}",
+            "machine_type":
+            f"{DATAFLOW_MACHINE_TYPE}",
+            "dataflow_service_options":
+            "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx",
+        },
     )
+
 
 @pytest.mark.timeout(7200)
 def test_pipeline_dataflow(

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -120,7 +120,7 @@ def dataflow_job(
             "responses_topic":
             responses_topic,
             "device":
-            "CPU",
+            "GPU",
             "sdk_container_image":
             f"gcr.io/{project}/{flex_template_image}",
             "machine_type":

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -50,6 +50,8 @@ DATAFLOW_MACHINE_TYPE = "g2-standard-4"
 GEMMA_GCS = "gs://perm-dataflow-gemma-example-testdata/pytorch_model"
 NAME = "dataflow/gemma-flex-template/streaming"
 
+# There are limited resources in us-central1, so change to a known good region.
+REGION = "us-west1"
 
 @pytest.fixture(scope="session")
 def test_name() -> str:
@@ -113,7 +115,7 @@ def dataflow_job(
         template_path=flex_template_path,
         bucket_name=bucket_name,
         project=project,
-        region=location,
+        region=REGION,
         parameters={
             "messages_subscription": messages_subscription,
             "responses_topic": responses_topic,
@@ -138,11 +140,11 @@ def test_pipeline_dataflow(
 ) -> None:
     print(f"Waiting for the Dataflow workers to start: {dataflow_job}")
     conftest.wait_until(
-        lambda: conftest.dataflow_num_workers(project, location, dataflow_job)
+        lambda: conftest.dataflow_num_workers(project, REGION, dataflow_job)
         > 0,
         "workers are running",
     )
-    num_workers = conftest.dataflow_num_workers(project, location,
+    num_workers = conftest.dataflow_num_workers(project, REGION,
                                                 dataflow_job)
     print(f"Dataflow job num_workers: {num_workers}")
 

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -120,6 +120,7 @@ def dataflow_job(
             "device": "GPU",
             "sdk_container_image": f"gcr.io/{project}/{flex_template_image}",
             "machine_type": f"{DATAFLOW_MACHINE_TYPE}",
+            "disk_size_gb": "50",
         },
         additional_experiments={
             "worker_accelerator" : "type:nvidia-l4;count:1;install-nvidia-driver",

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -129,7 +129,7 @@ def dataflow_job(
     )
 
 
-@pytest.mark.timeout(7200)
+@pytest.mark.timeout(5400)
 def test_pipeline_dataflow(
         project: str,
         location: str,

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -1,0 +1,143 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end tests.
+
+1. Set your project.
+    export GOOGLE_CLOUD_PROJECT="my-project-id"
+
+2. To use an existing bucket, set it without the 'gs://' prefix.
+    export GOOGLE_CLOUD_BUCKET="my-bucket-name"
+
+3. Change directory to the sample location.
+    cd dataflow/gemma-flex-template
+
+4. Set the PYTHONPATH to where the conftest is located.
+    export PYTHONPATH=..
+
+OPTION A: Run tests with pytest, you can use -k to run specific tests
+    python -m venv env
+    source env/bin/activate
+    pip install -r requirements.txt -r requirements-test.txt
+    pip check
+    python -m pytest --verbose -s
+
+OPTION B: Run tests with nox
+    pip install nox
+    nox -s py-3.10
+
+NOTE: For the tests to find the conftest in the testing infrastructure,
+      add the PYTHONPATH to the "env" in your noxfile_config.py file.
+"""
+from collections.abc import Callable, Iterator
+
+import conftest  # python-docs-samples/dataflow/conftest.py
+from conftest import Utils
+
+import pytest
+
+DATAFLOW_MACHINE_TYPE = "g2-standard-4"
+GEMMA_GCS = "gs://perm-dataflow-gemma-example-testdata/pytorch_model"
+NAME = "dataflow/gemma-flex-template/streaming"
+
+
+@pytest.fixture(scope="session")
+def test_name() -> str:
+    # Many fixtures expect a fixture called `test_name`, so be sure to define it!
+    return "dataflow/gemma-flex-template"
+
+@pytest.fixture(scope="session")
+def bucket_name(utils: Utils) -> str:
+    yield from utils.storage_bucket(NAME)
+
+@pytest.fixture(scope="session")
+def messages_topic(pubsub_topic: Callable[[str], str]) -> str:
+    return pubsub_topic("messages")
+
+
+@pytest.fixture(scope="session")
+def messages_subscription(pubsub_subscription: Callable[[str, str], str],
+                          messages_topic: str) -> str:
+    return pubsub_subscription("messages", messages_topic)
+
+
+@pytest.fixture(scope="session")
+def responses_topic(pubsub_topic: Callable[[str], str]) -> str:
+    return pubsub_topic("responses")
+
+
+@pytest.fixture(scope="session")
+def responses_subscription(pubsub_subscription: Callable[[str, str], str],
+                           responses_topic: str) -> str:
+    return pubsub_subscription("responses", responses_topic)
+
+@pytest.fixture(scope="session")
+def flex_template_image(utils: Utils) -> str:
+    #conftest.run_cmd("gsutil", "cp", "-r", GEMMA_GCS, ".")
+    yield from utils.cloud_build_submit(NAME)
+
+
+@pytest.fixture(scope="session")
+def flex_template_path(utils: Utils, bucket_name: str, flex_template_image: str) -> str:
+    yield from utils.dataflow_flex_template_build(bucket_name, flex_template_image)
+
+@pytest.fixture(scope="session")
+def dataflow_job(
+    utils: Utils,
+    project: str,
+    location: str,
+    bucket_name: str,
+    flex_template_image: str,
+    flex_template_path: str,
+    messages_subscription: str,
+    responses_topic: str,
+) -> str:
+    yield from utils.dataflow_flex_template_run(
+        job_name=NAME,
+        template_path=flex_template_path,
+        bucket_name=bucket_name,
+        project=project,
+        region=location,
+        parameters={"messages_subscription": messages_subscription,
+                    "responses_topic": responses_topic,
+                    "device": "CPU",
+                    "sdk_container_image": f"gcr.io/{project}/{flex_template_image}",
+                    "machine_type": f"{DATAFLOW_MACHINE_TYPE}",
+                    "dataflow_service_options": "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx",
+                    },
+    )
+
+@pytest.mark.timeout(7200)
+def test_pipeline_dataflow(
+        project: str,
+        location: str,
+        dataflow_job: str,
+        messages_topic: str,
+        responses_subscription: str,
+) -> None:
+    print(f"Waiting for the Dataflow workers to start: {dataflow_job}")
+    conftest.wait_until(
+        lambda: conftest.dataflow_num_workers(project, location, dataflow_job)
+        > 0,
+        "workers are running",
+    )
+    num_workers = conftest.dataflow_num_workers(project, location,
+                                                dataflow_job)
+    print(f"Dataflow job num_workers: {num_workers}")
+
+    messages = ["This is a test for a Python sample."]
+    conftest.pubsub_publish(messages_topic, messages)
+
+    print(f"Waiting for messages on {responses_subscription}")
+    responses = conftest.pubsub_wait_for_messages(responses_subscription)
+    assert responses, "expected at least one response"

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -46,7 +46,7 @@ from conftest import Utils
 
 import pytest
 
-DATAFLOW_MACHINE_TYPE = "g2-standard-4"
+DATAFLOW_MACHINE_TYPE = "e2-standard-4"
 GEMMA_GCS = "gs://perm-dataflow-gemma-example-testdata/pytorch_model"
 NAME = "dataflow/gemma-flex-template/streaming"
 

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -39,6 +39,7 @@ OPTION B: Run tests with nox
 NOTE: For the tests to find the conftest in the testing infrastructure,
       add the PYTHONPATH to the "env" in your noxfile_config.py file.
 """
+import base64
 from collections.abc import Callable
 
 import conftest  # python-docs-samples/dataflow/conftest.py
@@ -153,5 +154,18 @@ def test_pipeline_dataflow(
     conftest.pubsub_publish(messages_topic, messages)
 
     print(f"Waiting for messages on {responses_subscription}")
-    responses = conftest.pubsub_wait_for_messages(responses_subscription)
+    responses = conftest.pubsub_wait_for_messages_raw(responses_subscription)
+
+    print(f"Received {len(responses)} responses(s)")
+
+    for msg in responses:
+        print(f"- {type(msg)} - {msg}")
+        try:
+            decoded = base64.b64encode(msg)
+            print(f"- {decoded}\n({msg})")
+        except (UnicodeDecodeError, TypeError) as e:
+            print(f"Error while parsing: {e}.")
+            print("Continuing, anyway.")
+
+
     assert responses, "expected at least one response"

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -115,16 +115,11 @@ def dataflow_job(
         project=project,
         region=location,
         parameters={
-            "messages_subscription":
-            messages_subscription,
-            "responses_topic":
-            responses_topic,
-            "device":
-            "CPU",
-            "sdk_container_image":
-            f"gcr.io/{project}/{flex_template_image}",
-            "machine_type":
-            f"{DATAFLOW_MACHINE_TYPE}",
+            "messages_subscription": messages_subscription,
+            "responses_topic": responses_topic,
+            "device": "CPU",
+            "sdk_container_image": f"gcr.io/{project}/{flex_template_image}",
+            "machine_type": f"{DATAFLOW_MACHINE_TYPE}",
         },
     )
 

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -39,7 +39,7 @@ OPTION B: Run tests with nox
 NOTE: For the tests to find the conftest in the testing infrastructure,
       add the PYTHONPATH to the "env" in your noxfile_config.py file.
 """
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 
 import conftest  # python-docs-samples/dataflow/conftest.py
 from conftest import Utils
@@ -86,7 +86,7 @@ def responses_subscription(pubsub_subscription: Callable[[str, str], str],
 
 @pytest.fixture(scope="session")
 def flex_template_image(utils: Utils) -> str:
-    #conftest.run_cmd("gsutil", "cp", "-r", GEMMA_GCS, ".")
+    conftest.run_cmd("gsutil", "cp", "-r", GEMMA_GCS, ".")
     yield from utils.cloud_build_submit(NAME)
 
 

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -122,7 +122,7 @@ def dataflow_job(
             "machine_type": f"{DATAFLOW_MACHINE_TYPE}",
         },
         additional_experiments={
-            "worker_accelerator" : "type:nvidia-l4;count:1;install-nvidia-driver:5xx",
+            "worker_accelerator" : "type:nvidia-l4;count:1;install-nvidia-driver",
         }
     )
 

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -120,13 +120,11 @@ def dataflow_job(
             "responses_topic":
             responses_topic,
             "device":
-            "GPU",
+            "CPU",
             "sdk_container_image":
             f"gcr.io/{project}/{flex_template_image}",
             "machine_type":
             f"{DATAFLOW_MACHINE_TYPE}",
-            "dataflow_service_options":
-            "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx",
         },
     )
 

--- a/dataflow/gemma-flex-template/e2e_test.py
+++ b/dataflow/gemma-flex-template/e2e_test.py
@@ -167,5 +167,4 @@ def test_pipeline_dataflow(
             print(f"Error while parsing: {e}.")
             print("Continuing, anyway.")
 
-
     assert responses, "expected at least one response"

--- a/dataflow/gemma-flex-template/metadata.json
+++ b/dataflow/gemma-flex-template/metadata.json
@@ -1,0 +1,21 @@
+{
+    "name": "Streaming Gemma-on-Dataflow",
+    "description": "A flex template configuring a streaming Gemma pipeline using pytorch and pub/sub",
+    "parameters": [
+      {
+        "name": "messages_subscription",
+        "label": "Input messages subscription",
+        "helpText": "The pub/sub subscription to pull inputs from"
+      },
+      {
+        "name": "responses_topic",
+        "label": "Output messages topic",
+        "helpText": "The pub/sub topic to push inputs to"
+      },
+      {
+        "name": "device",
+        "label": "Device",
+        "helpText": "The device to run inference on. Can be 'CPU' or 'GPU'."
+      }
+    ]
+  }

--- a/dataflow/gemma-flex-template/metadata.json
+++ b/dataflow/gemma-flex-template/metadata.json
@@ -10,7 +10,7 @@
       {
         "name": "responses_topic",
         "label": "Output messages topic",
-        "helpText": "The pub/sub topic to push inputs to"
+        "helpText": "The pub/sub topic to push outputs to"
       },
       {
         "name": "device",

--- a/dataflow/gemma-flex-template/metadata.json
+++ b/dataflow/gemma-flex-template/metadata.json
@@ -16,6 +16,12 @@
         "name": "device",
         "label": "Device",
         "helpText": "The device to run inference on. Can be 'CPU' or 'GPU'."
+      },
+      {
+        "name": "disk_size_gb",
+        "label": "disk_size_gb",
+        "helpText": "disk_size_gb for worker",
+        "isOptional": true
       }
     ]
   }

--- a/dataflow/gemma-flex-template/noxfile_config.py
+++ b/dataflow/gemma-flex-template/noxfile_config.py
@@ -16,7 +16,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # Opting out of all Python versions except 3.11.
+    # Opting out of all Python versions except 3.10.
     # The Python version used is defined by the Dockerfile and the job
     # submission enviornment must match.
     "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12"],

--- a/dataflow/gemma-flex-template/noxfile_config.py
+++ b/dataflow/gemma-flex-template/noxfile_config.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a test configuration file. It is not a part of the sample.
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    # Opting out of all Python versions except 3.11.
+    # The Python version used is defined by the Dockerfile and the job
+    # submission enviornment must match.
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12"],
+    "envs": {
+        "PYTHONPATH": ".."
+    },
+}

--- a/dataflow/gemma-flex-template/requirements-test.txt
+++ b/dataflow/gemma-flex-template/requirements-test.txt
@@ -2,6 +2,6 @@ google-cloud-aiplatform==1.49.0
 google-cloud-dataflow-client==0.8.10
 google-cloud-pubsub==2.21.4
 google-cloud-storage==2.16.0
-pytest==7.4.0
+pytest==8.2.2
 pytest-timeout==2.3.1
 pyyaml==6.0.1

--- a/dataflow/gemma-flex-template/requirements-test.txt
+++ b/dataflow/gemma-flex-template/requirements-test.txt
@@ -1,7 +1,7 @@
-google-cloud-aiplatform==1.49.0
-google-cloud-dataflow-client==0.8.10
+google-cloud-aiplatform==1.62.0
+google-cloud-dataflow-client==0.8.12
 google-cloud-pubsub==2.23.0
-google-cloud-storage==2.16.0
-pytest==8.2.2
+google-cloud-storage==2.18.2
+pytest==8.3.2
 pytest-timeout==2.3.1
-pyyaml==6.0.1
+pyyaml==6.0.2

--- a/dataflow/gemma-flex-template/requirements-test.txt
+++ b/dataflow/gemma-flex-template/requirements-test.txt
@@ -1,6 +1,6 @@
 google-cloud-aiplatform==1.49.0
 google-cloud-dataflow-client==0.8.10
-google-cloud-pubsub==2.21.4
+google-cloud-pubsub==2.23.0
 google-cloud-storage==2.16.0
 pytest==8.2.2
 pytest-timeout==2.3.1

--- a/dataflow/gemma-flex-template/requirements-test.txt
+++ b/dataflow/gemma-flex-template/requirements-test.txt
@@ -1,0 +1,6 @@
+google-cloud-aiplatform==1.49.0
+google-cloud-dataflow-client==0.8.10
+google-cloud-pubsub==2.21.4
+google-cloud-storage==2.16.0
+pytest==7.4.0
+pytest-timeout==2.3.1

--- a/dataflow/gemma-flex-template/requirements-test.txt
+++ b/dataflow/gemma-flex-template/requirements-test.txt
@@ -4,3 +4,4 @@ google-cloud-pubsub==2.21.4
 google-cloud-storage==2.16.0
 pytest==7.4.0
 pytest-timeout==2.3.1
+pyyaml==6.0.1

--- a/dataflow/gemma-flex-template/requirements.txt
+++ b/dataflow/gemma-flex-template/requirements.txt
@@ -1,0 +1,3 @@
+apache_beam[gcp]==2.56.0
+immutabledict==4.2.0
+sentencepiece==0.2.0

--- a/dataflow/gemma-flex-template/requirements.txt
+++ b/dataflow/gemma-flex-template/requirements.txt
@@ -5,6 +5,6 @@ apache_beam[gcp]==2.58.0
 immutabledict==4.2.0
 sentencepiece==0.2.0
 
-# Local package, download it by running:
+# Also required, please download and install gemma_pytorch.
 #   git clone https://github.com/google/gemma_pytorch.git
-./gemma_pytorch
+#   pip install ./gemma_pytorch

--- a/dataflow/gemma-flex-template/requirements.txt
+++ b/dataflow/gemma-flex-template/requirements.txt
@@ -1,6 +1,10 @@
 # For reproducible builds, it is better to also include transitive dependencies: 
 # https://github.com/GoogleCloudPlatform/python-docs-samples/blob/c93accadf3bd29e9c3166676abb2c95564579c5e/dataflow/flex-templates/pipeline_with_dependencies/requirements.txt#L22, 
 # but for simplicity of this example, we are only including the top-level dependencies.
-apache_beam[gcp]==2.56.0
+apache_beam[gcp]==2.58.0
 immutabledict==4.2.0
 sentencepiece==0.2.0
+
+# Local package, download it by running:
+#   git clone https://github.com/google/gemma_pytorch.git
+./gemma_pytorch

--- a/dataflow/gemma-flex-template/requirements.txt
+++ b/dataflow/gemma-flex-template/requirements.txt
@@ -3,7 +3,6 @@
 # but for simplicity of this example, we are only including the top-level dependencies.
 apache_beam[gcp]==2.58.0
 immutabledict==4.2.0
-sentencepiece==0.2.0
 
 # Also required, please download and install gemma_pytorch.
 #   git clone https://github.com/google/gemma_pytorch.git

--- a/dataflow/gemma-flex-template/requirements.txt
+++ b/dataflow/gemma-flex-template/requirements.txt
@@ -1,3 +1,6 @@
+# For reproducible builds, it is better to also include transitive dependencies: 
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/c93accadf3bd29e9c3166676abb2c95564579c5e/dataflow/flex-templates/pipeline_with_dependencies/requirements.txt#L22, 
+# but for simplicity of this example, we are only including the top-level dependencies.
 apache_beam[gcp]==2.56.0
 immutabledict==4.2.0
 sentencepiece==0.2.0


### PR DESCRIPTION
## Description

Adds a Gemma Flex Template example and an e2e test running on Dataflow. This code example is similar to #11284, but using a Pytorch model and deploying as a flex template. The e2e test will need model weights staged to GCS like the streaming Gemma example.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved