### PR TITLE
fix(compute): Updating Debian 10 to Debian 12 in samples

### DIFF
--- a/compute/client_library/ingredients/instances/create_instance_from_template_with_overrides.py
+++ b/compute/client_library/ingredients/instances/create_instance_from_template_with_overrides.py
@@ -45,7 +45,7 @@ def create_instance_from_template_with_overrides(
               https://cloud.google.com/sdk/gcloud/reference/compute/machine-types/list
         new_disk_source_image: Path the the disk image you want to use for your new
             disk. This can be one of the public images
-            (like "projects/debian-cloud/global/images/family/debian-10")
+            (like "projects/debian-cloud/global/images/family/debian-12")
             or a private image you have access to.
             For a list of available public images, see the documentation:
             http://cloud.google.com/compute/docs/images

--- a/compute/client_library/ingredients/instances/create_start_instance/create_from_public_image.py
+++ b/compute/client_library/ingredients/instances/create_start_instance/create_from_public_image.py
@@ -35,7 +35,7 @@ def create_from_public_image(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link, True)]
     instance = create_instance(project_id, zone, instance_name, disks)

--- a/compute/client_library/ingredients/instances/create_start_instance/create_with_additional_disk.py
+++ b/compute/client_library/ingredients/instances/create_start_instance/create_with_additional_disk.py
@@ -35,7 +35,7 @@ def create_with_additional_disk(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [
         disk_from_image(disk_type, 20, True, newest_debian.self_link),

--- a/compute/client_library/ingredients/instances/create_start_instance/create_with_local_ssd.py
+++ b/compute/client_library/ingredients/instances/create_start_instance/create_with_local_ssd.py
@@ -35,7 +35,7 @@ def create_with_ssd(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [
         disk_from_image(disk_type, 10, True, newest_debian.self_link, True),

--- a/compute/client_library/ingredients/instances/create_start_instance/create_with_snapshotted_data_disk.py
+++ b/compute/client_library/ingredients/instances/create_start_instance/create_with_snapshotted_data_disk.py
@@ -35,7 +35,7 @@ def create_with_snapshotted_data_disk(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [
         disk_from_image(disk_type, 10, True, newest_debian.self_link),

--- a/compute/client_library/ingredients/instances/create_with_subnet.py
+++ b/compute/client_library/ingredients/instances/create_with_subnet.py
@@ -40,7 +40,7 @@ def create_with_subnet(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
     instance = create_instance(

--- a/compute/client_library/ingredients/instances/custom_machine_types/create_extra_mem_no_helper.py
+++ b/compute/client_library/ingredients/instances/custom_machine_types/create_extra_mem_no_helper.py
@@ -39,7 +39,7 @@ def create_custom_instances_extra_mem(
     Returns:
         List of Instance objects.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
     # The core_count and memory values are not validated anywhere and can be rejected by the API.

--- a/compute/client_library/ingredients/instances/custom_machine_types/create_shared_with_helper.py
+++ b/compute/client_library/ingredients/instances/custom_machine_types/create_shared_with_helper.py
@@ -50,7 +50,7 @@ def create_custom_shared_core_instance(
     )
     custom_type = CustomMachineType(zone, cpu_series, memory)
 
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
 

--- a/compute/client_library/ingredients/instances/custom_machine_types/create_with_helper.py
+++ b/compute/client_library/ingredients/instances/custom_machine_types/create_with_helper.py
@@ -51,7 +51,7 @@ def create_custom_instance(
     )
     custom_type = CustomMachineType(zone, cpu_series, memory, core_count)
 
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
 

--- a/compute/client_library/ingredients/instances/custom_machine_types/create_without_helper.py
+++ b/compute/client_library/ingredients/instances/custom_machine_types/create_without_helper.py
@@ -41,7 +41,7 @@ def create_custom_instances_no_helper(
     Returns:
         List of Instance objects.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
     params = [

--- a/compute/client_library/ingredients/instances/ip_address/assign_static_external_ip_to_new_vm.py
+++ b/compute/client_library/ingredients/instances/ip_address/assign_static_external_ip_to_new_vm.py
@@ -37,7 +37,7 @@ def assign_static_external_ip_to_new_vm(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link, True)]
     instance = create_instance(

--- a/compute/client_library/recipes/instances/create.py
+++ b/compute/client_library/recipes/instances/create.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         instance_zone = "europe-central2-b"
 
         newest_debian = get_image_from_family(
-            project="debian-cloud", family="debian-10"
+            project="debian-cloud", family="debian-12"
         )
         disk_type = f"zones/{instance_zone}/diskTypes/pd-standard"
         disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]

--- a/compute/client_library/snippets/instances/create.py
+++ b/compute/client_library/snippets/instances/create.py
@@ -288,7 +288,7 @@ if __name__ == "__main__":
         instance_zone = "europe-central2-b"
 
         newest_debian = get_image_from_family(
-            project="debian-cloud", family="debian-10"
+            project="debian-cloud", family="debian-12"
         )
         disk_type = f"zones/{instance_zone}/diskTypes/pd-standard"
         disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]

--- a/compute/client_library/snippets/instances/create_start_instance/create_from_public_image.py
+++ b/compute/client_library/snippets/instances/create_start_instance/create_from_public_image.py
@@ -283,7 +283,7 @@ def create_from_public_image(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link, True)]
     instance = create_instance(project_id, zone, instance_name, disks)

--- a/compute/client_library/snippets/instances/create_start_instance/create_with_additional_disk.py
+++ b/compute/client_library/snippets/instances/create_start_instance/create_with_additional_disk.py
@@ -314,7 +314,7 @@ def create_with_additional_disk(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [
         disk_from_image(disk_type, 20, True, newest_debian.self_link),

--- a/compute/client_library/snippets/instances/create_start_instance/create_with_local_ssd.py
+++ b/compute/client_library/snippets/instances/create_start_instance/create_with_local_ssd.py
@@ -303,7 +303,7 @@ def create_with_ssd(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [
         disk_from_image(disk_type, 10, True, newest_debian.self_link, True),

--- a/compute/client_library/snippets/instances/create_start_instance/create_with_snapshotted_data_disk.py
+++ b/compute/client_library/snippets/instances/create_start_instance/create_with_snapshotted_data_disk.py
@@ -322,7 +322,7 @@ def create_with_snapshotted_data_disk(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [
         disk_from_image(disk_type, 10, True, newest_debian.self_link),

--- a/compute/client_library/snippets/instances/create_with_subnet.py
+++ b/compute/client_library/snippets/instances/create_with_subnet.py
@@ -289,7 +289,7 @@ def create_with_subnet(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
     instance = create_instance(

--- a/compute/client_library/snippets/instances/custom_machine_types/create_shared_with_helper.py
+++ b/compute/client_library/snippets/instances/custom_machine_types/create_shared_with_helper.py
@@ -491,7 +491,7 @@ def create_custom_shared_core_instance(
     )
     custom_type = CustomMachineType(zone, cpu_series, memory)
 
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
 

--- a/compute/client_library/snippets/instances/custom_machine_types/create_with_helper.py
+++ b/compute/client_library/snippets/instances/custom_machine_types/create_with_helper.py
@@ -494,7 +494,7 @@ def create_custom_instance(
     )
     custom_type = CustomMachineType(zone, cpu_series, memory, core_count)
 
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
 

--- a/compute/client_library/snippets/instances/custom_machine_types/create_without_helper.py
+++ b/compute/client_library/snippets/instances/custom_machine_types/create_without_helper.py
@@ -285,7 +285,7 @@ def create_custom_instances_no_helper(
     Returns:
         List of Instance objects.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
     params = [

--- a/compute/client_library/snippets/instances/custom_machine_types/extra_mem_no_helper.py
+++ b/compute/client_library/snippets/instances/custom_machine_types/extra_mem_no_helper.py
@@ -285,7 +285,7 @@ def create_custom_instances_extra_mem(
     Returns:
         List of Instance objects.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
     # The core_count and memory values are not validated anywhere and can be rejected by the API.

--- a/compute/client_library/snippets/instances/from_instance_template/create_from_template_with_overrides.py
+++ b/compute/client_library/snippets/instances/from_instance_template/create_from_template_with_overrides.py
@@ -101,7 +101,7 @@ def create_instance_from_template_with_overrides(
               https://cloud.google.com/sdk/gcloud/reference/compute/machine-types/list
         new_disk_source_image: Path the the disk image you want to use for your new
             disk. This can be one of the public images
-            (like "projects/debian-cloud/global/images/family/debian-10")
+            (like "projects/debian-cloud/global/images/family/debian-12")
             or a private image you have access to.
             For a list of available public images, see the documentation:
             http://cloud.google.com/compute/docs/images

--- a/compute/client_library/snippets/instances/ip_address/assign_static_external_ip_to_new_vm.py
+++ b/compute/client_library/snippets/instances/ip_address/assign_static_external_ip_to_new_vm.py
@@ -285,7 +285,7 @@ def assign_static_external_ip_to_new_vm(
     Returns:
         Instance object.
     """
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{zone}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link, True)]
     instance = create_instance(

--- a/compute/client_library/snippets/tests/test_custom_types.py
+++ b/compute/client_library/snippets/tests/test_custom_types.py
@@ -45,7 +45,7 @@ def auto_delete_instance_name():
 def instance():
     instance_name = "test-instance-" + uuid.uuid4().hex[:10]
 
-    newest_debian = get_image_from_family(project="debian-cloud", family="debian-10")
+    newest_debian = get_image_from_family(project="debian-cloud", family="debian-12")
     disk_type = f"zones/{INSTANCE_ZONE}/diskTypes/pd-standard"
     disks = [disk_from_image(disk_type, 10, True, newest_debian.self_link)]
 

--- a/compute/client_library/snippets/tests/test_instance_start_stop.py
+++ b/compute/client_library/snippets/tests/test_instance_start_stop.py
@@ -43,7 +43,7 @@ def _make_disk(raw_key: bytes = None):
     disk = compute_v1.AttachedDisk()
     initialize_params = compute_v1.AttachedDiskInitializeParams()
     initialize_params.source_image = (
-        "projects/debian-cloud/global/images/family/debian-10"
+        "projects/debian-cloud/global/images/family/debian-12"
     )
     initialize_params.disk_size_gb = 10
     disk.initialize_params = initialize_params

--- a/compute/client_library/snippets/tests/test_ip_address.py
+++ b/compute/client_library/snippets/tests/test_ip_address.py
@@ -54,7 +54,7 @@ INSTANCE_ZONE = "us-central1-b"
 @pytest.fixture
 def disk_fixture():
     project = "debian-cloud"
-    family = "debian-10"
+    family = "debian-12"
     disk_type = f"zones/{INSTANCE_ZONE}/diskTypes/pd-standard"
     newest_debian = get_image_from_family(project=project, family=family)
     # Create and return the disk configuration


### PR DESCRIPTION
## Description

Fixes #11991
Fixes #11989
Fixes #11990 
Fixes #11988 
Fixes #11987 
Fixes #11986
Fixes #11985 
Fixes #11984
Fixes #11983
Fixes #11982
Fixes #11981
Fixes #11980
Fixes #11979
Fixes #11978
Fixes #11977
Fixes #11976
Fixes #11975
Fixes #11974

Debian 10 went poof, so it's time to move to newer version.