### PR TITLE
Chore: Update datastore for GAE Flex to use new runtimes

### DIFF
--- a/appengine/flexible/datastore/app.yaml
+++ b/appengine/flexible/datastore/app.yaml
@@ -17,4 +17,4 @@ env: flex
 entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
-  python_version: 3
+  operating_system: ubuntu22


### PR DESCRIPTION
Update the app.yaml to use newer runtimes for datastore. 