### PR TITLE
docs: Create set_undefined_finding sample

### DIFF
--- a/securitycenter/snippets/snippets_mute_config.py
+++ b/securitycenter/snippets/snippets_mute_config.py
@@ -257,7 +257,7 @@ def set_undefined_finding(finding_path: str) -> None:
     request.mute = securitycenter.Finding.Mute.UNDEFINED
 
     finding = client.set_mute(request)
-    print(f"Mute value for the finding: {finding.mute.name}")
+    print(f"Reset mute value for the finding: {finding.mute.name}")
 
 
 # [END securitycenter_set_mute_undefined]

--- a/securitycenter/snippets/snippets_mute_config.py
+++ b/securitycenter/snippets/snippets_mute_config.py
@@ -235,7 +235,7 @@ def set_unmute_finding(finding_path: str) -> None:
 
 
 # [START securitycenter_set_mute_undefined]
-def set_unmute_finding(finding_path: str) -> None:
+def set_undefined_finding(finding_path: str) -> None:
     """
       Reset mute state of an individual finding.
       Resetting a finding that isn't muted or unmuted has no effect.

--- a/securitycenter/snippets/snippets_mute_config.py
+++ b/securitycenter/snippets/snippets_mute_config.py
@@ -234,6 +234,35 @@ def set_unmute_finding(finding_path: str) -> None:
 # [END securitycenter_set_unmute]
 
 
+# [START securitycenter_set_mute_undefined]
+def set_unmute_finding(finding_path: str) -> None:
+    """
+      Reset mute state of an individual finding.
+      Resetting a finding that isn't muted or unmuted has no effect.
+      Various mute states are: UNDEFINED/MUTE/UNMUTE.
+    Args:
+        finding_path: The relative resource name of the finding. See:
+        https://cloud.google.com/apis/design/resource_names#relative_resource_name
+        Use any one of the following formats:
+        - organizations/{organization_id}/sources/{source_id}/finding/{finding_id},
+        - folders/{folder_id}/sources/{source_id}/finding/{finding_id},
+        - projects/{project_id}/sources/{source_id}/finding/{finding_id}.
+    """
+    from google.cloud import securitycenter
+
+    client = securitycenter.SecurityCenterClient()
+
+    request = securitycenter.SetMuteRequest()
+    request.name = finding_path
+    request.mute = securitycenter.Finding.Mute.UNDEFINED
+
+    finding = client.set_mute(request)
+    print(f"Mute value for the finding: {finding.mute.name}")
+
+
+# [END securitycenter_set_mute_undefined]
+
+
 # [START securitycenter_bulk_mute]
 def bulk_mute_findings(parent_path: str, mute_rule: str) -> None:
     """

--- a/securitycenter/snippets/snippets_mute_config_test.py
+++ b/securitycenter/snippets/snippets_mute_config_test.py
@@ -135,6 +135,16 @@ def test_set_unmute_finding(capsys: CaptureFixture, finding):
 @backoff.on_exception(
     backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
 )
+def test_set_undefined_finding(capsys: CaptureFixture, finding):
+    finding_path = finding.get("finding1")
+    snippets_mute_config.set_undefined_finding(finding_path)
+    out, _ = capsys.readouterr()
+    assert re.search("Reset mute value for the finding: UNDEFINED", out)
+
+
+@backoff.on_exception(
+    backoff.expo, (InternalServerError, ServiceUnavailable, NotFound), max_tries=3
+)
 def test_bulk_mute_findings(capsys: CaptureFixture, finding):
     # Mute findings that belong to this project.
     snippets_mute_config.bulk_mute_findings(


### PR DESCRIPTION
## Add set_undefined_finding code sample for use case: Resetting an individual finding mute_state to UNDEFINED.

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved