### PR TITLE
chore: Migrate region tags

### DIFF
--- a/endpoints/getting-started/deployment.yaml
+++ b/endpoints/getting-started/deployment.yaml
@@ -39,6 +39,7 @@ spec:
     spec:
       containers:
       # [START esp]
+      # [START endpoints_esp]
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:1
         args: [
@@ -48,6 +49,7 @@ spec:
           "--rollout_strategy=managed",
         ]
       # [END esp]
+      # [END endpoints_esp]
         ports:
         - containerPort: 8081
       - name: echo

--- a/endpoints/kubernetes/k8s-grpc-bookstore.yaml
+++ b/endpoints/kubernetes/k8s-grpc-bookstore.yaml
@@ -48,6 +48,7 @@ spec:
           secret:
             secretName: service-account-creds
       # [END secret-1]
+      # [START endpoints_service]
       # [START service]
       containers:
         - name: esp

--- a/endpoints/kubernetes/k8s-grpc-bookstore.yaml
+++ b/endpoints/kubernetes/k8s-grpc-bookstore.yaml
@@ -60,14 +60,17 @@ spec:
             "--service_account_key=/etc/nginx/creds/service-account-creds.json"
           ]
       # [END service]
+      # [END endpoints_service]
         ports:
           - containerPort: 9000
+          # [START endpoints_secret-2]
           # [START secret-2]
           volumeMounts:
             - mountPath: /etc/nginx/creds
               name: service-account-creds
               readOnly: true
           # [END secret-2]
+          # [END endpoints_secret-2]
       - name: bookstore
         image: gcr.io/endpointsv2/python-grpc-bookstore-server:1
         ports:

--- a/endpoints/kubernetes/k8s-grpc-bookstore.yaml
+++ b/endpoints/kubernetes/k8s-grpc-bookstore.yaml
@@ -63,14 +63,14 @@ spec:
       # [END endpoints_service]
         ports:
           - containerPort: 9000
-          # [START endpoints_secret-2]
+          # [START endpoints_secret_2]
           # [START secret-2]
           volumeMounts:
             - mountPath: /etc/nginx/creds
               name: service-account-creds
               readOnly: true
           # [END secret-2]
-          # [END endpoints_secret-2]
+          # [END endpoints_secret_2]
       - name: bookstore
         image: gcr.io/endpointsv2/python-grpc-bookstore-server:1
         ports:


### PR DESCRIPTION
Add endpoints product prefix to some regions that were missing it.

## Description

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved