### PR TITLE
feat(scc): add v2 samples for BigQuery Export config

### DIFF
--- a/securitycenter/snippets_v2/requirements.txt
+++ b/securitycenter/snippets_v2/requirements.txt
@@ -1,0 +1,1 @@
+google-cloud-bigquery==3.11.4

--- a/securitycenter/snippets_v2/snippets_bigquery_export_v2.py
+++ b/securitycenter/snippets_v2/snippets_bigquery_export_v2.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Snippets on exporting findings from Security Command Center to BigQuery."""
+
+
+# [START securitycenter_create_bigquery_export]
+
+
+def create_bigquery_export(
+    parent: str, export_filter: str, bigquery_dataset_id: str, bigquery_export_id: str
+):
+    from google.cloud import securitycenter_v2
+
+    """
+    Create export configuration to export findings from a project to a BigQuery dataset.
+    Optionally specify filter to export certain findings only.
+
+    Args:
+        parent: Use any one of the following resource paths:
+             - organizations/{organization_id}/locations/{location_id}
+             - folders/{folder_id}/locations/{location_id}
+             - projects/{project_id}/locations/{location_id}
+        export_filter: Expression that defines the filter to apply across create/update events of findings.
+        bigquery_dataset_id: The BigQuery dataset to write findings' updates to.
+        bigquery_export_id: Unique identifier provided by the client.
+             - example id: f"default-{str(uuid.uuid4()).split('-')[0]}"
+        For more info, see:
+        https://cloud.google.com/security-command-center/docs/how-to-analyze-findings-in-big-query#export_findings_from_to
+    """
+    client = securitycenter_v2.SecurityCenterClient()
+
+    # Create the BigQuery export configuration.
+    bigquery_export = securitycenter_v2.BigQueryExport()
+    bigquery_export.description = "Export low and medium findings if the compute resource has an IAM anomalous grant"
+    bigquery_export.filter = export_filter
+    bigquery_export.dataset = f"{parent}/datasets/{bigquery_dataset_id}"
+
+    request = securitycenter_v2.CreateBigQueryExportRequest()
+    request.parent = parent
+    request.big_query_export = bigquery_export
+    request.big_query_export_id = bigquery_export_id
+
+    # Create the export request.
+    response = client.create_big_query_export(request)
+
+    print(f"BigQuery export request created successfully: {response.name}\n")
+
+
+# [END securitycenter_create_bigquery_export]
+
+
+# [START securitycenter_get_bigquery_export]
+def get_bigquery_export(parent: str, bigquery_export_id: str):
+    from google.cloud import securitycenter_v2
+
+    """
+    Retrieve an existing BigQuery export.
+    Args:
+        parent: Use any one of the following resource paths:
+                 - organizations/{organization_id}/locations/{location_id}
+                 - folders/{folder_id}/locations/{location_id}
+                 - projects/{project_id}/locations/{location_id}
+        bigquery_export_id: Unique identifier that is used to identify the export.
+    """
+
+    client = securitycenter_v2.SecurityCenterClient()
+
+    request = securitycenter_v2.GetBigQueryExportRequest()
+    request.name = f"{parent}/bigQueryExports/{bigquery_export_id}"
+
+    response = client.get_big_query_export(request)
+    print(f"Retrieved the BigQuery export: {response.name}")
+
+
+# [END securitycenter_get_bigquery_export]
+
+
+# [START securitycenter_list_bigquery_export]
+def list_bigquery_exports(parent: str):
+    from google.cloud import securitycenter_v2
+
+    """
+    List BigQuery exports in the given parent.
+    Args:
+         parent: The parent which owns the collection of BigQuery exports.
+             Use any one of the following resource paths:
+                 - organizations/{organization_id}/locations/{location_id}
+                 - folders/{folder_id}/locations/{location_id}
+                 - projects/{project_id}/locations/{location_id}
+    """
+
+    client = securitycenter_v2.SecurityCenterClient()
+
+    request = securitycenter_v2.ListBigQueryExportsRequest()
+    request.parent = parent
+
+    response = client.list_big_query_exports(request)
+
+    print("Listing BigQuery exports:")
+    for bigquery_export in response:
+        print(bigquery_export.name)
+
+
+# [END securitycenter_list_bigquery_export]
+
+
+# [START securitycenter_update_bigquery_export]
+def update_bigquery_export(parent: str, export_filter: str, bigquery_export_id: str):
+    """
+    Updates an existing BigQuery export.
+    Args:
+        parent: Use any one of the following resource paths:
+                 - organizations/{organization_id}/locations/{location_id}
+                 - folders/{folder_id}/locations/{location_id}
+                 - projects/{project_id}/locations/{location_id}
+        export_filter: Expression that defines the filter to apply across create/update events of findings.
+        bigquery_export_id: Unique identifier provided by the client.
+        For more info, see:
+        https://cloud.google.com/security-command-center/docs/how-to-analyze-findings-in-big-query#export_findings_from_to
+    """
+    from google.cloud import securitycenter_v2
+    from google.protobuf import field_mask_pb2
+
+    client = securitycenter_v2.SecurityCenterClient()
+
+    # Set the new values for export configuration.
+    bigquery_export = securitycenter_v2.BigQueryExport()
+    bigquery_export.name = f"{parent}/bigQueryExports/{bigquery_export_id}"
+    bigquery_export.filter = export_filter
+
+    # Field mask to only update the export filter.
+    # Set the update mask to specify which properties should be updated.
+    # If empty, all mutable fields will be updated.
+    # For more info on constructing field mask path, see the proto or:
+    # https://googleapis.dev/python/protobuf/latest/google/protobuf/field_mask_pb2.html
+    field_mask = field_mask_pb2.FieldMask(paths=["filter"])
+
+    request = securitycenter_v2.UpdateBigQueryExportRequest()
+    request.big_query_export = bigquery_export
+    request.update_mask = field_mask
+
+    response = client.update_big_query_export(request)
+
+    if response.filter != export_filter:
+        print("Failed to update BigQueryExport!")
+        return
+    print("BigQueryExport updated successfully!")
+
+
+# [END securitycenter_update_bigquery_export]
+
+
+# [START securitycenter_delete_bigquery_export]
+def delete_bigquery_export(parent: str, bigquery_export_id: str):
+    """
+    Delete an existing BigQuery export.
+    Args:
+        parent: Use any one of the following resource paths:
+                 - organizations/{organization_id}/locations/{location_id}
+                 - folders/{folder_id}/locations/{location_id}
+                 - projects/{project_id}/locations/{location_id}
+        bigquery_export_id: Unique identifier that is used to identify the export.
+    """
+    from google.cloud import securitycenter_v2
+
+    client = securitycenter_v2.SecurityCenterClient()
+
+    request = securitycenter_v2.DeleteBigQueryExportRequest()
+    request.name = f"{parent}/bigQueryExports/{bigquery_export_id}"
+
+    client.delete_big_query_export(request)
+    print(f"BigQuery export request deleted successfully: {bigquery_export_id}")
+
+
+# [END securitycenter_delete_bigquery_export]

--- a/securitycenter/snippets_v2/snippets_bigquery_export_v2.py
+++ b/securitycenter/snippets_v2/snippets_bigquery_export_v2.py
@@ -47,7 +47,7 @@ def create_bigquery_export(
     bigquery_export = securitycenter_v2.BigQueryExport()
     bigquery_export.description = "Export low and medium findings if the compute resource has an IAM anomalous grant"
     bigquery_export.filter = export_filter
-    bigquery_export.dataset = f"{parent}/datasets/{bigquery_dataset_id}"
+    bigquery_export.dataset = bigquery_dataset_id
 
     request = securitycenter_v2.CreateBigQueryExportRequest()
     request.parent = parent

--- a/securitycenter/snippets_v2/snippets_bigquery_export_v2.py
+++ b/securitycenter/snippets_v2/snippets_bigquery_export_v2.py
@@ -17,7 +17,7 @@
 """Snippets on exporting findings from Security Command Center to BigQuery."""
 
 
-# [START securitycenter_create_bigquery_export]
+# [START securitycenter_create_bigquery_export_v2]
 
 
 def create_bigquery_export(
@@ -36,6 +36,7 @@ def create_bigquery_export(
              - projects/{project_id}/locations/{location_id}
         export_filter: Expression that defines the filter to apply across create/update events of findings.
         bigquery_dataset_id: The BigQuery dataset to write findings' updates to.
+             - projects/{PROJECT_ID}/datasets/{BIGQUERY_DATASET_ID}
         bigquery_export_id: Unique identifier provided by the client.
              - example id: f"default-{str(uuid.uuid4()).split('-')[0]}"
         For more info, see:
@@ -58,12 +59,12 @@ def create_bigquery_export(
     response = client.create_big_query_export(request)
 
     print(f"BigQuery export request created successfully: {response.name}\n")
+    return response
+
+# [END securitycenter_create_bigquery_export_v2]
 
 
-# [END securitycenter_create_bigquery_export]
-
-
-# [START securitycenter_get_bigquery_export]
+# [START securitycenter_get_bigquery_export_v2]
 def get_bigquery_export(parent: str, bigquery_export_id: str):
     from google.cloud import securitycenter_v2
 
@@ -84,12 +85,12 @@ def get_bigquery_export(parent: str, bigquery_export_id: str):
 
     response = client.get_big_query_export(request)
     print(f"Retrieved the BigQuery export: {response.name}")
+    return response
+
+# [END securitycenter_get_bigquery_export_v2]
 
 
-# [END securitycenter_get_bigquery_export]
-
-
-# [START securitycenter_list_bigquery_export]
+# [START securitycenter_list_bigquery_export_v2]
 def list_bigquery_exports(parent: str):
     from google.cloud import securitycenter_v2
 
@@ -113,12 +114,12 @@ def list_bigquery_exports(parent: str):
     print("Listing BigQuery exports:")
     for bigquery_export in response:
         print(bigquery_export.name)
+    return response
+
+# [END securitycenter_list_bigquery_export_v2]
 
 
-# [END securitycenter_list_bigquery_export]
-
-
-# [START securitycenter_update_bigquery_export]
+# [START securitycenter_update_bigquery_export_v2]
 def update_bigquery_export(parent: str, export_filter: str, bigquery_export_id: str):
     """
     Updates an existing BigQuery export.
