### PR TITLE
fix(sts): skip aws test with bucket quota limit

### DIFF
--- a/storagetransfer/conftest.py
+++ b/storagetransfer/conftest.py
@@ -227,7 +227,11 @@ def aws_source_bucket(bucket_name: str, secret_cache):
     s3_client = boto3.client("s3", **aws_key_pair(secret_cache))
     s3_resource = boto3.resource("s3", **aws_key_pair(secret_cache))
 
-    s3_client.create_bucket(Bucket=bucket_name)
+    try:
+        s3_client.create_bucket(Bucket=bucket_name)
+    except Exception:
+        # Skip AWS tests until bucket quota limit is resolved, per team discussion.
+        pytest.skip("Skipping due to AWS bucket restrictions and limitations.")
 
     yield bucket_name
 


### PR DESCRIPTION
Skip AWS test that hit bucket quota limit

Per team discussion, unblock periodic tests until aws bucket quota issue is resolved

Fixes #12009

