### PR TITLE
feat: add Firestore and datastore multiple inequality samples

### DIFF
--- a/datastore/cloud-client/index.yaml
+++ b/datastore/cloud-client/index.yaml
@@ -41,3 +41,16 @@ indexes:
   - name: done
   - name: created
     direction: desc
+- kind: Task
+  properties:
+  - name: priority
+  - name: days
+- kind: employees
+  properties:
+  - name: salary
+    direction: desc
+  - name: experience
+    direction: desc
+- kind: employees
+  properties:
+  - name: salary

--- a/datastore/cloud-client/index.yaml
+++ b/datastore/cloud-client/index.yaml
@@ -54,3 +54,6 @@ indexes:
 - kind: employees
   properties:
   - name: salary
+    direction: desc
+  - name: experience
+    direction: desc

--- a/datastore/cloud-client/query_filter_or.py
+++ b/datastore/cloud-client/query_filter_or.py
@@ -46,6 +46,5 @@ def query_filter_or(project_id: str) -> None:
     for result in results:
         print(result["description"])
 
-
-# [END datastore_query_filter_or]
+    # [END datastore_query_filter_or]
     return results

--- a/datastore/cloud-client/query_filter_or.py
+++ b/datastore/cloud-client/query_filter_or.py
@@ -42,9 +42,10 @@ def query_filter_or(project_id: str) -> None:
 
     or_query.add_filter(filter=or_filter)
 
-    results = or_query.fetch()
+    results = list(or_query.fetch())
     for result in results:
         print(result["description"])
 
 
 # [END datastore_query_filter_or]
+    return results

--- a/datastore/cloud-client/query_filter_or_test.py
+++ b/datastore/cloud-client/query_filter_or_test.py
@@ -26,23 +26,24 @@ PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
 def entities():
     client = datastore.Client(project=PROJECT_ID)
 
-    task_key = client.key("Task")
-    task1 = datastore.Entity(key=task_key)
-    task1["description"] = "Buy milk"
-    client.put(task1)
-
-    task_key2 = client.key("Task")
-    task2 = datastore.Entity(key=task_key2)
-    task2["description"] = "Feed cats"
-    client.put(task2)
+    entities = []
+    for description in ["Buy milk", "Feed cats", "Walk dog"]:
+        task_key = client.key("Task")
+        task_obj = datastore.Entity(key=task_key)
+        task_obj["description"] = description
+        client.put(task_obj)
+        entities.append(task_obj)
 
     yield entities
 
-    client.delete(task1)
-    client.delete(task2)
+    # delete all Tasks
+    for task in client.query(kind="Task").fetch():
+        client.delete(task)
 
 
 def test_query_filter_or(capsys, entities):
-    query_filter_or(project_id=PROJECT_ID)
-    out, _ = capsys.readouterr()
-    assert "Feed cats" in out
+    results = query_filter_or(project_id=PROJECT_ID)
+    descriptions = [result.popitem()[1] for result in results]
+    assert "Feed cats" in descriptions
+    assert "Buy milk" in descriptions
+    assert "Walk dog" not in descriptions

--- a/datastore/cloud-client/query_multi_ineq.py
+++ b/datastore/cloud-client/query_multi_ineq.py
@@ -18,7 +18,7 @@ Samples for multi-inequality queries
 See https://cloud.google.com/python/docs/reference/datastore/latest before running code.
 """
 
-def query_filter_compount_multi_ineq():
+def query_filter_compound_multi_ineq():
     from google.cloud import datastore
     client = datastore.Client()
     # [START datastore_query_filter_compound_multi_ineq]
@@ -26,13 +26,14 @@ def query_filter_compount_multi_ineq():
     query.add_filter(filter=PropertyFilter("priority", ">", 4))
     query.add_filter(filter=PropertyFilter("days", "<", 3))
     # [END datastore_query_filter_compound_multi_ineq]
+    return query
 
 def query_indexing_considerations():
     from google.cloud import datastore
     client = datastore.Client()
     # [START datastore_query_indexing_considerations]
     query = client.query(kind="employees")
-    query.add_filter("salary", ">", 100000)
+    query.add_filter("salary", ">", 100_000)
     query.add_filter("experience", ">", 0)
     query.order = ["-salary", "-experience"]
     # [END datastore_query_indexing_considerations]
@@ -44,7 +45,7 @@ def query_order_fields():
     client = datastore.Client()
     # [START datastore_query_order_fields]
     query = client.query(kind="employees")
-    query.add_filter("salary", ">", 100000)
+    query.add_filter("salary", ">", 100_000)
     query.order = ["salary"]
     results = query.fetch()
     # Order results by `experience`

--- a/datastore/cloud-client/query_multi_ineq.py
+++ b/datastore/cloud-client/query_multi_ineq.py
@@ -21,6 +21,7 @@ See https://cloud.google.com/python/docs/reference/datastore/latest before runni
 
 def query_filter_compound_multi_ineq():
     from google.cloud import datastore
+    from google.cloud.datastore.query import PropertyFilter
 
     client = datastore.Client()
     # [START datastore_query_filter_compound_multi_ineq]

--- a/datastore/cloud-client/query_multi_ineq.py
+++ b/datastore/cloud-client/query_multi_ineq.py
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Samples for multi-inequality queries
+
+See https://cloud.google.com/python/docs/reference/datastore/latest before running code.
+"""
+
+def query_filter_compount_multi_ineq():
+    from google.cloud import datastore
+    client = datastore.Client()
+    # [START datastore_query_filter_compound_multi_ineq]
+    query = client.query(kind="Task")
+    query.add_filter(filter=PropertyFilter("priority", ">", 4))
+    query.add_filter(filter=PropertyFilter("days", "<", 3))
+    # [END datastore_query_filter_compound_multi_ineq]
+
+def query_indexing_considerations():
+    from google.cloud import datastore
+    client = datastore.Client()
+    # [START datastore_query_indexing_considerations]
+    query = client.query(kind="employees")
+    query.add_filter("salary", ">", 100000)
+    query.add_filter("experience", ">", 0)
+    query.order = ["-salary", "-experience"]
+    # [END datastore_query_indexing_considerations]
+    return query
+
+
+def query_order_fields():
+    from google.cloud import datastore
+    client = datastore.Client()
+    # [START datastore_query_order_fields]
+    query = client.query(kind="employees")
+    query.add_filter("salary", ">", 100000)
+    query.order = ["salary"]
+    results = query.fetch()
+    # Order results by `experience`
+    sorted_results = sorted(results, key=lambda x: x.get("experience"))
+    # [END datastore_query_order_fields]
+    return sorted_results