@@ -159,12 +160,12 @@ def update_bigquery_export(parent: str, export_filter: str, bigquery_export_id: 
         print("Failed to update BigQueryExport!")
         return
     print("BigQueryExport updated successfully!")
+    return response
+
+# [END securitycenter_update_bigquery_export_v2]
 
 
-# [END securitycenter_update_bigquery_export]
-
-
-# [START securitycenter_delete_bigquery_export]
+# [START securitycenter_delete_bigquery_export_v2]
 def delete_bigquery_export(parent: str, bigquery_export_id: str):
     """
     Delete an existing BigQuery export.
@@ -186,4 +187,4 @@ def delete_bigquery_export(parent: str, bigquery_export_id: str):
     print(f"BigQuery export request deleted successfully: {bigquery_export_id}")
 
 
-# [END securitycenter_delete_bigquery_export]
+# [END securitycenter_delete_bigquery_export_v2]

--- a/securitycenter/snippets_v2/snippets_bigquery_export_v2_test.py
+++ b/securitycenter/snippets_v2/snippets_bigquery_export_v2_test.py
@@ -40,7 +40,7 @@ def bigquery_export_id():
     create_bigquery_dataset(BIGQUERY_DATASET_ID)
     export_filter = 'severity="LOW" OR severity="MEDIUM"'
     snippets_bigquery_export_v2.create_bigquery_export(
-        f"projects/{PROJECT_ID}/locations/{LOCATION_ID}", export_filter, BIGQUERY_DATASET_ID, bigquery_export_id
+        f"projects/{PROJECT_ID}/locations/{LOCATION_ID}", export_filter, f"projects/{PROJECT_ID}/datasets/{BIGQUERY_DATASET_ID}", bigquery_export_id
     )
 
     yield bigquery_export_id
@@ -81,6 +81,8 @@ def delete_bigquery_dataset(dataset_id: str):
     backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
 )
 def test_get_bigquery_export(capsys: CaptureFixture, bigquery_export_id: str):
+    print("**********")
+    print(LOCATION_ID)
     snippets_bigquery_export_v2.get_bigquery_export(
         f"projects/{PROJECT_ID}/locations/{LOCATION_ID}", bigquery_export_id
     )

--- a/securitycenter/snippets_v2/snippets_bigquery_export_v2_test.py
+++ b/securitycenter/snippets_v2/snippets_bigquery_export_v2_test.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# TODO(developer): Replace these variables before running the sample.
+import os
+import re
+import uuid
+
+from _pytest.capture import CaptureFixture
+import backoff
+from google.api_core.exceptions import InternalServerError, NotFound, ServiceUnavailable
+import pytest
+
+import snippets_bigquery_export_v2
+
+PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
+GOOGLE_APPLICATION_CREDENTIALS = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+BIGQUERY_DATASET_ID = f"sampledataset{str(uuid.uuid4()).split('-')[0]}"
+LOCATION_ID = os.environ["GCLOUD_LOCATION"]
+
+
+@pytest.fixture(scope="module")
+def bigquery_export_id():
+    bigquery_export_id = f"default-{str(uuid.uuid4()).split('-')[0]}"
+
+    create_bigquery_dataset(BIGQUERY_DATASET_ID)
+    export_filter = 'severity="LOW" OR severity="MEDIUM"'
+    snippets_bigquery_export_v2.create_bigquery_export(
+        f"projects/{PROJECT_ID}/locations/{LOCATION_ID}", export_filter, BIGQUERY_DATASET_ID, bigquery_export_id
+    )
+
+    yield bigquery_export_id
+
+    snippets_bigquery_export_v2.delete_bigquery_export(
+        f"projects/{PROJECT_ID}/locations/{LOCATION_ID}", bigquery_export_id
+    )
+    delete_bigquery_dataset(BIGQUERY_DATASET_ID)
+
+
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
+)
+def create_bigquery_dataset(dataset_id: str):
+    from google.cloud import bigquery
+
+    bigquery_client = bigquery.Client()
+
+    dataset_id_full = f"{PROJECT_ID}.{dataset_id}"
+    dataset = bigquery.Dataset(dataset_id_full)
+
+    dataset = bigquery_client.create_dataset(dataset)
+    print(f"Dataset {dataset.dataset_id} created.")
+
+
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
+)
+def delete_bigquery_dataset(dataset_id: str):
+    from google.cloud import bigquery
+
+    bigquery_client = bigquery.Client()
+    bigquery_client.delete_dataset(dataset_id)
+    print(f"Dataset {dataset_id} deleted.")
+
+
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
+)
+def test_get_bigquery_export(capsys: CaptureFixture, bigquery_export_id: str):
+    snippets_bigquery_export_v2.get_bigquery_export(
+        f"projects/{PROJECT_ID}/locations/{LOCATION_ID}", bigquery_export_id
+    )
+    out, _ = capsys.readouterr()
+    assert re.search(
+        "Retrieved the BigQuery export",
+        out,
+    )
+    assert re.search(f"bigQueryExports/{bigquery_export_id}", out)
+
+
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
+)
+def test_list_bigquery_exports(capsys: CaptureFixture, bigquery_export_id: str):
+    snippets_bigquery_export_v2.list_bigquery_exports(f"projects/{PROJECT_ID}/locations/{LOCATION_ID}")
+    out, _ = capsys.readouterr()
+    assert re.search("Listing BigQuery exports:", out)
+    assert re.search(bigquery_export_id, out)
+
+
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
+)
+def test_update_bigquery_exports(capsys: CaptureFixture, bigquery_export_id: str):
+    export_filter = 'severity="MEDIUM"'
+    snippets_bigquery_export_v2.update_bigquery_export(
+        f"projects/{PROJECT_ID}/locations/{LOCATION_ID}", export_filter, bigquery_export_id
+    )
+    out, _ = capsys.readouterr()
+    assert re.search("BigQueryExport updated successfully!", out)


### PR DESCRIPTION

https://cloud.google.com/security-command-center/docs/reference/rest/v2/projects.locations.bigQueryExports


Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved