### PR TITLE
chore: update Django samples to 5.1 (Python 3.10+)

### DIFF
--- a/appengine/flexible/django_cloudsql/mysite/settings.py
+++ b/appengine/flexible/django_cloudsql/mysite/settings.py
@@ -158,7 +158,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 
@@ -168,8 +167,14 @@ USE_TZ = True
 # Define static storage via django-storages[google]
 GS_BUCKET_NAME = env("GS_BUCKET_NAME")
 STATIC_URL = "/static/"
-DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
-STATICFILES_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+    },
+}
 GS_DEFAULT_ACL = "publicRead"
 # [END gaeflex_py_django_static_config]
 # [END staticurl]

--- a/appengine/flexible/django_cloudsql/polls/urls.py
+++ b/appengine/flexible/django_cloudsql/polls/urls.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.urls import re_path
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    re_path(r"^$", views.index, name="index"),
+    path("", views.index, name="index"),
 ]

--- a/appengine/flexible/django_cloudsql/requirements.txt
+++ b/appengine/flexible/django_cloudsql/requirements.txt
@@ -1,5 +1,5 @@
-Django==5.0.4; python_version >= "3.10"
-Django==4.2.13; python_version < "3.10"
+Django==5.1; python_version >= "3.10"
+Django==4.2.15; python_version >= "3.8" and python_version < "3.10"
 gunicorn==22.0.0
 psycopg2-binary==2.9.9
 django-environ==0.11.2

--- a/appengine/flexible/hello_world_django/project_name/urls.py
+++ b/appengine/flexible/hello_world_django/project_name/urls.py
@@ -27,13 +27,13 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 import helloworld.views
 
 
 urlpatterns = [
-    url(r"^admin/", include(admin.site.urls)),
-    url(r"^$", helloworld.views.index),
+    path("admin/", include(admin.site.urls)),
+    path("", helloworld.views.index),
 ]

--- a/appengine/flexible/hello_world_django/project_name/urls.py
+++ b/appengine/flexible/hello_world_django/project_name/urls.py
@@ -27,8 +27,8 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.urls import include, path
 from django.contrib import admin
+from django.urls import include, path
 
 import helloworld.views
 

--- a/appengine/flexible/hello_world_django/project_name/urls.py
+++ b/appengine/flexible/hello_world_django/project_name/urls.py
@@ -12,21 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""project_name URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/stable/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
-"""
 from django.contrib import admin
 from django.urls import include, path
 

--- a/appengine/flexible/hello_world_django/requirements.txt
+++ b/appengine/flexible/hello_world_django/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.0.4; python_version >= "3.10"
+Django==5.1; python_version >= "3.10"
 Django==4.2.13; python_version >= "3.8" and python_version < "3.10"
 Django==3.2.25; python_version < "3.8"
 gunicorn==22.0.0

--- a/appengine/flexible/hello_world_django/requirements.txt
+++ b/appengine/flexible/hello_world_django/requirements.txt
@@ -1,4 +1,4 @@
 Django==5.1; python_version >= "3.10"
-Django==4.2.13; python_version >= "3.8" and python_version < "3.10"
+Django==4.2.15; python_version >= "3.8" and python_version < "3.10"
 Django==3.2.25; python_version < "3.8"
 gunicorn==22.0.0

--- a/appengine/flexible_python37_and_earlier/django_cloudsql/polls/urls.py
+++ b/appengine/flexible_python37_and_earlier/django_cloudsql/polls/urls.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from django.urls import re_path
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    re_path(r"^$", views.index, name="index"),
+    path("", views.index, name="index"),
 ]

--- a/appengine/flexible_python37_and_earlier/django_cloudsql/requirements.txt
+++ b/appengine/flexible_python37_and_earlier/django_cloudsql/requirements.txt
@@ -1,5 +1,5 @@
-Django==5.0.4; python_version >= "3.10"
-Django==4.2.13; python_version >= "3.8" and python_version < "3.10"
+Django==5.1; python_version >= "3.10"
+Django==4.2.15; python_version >= "3.8" and python_version < "3.10"
 Django==3.2.25; python_version < "3.8"
 gunicorn==22.0.0
 psycopg2-binary==2.9.9

--- a/appengine/flexible_python37_and_earlier/hello_world_django/project_name/urls.py
+++ b/appengine/flexible_python37_and_earlier/hello_world_django/project_name/urls.py
@@ -27,13 +27,13 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 import helloworld.views
 
 
 urlpatterns = [
-    url(r"^admin/", include(admin.site.urls)),
-    url(r"^$", helloworld.views.index),
+    path("admin/", include(admin.site.urls)),
+    path("", helloworld.views.index),
 ]

--- a/appengine/flexible_python37_and_earlier/hello_world_django/project_name/urls.py
+++ b/appengine/flexible_python37_and_earlier/hello_world_django/project_name/urls.py
@@ -27,8 +27,8 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.urls import include, path
 from django.contrib import admin
+from django.urls import include, path
 
 import helloworld.views
 

--- a/appengine/flexible_python37_and_earlier/hello_world_django/project_name/urls.py
+++ b/appengine/flexible_python37_and_earlier/hello_world_django/project_name/urls.py
@@ -12,21 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""project_name URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/stable/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add an import:  from blog import urls as blog_urls
-    2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
-"""
 from django.contrib import admin
 from django.urls import include, path
 

--- a/appengine/flexible_python37_and_earlier/hello_world_django/requirements.txt
+++ b/appengine/flexible_python37_and_earlier/hello_world_django/requirements.txt
@@ -1,5 +1,4 @@
-Django==5.0.4; python_version >= "3.10"
-Django==5.0.3; python_version >= "3.10"
-Django==4.2.13; python_version >= "3.8" and python_version < "3.10"
+Django==5.1; python_version >= "3.10"
+Django==4.2.15; python_version >= "3.8" and python_version < "3.10"
 Django==3.2.25; python_version < "3.8"
 gunicorn==22.0.0

--- a/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
@@ -1,5 +1,5 @@
-Django==5.0.7; python_version >= "3.10"
-Django==4.2.8; python_version < "3.10"
+Django==5.1; python_version >= "3.10"
+Django==4.2.15; python_version < "3.10"
 django-environ==0.10.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.2.3

--- a/appengine/standard_python3/bundled-services/deferred/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/deferred/django/requirements.txt
@@ -1,6 +1,6 @@
-Django==5.0.3; python_version >= "3.10"
-Django==4.2.8; python_version >= "3.8" and python_version < "3.10"
-Django==3.2.23; python_version < "3.8"
+Django==5.1; python_version >= "3.10"
+Django==4.2.15; python_version >= "3.8" and python_version < "3.10"
+Django==3.2.25; python_version < "3.8"
 django-environ==0.10.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.3.1

--- a/appengine/standard_python3/bundled-services/mail/django/main.py
+++ b/appengine/standard_python3/bundled-services/mail/django/main.py
@@ -17,6 +17,7 @@ import os
 from django.conf import settings
 from django.core.wsgi import get_wsgi_application
 from django.http import HttpResponse
+from django.urls import path
 from django.urls import re_path
 from google.appengine.api import mail, wrap_wsgi_app
 
@@ -105,9 +106,9 @@ def receive_bounce(request):
 
 
 urlpatterns = [
-    re_path(r"^$", home_page),
+    path("", home_page),
     re_path(r"^_ah/mail/.*$", receive_mail),
-    re_path(r"^_ah/bounce$", receive_bounce),
+    path("_ah/bounce", receive_bounce),
 ]
 
 settings.configure(

--- a/appengine/standard_python3/bundled-services/mail/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/mail/django/requirements.txt
@@ -1,6 +1,6 @@
-Django==5.0.7; python_version >= "3.10"
-Django==4.2.8; python_version >= "3.8" and python_version < "3.10"
-Django==3.2.23; python_version < "3.8"
+Django==5.1; python_version >= "3.10"
+Django==4.2.15; python_version >= "3.8" and python_version < "3.10"
+Django==3.2.25; python_version < "3.8"
 django-environ==0.10.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.2.3

--- a/appengine/standard_python3/django/requirements.txt
+++ b/appengine/standard_python3/django/requirements.txt
@@ -1,6 +1,6 @@
-Django==5.0.3; python_version >= "3.10"
-Django==4.2.8; python_version >= "3.8" and python_version < "3.10"
-Django==3.2.23; python_version < "3.8"
+Django==5.1; python_version >= "3.10"
+Django==4.2.15; python_version >= "3.8" and python_version < "3.10"
+Django==3.2.25; python_version < "3.8"
 django-environ==0.10.0
 psycopg2-binary==2.9.9
 google-cloud-secret-manager==2.16.1

--- a/kubernetes_engine/django_tutorial/requirements.txt
+++ b/kubernetes_engine/django_tutorial/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.0.4; python_version >= "3.10"
+Django==5.1; python_version >= "3.10"
 Django==4.2.13; python_version >= "3.8" and python_version < "3.10"
 Django==3.2.25; python_version < "3.8"
 # Uncomment the mysqlclient requirement if you are using MySQL rather than

--- a/run/django/mysite/settings.py
+++ b/run/django/mysite/settings.py
@@ -161,7 +161,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 
@@ -170,8 +169,14 @@ USE_TZ = True
 # Define static storage via django-storages[google]
 GS_BUCKET_NAME = env("GS_BUCKET_NAME")
 STATIC_URL = "/static/"
-DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
-STATICFILES_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+    },
+}
 GS_DEFAULT_ACL = "publicRead"
 # [END cloudrun_django_static_config]
 

--- a/run/django/requirements.txt
+++ b/run/django/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.0.4; python_version >= "3.10"
+Django==5.1; python_version >= "3.10"
 Django==4.2.13; python_version >= "3.8" and python_version < "3.10"
 Django==3.2.25; python_version < "3.8"
 django-storages[google]==1.14.2


### PR DESCRIPTION
## Description

Replaces #12111, #12112, #12113, #12114, #12116, #12117

* Updates Django 5.x series to 5.1 for Python 3.10+ 
* Updates Django 4.x series to latest patch for Python 3.8+
* Updates Django 3.x series to latest patch for <Python 3.8
* Removes duplicate dependency declaration for Python 3.10 in some samples
* Applies `django-upgrade` targetting minimum supported version per sample (s/re_path/path, adds `STORAGES`)

- [x] Please **merge** this PR for me once it is approved