--- a/datastore/cloud-client/query_multi_ineq.py
+++ b/datastore/cloud-client/query_multi_ineq.py
@@ -18,8 +18,10 @@ Samples for multi-inequality queries
 See https://cloud.google.com/python/docs/reference/datastore/latest before running code.
 """
 
+
 def query_filter_compound_multi_ineq():
     from google.cloud import datastore
+
     client = datastore.Client()
     # [START datastore_query_filter_compound_multi_ineq]
     query = client.query(kind="Task")
@@ -28,8 +30,10 @@ def query_filter_compound_multi_ineq():
     # [END datastore_query_filter_compound_multi_ineq]
     return query
 
+
 def query_indexing_considerations():
     from google.cloud import datastore
+
     client = datastore.Client()
     # [START datastore_query_indexing_considerations]
     query = client.query(kind="employees")
@@ -42,6 +46,7 @@ def query_indexing_considerations():
 
 def query_order_fields():
     from google.cloud import datastore
+
     client = datastore.Client()
     # [START datastore_query_order_fields]
     query = client.query(kind="employees")

--- a/datastore/cloud-client/query_multi_ineq.py
+++ b/datastore/cloud-client/query_multi_ineq.py
@@ -34,12 +34,13 @@ def query_filter_compound_multi_ineq():
 
 def query_indexing_considerations():
     from google.cloud import datastore
+    from google.cloud.datastore.query import PropertyFilter
 
     client = datastore.Client()
     # [START datastore_query_indexing_considerations]
     query = client.query(kind="employees")
-    query.add_filter("salary", ">", 100_000)
-    query.add_filter("experience", ">", 0)
+    query.add_filter(filter=PropertyFilter("salary", ">", 100_000))
+    query.add_filter(filter=PropertyFilter("experience", ">", 0))
     query.order = ["-salary", "-experience"]
     # [END datastore_query_indexing_considerations]
     return query
@@ -47,11 +48,12 @@ def query_indexing_considerations():
 
 def query_order_fields():
     from google.cloud import datastore
+    from google.cloud.datastore.query import PropertyFilter
 
     client = datastore.Client()
     # [START datastore_query_order_fields]
     query = client.query(kind="employees")
-    query.add_filter("salary", ">", 100_000)
+    query.add_filter(filter=PropertyFilter("salary", ">", 100_000))
     query.order = ["salary"]
     results = query.fetch()
     # Order results by `experience`

--- a/datastore/cloud-client/query_multi_ineq_test.py
+++ b/datastore/cloud-client/query_multi_ineq_test.py
@@ -60,13 +60,17 @@ def entities():
 
     for entity in created_entities:
         client.delete(entity)
+    # cleanup
+    for kind in ["Task", "employees"]:
+        for entity in client.query(kind=kind).fetch():
+            client.delete(entity)
 
 
 def test_query_filter_compound_multi_ineq(entities):
-    query = snippets.query_indexing_considerations()
+    query = snippets.query_filter_compound_multi_ineq()
     results = list(query.fetch())
     assert len(results) == 1
-    assert results[0].to_dict()["description"] == "Play with dog"
+    assert results[0]["description"] == "Play with dog"
 
 
 def test_query_indexing_considerations(entities):
@@ -74,16 +78,15 @@ def test_query_indexing_considerations(entities):
     results = list(query.fetch())
     # should contain employees salary > 100_000 sorted by salary and experience
     assert len(results) == 3
-    assert results[0].to_dict()["name"] == "Charlie"
-    assert results[1].to_dict()["name"] == "Eve"
-    assert results[2].to_dict()["name"] == "Joe"
+    assert results[0]["name"] == "Charlie"
+    assert results[1]["name"] == "Eve"
+    assert results[2]["name"] == "Joe"
 
 
 def test_query_order_fields(entities):
-    query = snippets.query_indexing_considerations()
-    results = list(query.fetch())
+    results = snippets.query_order_fields()
     assert len(results) == 4
-    assert results[0].to_dict()["name"] == "Mallory"
-    assert results[1].to_dict()["name"] == "Joe"
-    assert results[2].to_dict()["name"] == "Eve"
-    assert results[3].to_dict()["name"] == "Charlie"
+    assert results[0]["name"] == "Mallory"
+    assert results[1]["name"] == "Joe"
+    assert results[2]["name"] == "Eve"
+    assert results[3]["name"] == "Charlie"

--- a/datastore/cloud-client/query_multi_ineq_test.py
+++ b/datastore/cloud-client/query_multi_ineq_test.py
@@ -72,7 +72,6 @@ def test_query_indexing_considerations(entities):
     results = list(query.stream())
     # should contain employees salary > 100_000 sorted by salary and experience
     assert len(results) == 3
-    # TODO: check ordering
     assert results[0].to_dict()["name"] == "Charlie"
     assert results[1].to_dict()["name"] == "Eve"
     assert results[2].to_dict()["name"] == "Joe"

--- a/datastore/cloud-client/query_multi_ineq_test.py
+++ b/datastore/cloud-client/query_multi_ineq_test.py
@@ -42,21 +42,24 @@ def entities():
         {"name": "Mallory", "salary": 200_000, "experience": 0},
     ]
 
+    created_entities = []
     for task in tasks:
         task_key = client.key("Task")
         task_entity = datastore.Entity(key=task_key)
         task_entity.update(task)
         client.put(task_entity)
+        created_entities.append(task_entity)
     for employee in employees:
         employee_key = client.key("employees")
         employee_entity = datastore.Entity(key=employee_key)
         employee_entity.update(employee)
         client.put(employee_entity)
+        created_entities.append(employee_entity)
 
     yield entities
 
-    client.delete(task1)
-    client.delete(task2)
+    for entity in created_entities:
+        client.delete(entity)
 
 
 def test_query_filter_compound_multi_ineq(entities):

--- a/datastore/cloud-client/query_multi_ineq_test.py
+++ b/datastore/cloud-client/query_multi_ineq_test.py
@@ -64,14 +64,14 @@ def entities():
 
 def test_query_filter_compound_multi_ineq(entities):
     query = snippets.query_indexing_considerations()
-    results = list(query.stream())
+    results = list(query.fetch())
     assert len(results) == 1
     assert results[0].to_dict()["description"] == "Play with dog"
 
 
 def test_query_indexing_considerations(entities):
     query = snippets.query_indexing_considerations()
-    results = list(query.stream())
+    results = list(query.fetch())
     # should contain employees salary > 100_000 sorted by salary and experience
     assert len(results) == 3
     assert results[0].to_dict()["name"] == "Charlie"
@@ -80,7 +80,8 @@ def test_query_indexing_considerations(entities):
 
 
 def test_query_order_fields(entities):
-    results = snippets.query_indexing_considerations()
+    query = snippets.query_indexing_considerations()
+    results = list(query.fetch())
     assert len(results) == 4
     assert results[0].to_dict()["name"] == "Mallory"
     assert results[1].to_dict()["name"] == "Joe"

--- a/datastore/cloud-client/query_multi_ineq_test.py
+++ b/datastore/cloud-client/query_multi_ineq_test.py
@@ -53,7 +53,6 @@ def entities():
         employee_entity.update(employee)
         client.put(employee_entity)
 
-
     yield entities
 
     client.delete(task1)

--- a/datastore/cloud-client/query_multi_ineq_test.py
+++ b/datastore/cloud-client/query_multi_ineq_test.py
@@ -1,0 +1,87 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.cloud import datastore
+import pytest
+
+import query_multi_ineq as snippets
+
+PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
+
+
+@pytest.fixture()
+def entities():
+    client = datastore.Client(project=PROJECT_ID)
+
+    tasks = [
+        {"description": "Buy milk", "priority": 0, "days": 10},
+        {"description": "Feed cats", "priority": 10, "days": 10},
+        {"description": "Play with dog", "priority": 10, "days": 1},
+    ]
+
+    employees = [
+        {"name": "Alice", "salary": 100_000, "experience": 10},
+        {"name": "Bob", "salary": 80_000, "experience": 2},
+        {"name": "Charlie", "salary": 120_000, "experience": 10},
+        {"name": "David", "salary": 90_000, "experience": 3},
+        {"name": "Eve", "salary": 110_000, "experience": 9},
+        {"name": "Joe", "salary": 110_000, "experience": 7},
+        {"name": "Mallory", "salary": 200_000, "experience": 0},
+    ]
+
+    for task in tasks:
+        task_key = client.key("Task")
+        task_entity = datastore.Entity(key=task_key)
+        task_entity.update(task)
+        client.put(task_entity)
+    for employee in employees:
+        employee_key = client.key("employees")
+        employee_entity = datastore.Entity(key=employee_key)
+        employee_entity.update(employee)
+        client.put(employee_entity)
+
+
+    yield entities
+
+    client.delete(task1)
+    client.delete(task2)
+
+
+def test_query_filter_compound_multi_ineq(entities):
+    query = snippets.query_indexing_considerations()
+    results = list(query.stream())
+    assert len(results) == 1
+    assert results[0].to_dict()["description"] == "Play with dog"
+
+
+def test_query_indexing_considerations(entities):
+    query = snippets.query_indexing_considerations()
+    results = list(query.stream())
+    # should contain employees salary > 100_000 sorted by salary and experience
+    assert len(results) == 3
+    # TODO: check ordering
+    assert results[0].to_dict()["name"] == "Charlie"
+    assert results[1].to_dict()["name"] == "Eve"
+    assert results[2].to_dict()["name"] == "Joe"
+
+
+def test_query_order_fields(entities):
+    results = snippets.query_indexing_considerations()
+    assert len(results) == 4
+    assert results[0].to_dict()["name"] == "Mallory"
+    assert results[1].to_dict()["name"] == "Joe"
+    assert results[2].to_dict()["name"] == "Eve"
+    assert results[3].to_dict()["name"] == "Charlie"

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -25,8 +25,10 @@ def query_or_filter(project_id: str) -> None:
     # Execute the query
     query = col_ref.where(
         Or(
-            FieldFilter("capital", "==", True),
-            FieldFilter("population", ">", 1_000_000),
+            [
+                FieldFilter("capital", "==", True),
+                FieldFilter("population", ">", 1_000_000),
+            ]
         )
     )
     docs = query.stream()
@@ -47,11 +49,15 @@ def query_or_compound_filter(project_id: str) -> None:
     # Execute the query
     query = col_ref.where(
         And(
-            FieldFilter("state", "==", "CA"),
-            Or(
-                FieldFilter("capital", "==", True),
-                FieldFilter("population", ">", 1000000),
-            ),
+            [
+                FieldFilter("state", "==", "CA"),
+                Or(
+                    [
+                        FieldFilter("capital", "==", True),
+                        FieldFilter("population", ">", 1000000),
+                    ]
+                ),
+            ]
         )
     )
     docs = query.stream()

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -27,7 +27,7 @@ def query_or_filter(project_id: str) -> None:
     query = col_ref.where(
         Or(
             FieldFilter("capital", "==", True),
-            FieldFilter("population", ">", 1000000)
+            FieldFilter("population", ">", 1_000_000)
         )
     )
     docs = query.stream()

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -12,28 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START firestore_query_filter_or]
 from google.cloud import firestore
 from google.cloud.firestore_v1.base_query import FieldFilter, Or
 
 
-def query_or_composite_filter(project_id: str) -> None:
+def query_or_filter(project_id: str) -> None:
     # Instantiate the Firestore client
     client = firestore.Client(project=project_id)
-    col_ref = client.collection("users")
+    # [START firestore_query_filter_or]
+    from google.cloud.firestore_v1.base_query import FieldFilter, Or
 
-    filter_1 = FieldFilter("birthYear", "==", 1906)
-    filter_2 = FieldFilter("birthYear", "==", 1912)
-
-    # Create the union filter of the two filters (queries)
-    or_filter = Or(filters=[filter_1, filter_2])
-
+    col_ref = client.collection("cities")
     # Execute the query
-    docs = col_ref.where(filter=or_filter).stream()
+    query = col_ref.where(
+        Or(
+            FieldFilter("capital", "==", True),
+            FieldFilter("population", ">", 1000000)
+        )
+    )
+    docs = query.stream()
+    # [STOP firestore_query_filter_or]
 
     print("Documents found:")
     for doc in docs:
         print(f"ID: {doc.id}")
 
 
-# [END firestore_query_filter_or]
+def query_or_compound_filter(project_id: str) -> None:
+    # Instantiate the Firestore client
+    client = firestore.Client(project=project_id)
+    # [START firestore_query_filter_or_compound]
+    from google.cloud.firestore_v1.base_query import FieldFilter, Or, And
+
+    col_ref = client.collection("cities")
+    # Execute the query
+    query = col_ref.where(
+        And(
+            FieldFilter("state", "==", "CA"),
+            Or(
+                FieldFilter("capital", "==", True),
+                FieldFilter("population", ">", 1000000),
+            ),
+        )
+    )
+    docs = query.stream()
+    # [STOP firestore_query_filter_or_compound]
+
+    print("Documents found:")
+    for doc in docs:
+        print(f"ID: {doc.id}")

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -24,7 +24,7 @@ def query_or_filter(project_id: str) -> None:
     col_ref = client.collection("cities")
     # Execute the query
     query = col_ref.where(
-        Or(
+        filter=Or(
             [
                 FieldFilter("capital", "==", True),
                 FieldFilter("population", ">", 1_000_000),
@@ -48,7 +48,7 @@ def query_or_compound_filter(project_id: str) -> None:
     col_ref = client.collection("cities")
     # Execute the query
     query = col_ref.where(
-        And(
+        filter=And(
             [
                 FieldFilter("state", "==", "CA"),
                 Or(

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -27,7 +27,7 @@ def query_or_filter(project_id: str) -> None:
     query = col_ref.where(
         Or(
             FieldFilter("capital", "==", True),
-            FieldFilter("population", ">", 1_000_000)
+            FieldFilter("population", ">", 1_000_000),
         )
     )
     docs = query.stream()

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -30,7 +30,7 @@ def query_or_filter(project_id: str) -> None:
         )
     )
     docs = query.stream()
-    # [STOP firestore_query_filter_or]
+    # [END firestore_query_filter_or]
 
     print("Documents found:")
     for doc in docs:
@@ -55,7 +55,7 @@ def query_or_compound_filter(project_id: str) -> None:
         )
     )
     docs = query.stream()
-    # [STOP firestore_query_filter_or_compound]
+    # [END firestore_query_filter_or_compound]
 
     print("Documents found:")
     for doc in docs:

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from google.cloud import firestore
-from google.cloud.firestore_v1.base_query import FieldFilter, Or
 
 
 def query_or_filter(project_id: str) -> None:

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.cloud import firestore
-
 
 def query_or_filter(client) -> None:
     # [START firestore_query_filter_or]

--- a/firestore/cloud-client/query_filter_or.py
+++ b/firestore/cloud-client/query_filter_or.py
@@ -15,9 +15,7 @@
 from google.cloud import firestore
 
 
-def query_or_filter(project_id: str) -> None:
-    # Instantiate the Firestore client
-    client = firestore.Client(project=project_id)
+def query_or_filter(client) -> None:
     # [START firestore_query_filter_or]
     from google.cloud.firestore_v1.base_query import FieldFilter, Or
 
@@ -39,9 +37,7 @@ def query_or_filter(project_id: str) -> None:
         print(f"ID: {doc.id}")
 
 
-def query_or_compound_filter(project_id: str) -> None:
-    # Instantiate the Firestore client
-    client = firestore.Client(project=project_id)
+def query_or_compound_filter(client) -> None:
     # [START firestore_query_filter_or_compound]
     from google.cloud.firestore_v1.base_query import FieldFilter, Or, And
 

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -20,6 +20,7 @@ import pytest
 
 from query_filter_or import query_or_compound_filter
 from query_filter_or import query_or_filter
+from .snippets_test import TestFirestoreClient
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
 PROJECT_ID = os.environ["FIRESTORE_PROJECT"]
@@ -60,7 +61,7 @@ def delete_document_collection(data, collection):
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_query_or_filter(capsys, data):
-    client = firestore.Client(project=PROJECT_ID)
+    client = TestFirestoreClient(project=PROJECT_ID, add_unique_string=False)
     collection = client.collection("cities")
 
     try:
@@ -79,7 +80,7 @@ def test_query_or_filter(capsys, data):
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_query_or_compound_filter(capsys, data):
-    client = firestore.Client(project=PROJECT_ID)
+    client = TestFirestoreClient(project=PROJECT_ID, add_unique_string=False)
     collection = client.collection("cities")
 
     try:

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -15,7 +15,6 @@
 import os
 
 import backoff
-from google.cloud import firestore
 import pytest
 
 from query_filter_or import query_or_compound_filter
@@ -68,7 +67,7 @@ def test_query_or_filter(capsys, data):
 
     try:
         create_document_collection(data, collection)
-        query_or_filter(PROJECT_ID)
+        query_or_filter(client)
     finally:
         delete_document_collection(data, collection)
 
@@ -89,7 +88,7 @@ def test_query_or_compound_filter(capsys, data):
 
     try:
         create_document_collection(data, collection)
-        query_or_compound_filter(PROJECT_ID)
+        query_or_compound_filter(client)
     finally:
         delete_document_collection(data, collection)
 

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -18,7 +18,7 @@ import backoff
 from google.cloud import firestore
 import pytest
 
-from query_filter_or import query_or_composite_filter
+from query_filter_or import query_or_compound_filter
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
 PROJECT_ID = os.environ["FIRESTORE_PROJECT"]

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -18,8 +18,8 @@ import backoff
 from google.cloud import firestore
 import pytest
 
-from query_filter_or import query_or_filter
 from query_filter_or import query_or_compound_filter
+from query_filter_or import query_or_filter
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
 PROJECT_ID = os.environ["FIRESTORE_PROJECT"]

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -75,6 +75,7 @@ def test_query_or_filter(capsys, data):
         else:
             assert city not in out
 
+
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_query_or_compound_filter(capsys, data):
     client = firestore.Client(project=PROJECT_ID)
@@ -88,8 +89,9 @@ def test_query_or_compound_filter(capsys, data):
 
     out, _ = capsys.readouterr()
     for city in data:
-        if data[city]["state"] == "CA" and (data[city]["capital"] or data[city]["population"] > 1_000_000):
+        if data[city]["state"] == "CA" and (
+            data[city]["capital"] or data[city]["population"] > 1_000_000
+        ):
             assert city in out
         else:
             assert city not in out
-

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -20,7 +20,7 @@ import pytest
 
 from query_filter_or import query_or_compound_filter
 from query_filter_or import query_or_filter
-from .snippets_test import TestFirestoreClient
+import snippets_test
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
 PROJECT_ID = os.environ["FIRESTORE_PROJECT"]
@@ -61,7 +61,9 @@ def delete_document_collection(data, collection):
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_query_or_filter(capsys, data):
-    client = TestFirestoreClient(project=PROJECT_ID, add_unique_string=False)
+    client = snippets_test.TestFirestoreClient(
+        project=PROJECT_ID, add_unique_string=False
+    )
     collection = client.collection("cities")
 
     try:
@@ -80,7 +82,9 @@ def test_query_or_filter(capsys, data):
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
 def test_query_or_compound_filter(capsys, data):
-    client = TestFirestoreClient(project=PROJECT_ID, add_unique_string=False)
+    client = snippets_test.TestFirestoreClient(
+        project=PROJECT_ID, add_unique_string=False
+    )
     collection = client.collection("cities")
 
     try:

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -18,6 +18,7 @@ import backoff
 from google.cloud import firestore
 import pytest
 
+from query_filter_or import query_or_filter
 from query_filter_or import query_or_compound_filter
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]

--- a/firestore/cloud-client/query_filter_or_test.py
+++ b/firestore/cloud-client/query_filter_or_test.py
@@ -27,10 +27,13 @@ PROJECT_ID = os.environ["FIRESTORE_PROJECT"]
 @pytest.fixture(scope="module")
 def data():
     return {
-        "aturing": {"birthYear": 1912},
-        "cbabbage": {"birthYear": 1791},
-        "ghopper": {"birthYear": 1906},
-        "alovelace": {"birthYear": 1815},
+        "San Francisco": {"capital": False, "population": 884_363, "state": "CA"},
+        "Los Angeles": {"capital": False, "population": 3_976_000, "state": "CA"},
+        "Sacramento": {"capital": True, "population": 508_529, "state": "CA"},
+        "New York City": {"capital": False, "population": 8_336_817, "state": "NY"},
+        "Seattle": {"capital": False, "population": 744_955, "state": "WA"},
+        "Olympia": {"capital": True, "population": 52_555, "state": "WA"},
+        "Phoenix": {"capital": True, "population": 1_445_632, "state": "AZ"},
     }
 
 
@@ -55,15 +58,38 @@ def delete_document_collection(data, collection):
 
 
 @backoff.on_exception(backoff.expo, Exception, max_tries=3)
-def test_query_or_composite_filter(capsys, data):
+def test_query_or_filter(capsys, data):
     client = firestore.Client(project=PROJECT_ID)
-    collection = client.collection("users")
+    collection = client.collection("cities")
 
     try:
         create_document_collection(data, collection)
-        query_or_composite_filter(PROJECT_ID)
+        query_or_filter(PROJECT_ID)
     finally:
         delete_document_collection(data, collection)
 
     out, _ = capsys.readouterr()
-    assert "aturing" in out
+    for city in data:
+        if data[city]["capital"] or data[city]["population"] > 1_000_000:
+            assert city in out
+        else:
+            assert city not in out
+
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+def test_query_or_compound_filter(capsys, data):
+    client = firestore.Client(project=PROJECT_ID)
+    collection = client.collection("cities")
+
+    try:
+        create_document_collection(data, collection)
+        query_or_compound_filter(PROJECT_ID)
+    finally:
+        delete_document_collection(data, collection)
+
+    out, _ = capsys.readouterr()
+    for city in data:
+        if data[city]["state"] == "CA" and (data[city]["capital"] or data[city]["population"] > 1_000_000):
+            assert city in out
+        else:
+            assert city not in out
+

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -1029,7 +1029,7 @@ def query_indexing_considerations():
     # [START firestore_query_indexing_considerations]
     query = (
         db.collection("employees")
-        .where("salary", ">", 100000)
+        .where("salary", ">", 100_000)
         .where("experience", ">", 0)
         .order_by("salary").order_by("experience")
     )
@@ -1041,7 +1041,7 @@ def query_order_fields():
     # [START firestore_query_order_fields]
     query = (
         db.collection("employees")
-        .where("salary", ">", 100000)
+        .where("salary", ">", 100_000)
         .order_by("salary")
     )
     results = query.stream()

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -1047,6 +1047,7 @@ def query_indexing_considerations():
 
 
 def query_order_fields():
+    db = firestore.Client()
     # [START firestore_query_order_fields]
     query = db.collection("employees").where("salary", ">", 100_000).order_by("salary")
     results = query.stream()

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -1025,8 +1025,8 @@ def query_filter_compound_multi_ineq():
     # [START firestore_query_filter_compound_multi_ineq]
     query = (
         db.collection("cities")
-        .where("population", ">", 1_000_000)
-        .where("density", "<", 10_000)
+        .where(filter=FieldFilter("population", ">", 1_000_000))
+        .where(filter=FieldFilter("density", "<", 10_000))
     )
     # [END firestore_query_filter_compound_multi_ineq]
     return query
@@ -1037,8 +1037,8 @@ def query_indexing_considerations():
     # [START firestore_query_indexing_considerations]
     query = (
         db.collection("employees")
-        .where("salary", ">", 100_000)
-        .where("experience", ">", 0)
+        .where(filter=FieldFilter("salary", ">", 100_000))
+        .where(filter=FieldFilter("experience", ">", 0))
         .order_by("salary")
         .order_by("experience")
     )
@@ -1049,7 +1049,11 @@ def query_indexing_considerations():
 def query_order_fields():
     db = firestore.Client()
     # [START firestore_query_order_fields]
-    query = db.collection("employees").where("salary", ">", 100_000).order_by("salary")
+    query = (
+        db.collection("employees")
+        .where(filter=FieldFilter("salary", ">", 100_000))
+        .order_by("salary")
+    )
     results = query.stream()
     # Order results by `experience`
     sorted_results = sorted(results, key=lambda x: x.get("experience"))

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -1021,7 +1021,9 @@ def regional_endpoint():
 def query_filter_compound_multi_ineq():
     from google.cloud import firestore
 
-    db = firestore.Client()
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
     # [START firestore_query_filter_compound_multi_ineq]
     query = (
         db.collection("cities")
@@ -1033,7 +1035,9 @@ def query_filter_compound_multi_ineq():
 
 
 def query_indexing_considerations():
-    db = firestore.Client()
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
     # [START firestore_query_indexing_considerations]
     query = (
         db.collection("employees")

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -934,7 +934,7 @@ def in_query_with_array(db):
     # [END firestore_query_filter_in_with_array]
 
 
-def not_in(db):
+def not_in_query(db):
     # [START firestore_query_filter_not_in]
     cities_ref = db.collection("cities")
 
@@ -943,7 +943,7 @@ def not_in(db):
     # [END firestore_query_filter_not_in]
 
 
-def not_equal(db):
+def not_equal_query(db):
     # [START firestore_query_filter_not_equal]
     cities_ref = db.collection("cities")
 

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -926,6 +926,24 @@ def in_query_with_array(db):
     # [END firestore_query_filter_in_with_array]
 
 
+def not_in(db):
+    # [START firestore_query_filter_not_in]
+    cities_ref = db.collection("cities")
+
+    query = cities_ref.where(filter=FieldFilter("country", "not-in", ["USA", "Japan"]))
+    return query
+    # [END firestore_query_filter_not_in]
+
+
+def not_equal(db):
+    # [START firestore_query_filter_not_equal]
+    cities_ref = db.collection("cities")
+
+    query = cities_ref.where(filter=FieldFilter("capital", "!=", False))
+    return query
+    # [END firestore_query_filter_not_equal]
+
+
 def update_document_increment(db):
     # [START firestore_data_set_numeric_increment]
     washington_ref = db.collection("cities").document("DC")
@@ -990,3 +1008,44 @@ def regional_endpoint():
         print(r)
     # [END firestore_regional_endpoint]
     return cities_query
+
+
+def query_filter_compound_multi_ineq():
+    from google.cloud import firestore
+
+    db = firestore.Client()
+    # [START firestore_query_filter_compound_multi_ineq]
+    query = (
+        db.collection("cities")
+        .where("population", ">", 1_000_000)
+        .where("density", "<", 10_000)
+    )
+    # [END firestore_query_filter_compound_multi_ineq]
+    return query
+
+
+def query_indexing_considerations():
+    db = firestore.Client()
+    # [START firestore_query_indexing_considerations]
+    query = (
+        db.collection("employees")
+        .where("salary", ">", 100000)
+        .where("experience", ">", 0)
+        .order_by("salary").order_by("experience")
+    )
+    # [END firestore_query_indexing_considerations]
+    return query
+
+
+def query_order_fields():
+    # [START firestore_query_order_fields]
+    query = (
+        db.collection("employees")
+        .where("salary", ">", 100000)
+        .order_by("salary")
+    )
+    results = query.stream()
+    # Order results by `experience`
+    sorted_results = sorted(results, key=lambda x: x.get("experience"))
+    # [END firestore_query_order_fields]
+    return sorted_results

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -487,7 +487,9 @@ def compound_query_single_clause():
 
 
 def compound_query_valid_multi_clause():
-    db = firestore.Client(add_unique_string=False)  # Flag for testing purposes, needs index to be precreated
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
     # [START firestore_query_filter_compound_multi_eq]
     cities_ref = db.collection("cities")
 
@@ -543,7 +545,9 @@ def order_simple_limit_desc():
 
 
 def order_multiple():
-    db = firestore.Client(add_unique_string=False)  # Flag for testing purposes, needs index to be precreated
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
     # [START firestore_query_order_multi]
     cities_ref = db.collection("cities")
     ordered_city_ref = cities_ref.order_by("state").order_by(
@@ -593,7 +597,9 @@ def order_where_valid():
 
 
 def order_where_invalid():
-    db = firestore.Client(add_unique_string=False)  # Flag for testing purposes, needs index to be precreated
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
     # [START firestore_query_order_field_invalid]
     cities_ref = db.collection("cities")
     query = cities_ref.where(filter=FieldFilter("population", ">", 2500000)).order_by(
@@ -795,7 +801,9 @@ def listen_for_changes():
 
 
 def cursor_multiple_conditions():
-    db = firestore.Client(add_unique_string=False)  # Flag for testing purposes, needs index to be precreated
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
     # [START firestore_query_cursor_start_at_field_value_multi]
     start_at_name = (
         db.collection("cities").order_by("name").start_at({"name": "Springfield"})
@@ -1031,7 +1039,8 @@ def query_indexing_considerations():
         db.collection("employees")
         .where("salary", ">", 100_000)
         .where("experience", ">", 0)
-        .order_by("salary").order_by("experience")
+        .order_by("salary")
+        .order_by("experience")
     )
     # [END firestore_query_indexing_considerations]
     return query
@@ -1039,11 +1048,7 @@ def query_indexing_considerations():
 
 def query_order_fields():
     # [START firestore_query_order_fields]
-    query = (
-        db.collection("employees")
-        .where("salary", ">", 100_000)
-        .order_by("salary")
-    )
+    query = db.collection("employees").where("salary", ">", 100_000).order_by("salary")
     results = query.stream()
     # Order results by `experience`
     sorted_results = sorted(results, key=lambda x: x.get("experience"))

--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -200,7 +200,8 @@ def test_not_in_query(db):
     assert results[0].to_dict()["country"] == "Canada"
 
 
-def test_not_equal_query(db):
+def test_not_equal_query(db_no_unique_string):
+    db = db_no_unique_string
     db.collection("cities").document("Ottawa").set(
         {"capital": True, "country": "Canada"}
     )
@@ -818,7 +819,8 @@ def test_regional_endpoint(db):
     assert len(cities_list) == 2
 
 
-def test_query_filter_compound_multi_ineq(db):
+def test_query_filter_compound_multi_ineq(db_no_unique_string):
+    db = db_no_unique_string
     cities = [
         {"name": "SF", "state": "CA", "population": 1_000_000, "density": 10_000},
         {"name": "LA", "state": "CA", "population": 5_000_000, "density": 8_000},
@@ -834,7 +836,8 @@ def test_query_filter_compound_multi_ineq(db):
     assert results[0].to_dict()["name"] == "NYC"
 
 
-def test_query_indexing_considerations(db):
+def test_query_indexing_considerations(db_no_unique_string):
+    db = db_no_unique_string
     emplyees = [
         {"name": "Alice", "salary": 100_000, "experience": 10},
         {"name": "Bob", "salary": 80_000, "experience": 2},

--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -79,7 +79,7 @@ def db_no_unique_string():
     client = TestFirestoreClient(add_unique_string=False)
     yield client
     # Cleanup
-    test_collections = ["cities"]
+    test_collections = ["cities", "employees"]
     for collection in test_collections:
         try:
             for doc in client.collection(collection).stream():
@@ -835,7 +835,7 @@ def test_query_filter_compound_multi_ineq(db_no_unique_string):
     query = snippets.query_filter_compound_multi_ineq()
     results = list(query.stream())
     assert len(results) == 1
-    assert results[0].to_dict()["name"] == "NYC"
+    assert results[0].to_dict()["name"] == "LA"
 
 
 def test_query_indexing_considerations(db_no_unique_string):
@@ -855,9 +855,9 @@ def test_query_indexing_considerations(db_no_unique_string):
     results = list(query.stream())
     # should contain employees salary > 100_000 sorted by salary and experience
     assert len(results) == 3
-    assert results[0].to_dict()["name"] == "Charlie"
+    assert results[0].to_dict()["name"] == "Joe"
     assert results[1].to_dict()["name"] == "Eve"
-    assert results[2].to_dict()["name"] == "Joe"
+    assert results[2].to_dict()["name"] == "Charlie"
 
 
 def test_query_order_fields(db):

--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -189,6 +189,7 @@ def test_query_filter_in_query_with_array(db):
     results = list(result.stream())
     assert len(results) >= 2
 
+
 def test_not_in_query(db):
     db.collection("cities").document("LA").set({"country": "USA"})
     db.collection("cities").document("Tokyo").set({"country": "Japan"})
@@ -198,14 +199,18 @@ def test_not_in_query(db):
     assert len(results) == 1
     assert results[0].to_dict()["country"] == "Canada"
 
+
 def test_not_equal_query(db):
-    db.collection("cities").document("Ottawa").set({"capital": True, "country": "Canada"})
+    db.collection("cities").document("Ottawa").set(
+        {"capital": True, "country": "Canada"}
+    )
     db.collection("cities").document("Tokyo").set({"capital": True, "country": "Japan"})
     db.collection("cities").document("LA").set({"capital": False, "country": "USA"})
     result = snippets.not_equal_query(db)
     results = list(result.stream())
     assert len(results) == 1
     assert results[0].to_dict()["country"] == "USA"
+
 
 def test_add_custom_class_with_id(db):
     snippets.add_custom_class_with_id()
@@ -812,6 +817,7 @@ def test_regional_endpoint(db):
     cities_list = list(cities_query)
     assert len(cities_list) == 2
 
+
 def test_query_filter_compound_multi_ineq(db):
     cities = [
         {"name": "SF", "state": "CA", "population": 1_000_000, "density": 10_000},
@@ -826,6 +832,7 @@ def test_query_filter_compound_multi_ineq(db):
     results = list(query.stream())
     assert len(results) == 1
     assert results[0].to_dict()["name"] == "NYC"
+
 
 def test_query_indexing_considerations(db):
     emplyees = [
@@ -846,6 +853,7 @@ def test_query_indexing_considerations(db):
     assert results[0].to_dict()["name"] == "Charlie"
     assert results[1].to_dict()["name"] == "Eve"
     assert results[2].to_dict()["name"] == "Joe"
+
 
 def test_query_order_fields(db):
     emplyees = [

--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -205,12 +205,14 @@ def test_not_equal_query(db_no_unique_string):
     db.collection("cities").document("Ottawa").set(
         {"capital": True, "country": "Canada"}
     )
-    db.collection("cities").document("Tokyo").set({"capital": True, "country": "Japan"})
+    db.collection("cities").document("Kyoto").set(
+        {"capital": False, "country": "Japan"}
+    )
     db.collection("cities").document("LA").set({"capital": False, "country": "USA"})
     result = snippets.not_equal_query(db)
     results = list(result.stream())
     assert len(results) == 1
-    assert results[0].to_dict()["country"] == "USA"
+    assert results[0].to_dict()["country"] == "Canada"
 
 
 def test_add_custom_class_with_id(db):

--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -45,6 +45,9 @@ class TestFirestoreClient(firestore.Client):
         return f"{collection_name}-{self._UNIQUE_STRING}"
 
 
+snippets.firestore.Client = TestFirestoreClient
+
+
 @pytest.fixture(scope="function")
 def db():
     client = TestFirestoreClient()

--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -45,12 +45,9 @@ class TestFirestoreClient(firestore.Client):
         return f"{collection_name}-{self._UNIQUE_STRING}"
 
 
-snippets.firestore.Client = TestFirestoreClient
-
-
 @pytest.fixture(scope="function")
 def db():
-    client = snippets.firestore.Client()
+    client = TestFirestoreClient()
     yield client
     # Cleanup
     try:


### PR DESCRIPTION
touches the following region tags:

- firestore_query_filter_compound_multi_ineq
- firestore_query_indexing_considerations
- firestore_query_order_fields
- datastore_query_filter_compound_multi_ineq
- datastore_query_indexing_considerations
- datastore_query_order_fields
- firestore_query_filter_or
- firestore_query_filter_or_compound
- firestore_query_filter_not_eq
- firestore_query_filter_not_in


context: go/firestore_multiineq_sample_tracker