### PR TITLE
Fix script to pause/unpause DAGs in Composer env

### DIFF
--- a/composer/tools/composer_dags.py
+++ b/composer/tools/composer_dags.py
@@ -60,9 +60,9 @@ class DAG:
         else:
             list_of_dags = []
             for line in command_output.split("\n"):
-                if re.compile("[a-z_]+|[a-z]+|[a-z]+|[a-z_]+").findall(line):
+                if re.compile("^[a-zA-Z].*").findall(line):
                     list_of_dags.append(line.split()[0])
-            return list_of_dags[1:-1]
+            return list_of_dags
 
     @staticmethod
     def _run_shell_command_locally_once(


### PR DESCRIPTION
## Description
This PR fixes rendering of `gcloud list dags` command output for further pausing/unpausing of specific DAG. 
Authored: uladaz@google.com

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved