### PR TITLE
chore: Remove quota project from API key auth sample.

### DIFF
--- a/auth/api-client/api_key_test.py
+++ b/auth/api-client/api_key_test.py
@@ -67,7 +67,7 @@ def test_authenticate_with_api_key(api_key: Key, capsys: CaptureFixture) -> None
         "google.cloud.language_v1.LanguageServiceClient.analyze_sentiment",
         get_mock_sentiment_response(),
     ):
-        authenticate_with_api_key.authenticate_with_api_key(PROJECT, api_key.key_string)
+        authenticate_with_api_key.authenticate_with_api_key(api_key.key_string)
     out, _ = capsys.readouterr()
     assert re.search("Successfully authenticated using the API key", out)
 

--- a/auth/api-client/authenticate_with_api_key.py
+++ b/auth/api-client/authenticate_with_api_key.py
@@ -27,7 +27,7 @@ def authenticate_with_api_key(api_key_string: str) -> None:
         api_key_string: The API key to authenticate to the service.
     """
 
-    # Initialize the Language Service client and set the API key and the quota project id.
+    # Initialize the Language Service client and set the API key
     client = language_v1.LanguageServiceClient(
         client_options={"api_key": api_key_string}
     )

--- a/auth/api-client/authenticate_with_api_key.py
+++ b/auth/api-client/authenticate_with_api_key.py
@@ -17,20 +17,19 @@
 from google.cloud import language_v1
 
 
-def authenticate_with_api_key(quota_project_id: str, api_key_string: str) -> None:
+def authenticate_with_api_key(api_key_string: str) -> None:
     """
     Authenticates with an API key for Google Language service.
 
     TODO(Developer): Replace these variables before running the sample.
 
     Args:
-        quota_project_id: Google Cloud project id that should be used for quota and billing purposes.
         api_key_string: The API key to authenticate to the service.
     """
 
     # Initialize the Language Service client and set the API key and the quota project id.
     client = language_v1.LanguageServiceClient(
-        client_options={"api_key": api_key_string, "quota_project_id": quota_project_id}
+        client_options={"api_key": api_key_string}
     )
 
     text = "Hello, world!"

--- a/auth/api-client/authenticate_with_api_key.py
+++ b/auth/api-client/authenticate_with_api_key.py
@@ -21,7 +21,7 @@ def authenticate_with_api_key(api_key_string: str) -> None:
     """
     Authenticates with an API key for Google Language service.
 
-    TODO(Developer): Replace these variables before running the sample.
+    TODO(Developer): Replace this variable before running the sample.
 
     Args:
         api_key_string: The API key to authenticate to the service.


### PR DESCRIPTION
Quota should be derived from the API key.

ETA:
based on documentation for the underlying API, the call authenticates with the API key and doesn't do anything associated with a passed in project ID. 

This will update https://cloud.google.com/docs/authentication/api-keys 

