### PR TITLE
Update Gemma on Dataflow example to pass max_length as arg

### DIFF
--- a/dataflow/gemma/custom_model_gemma.py
+++ b/dataflow/gemma/custom_model_gemma.py
@@ -77,9 +77,16 @@ class GemmaModelHandler(ModelHandler[str, PredictionResult, GemmaCausalLM]):
         # Loop each text string, and use a tuple to store the inference results.
         predictions = []
         for one_text in batch:
-            result = model.generate(one_text, max_length=64)
+            result = model.generate(one_text, **inference_args)
             predictions.append(result)
         return utils._convert_to_result(batch, predictions, self._model_name)
+
+    def validate_inference_args(self, inference_args: Optional[dict[str,
+                                                                    Any]]):
+        if len(inference_args) > 1 or "max_length" not in inference_args.keys:
+            raise ValueError(
+                "invalid inference args, only valid arg is max_length, got",
+                inference_args)
 
 
 class FormatOutput(beam.DoFn):
@@ -123,8 +130,10 @@ if __name__ == "__main__":
         beam.io.ReadFromPubSub(subscription=args.messages_subscription)
         | "Parse" >> beam.Map(lambda x: x.decode("utf-8"))
         | "RunInference-Gemma" >> RunInference(
-            GemmaModelHandler(args.model_path)
-        )  # Send the prompts to the model and get responses.
+            GemmaModelHandler(args.model_path),
+            inference_args={
+                "max_length", 64
+            })  # Send the prompts to the model and get responses.
         | "Format Output" >> beam.ParDo(FormatOutput())  # Format the output.
         | "Publish Result" >>
         beam.io.gcp.pubsub.WriteStringsToPubSub(topic=args.responses_topic))


### PR DESCRIPTION
## Description

Passes the max_length parameter to Gemma's `generate()` call through inference_args rather than having a hard-coded option.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved