### PR TITLE
fix(kms): align sample to other languages

### DIFF
--- a/kms/snippets/create_key_for_import.py
+++ b/kms/snippets/create_key_for_import.py
@@ -56,6 +56,8 @@ def create_key_for_import(
             "parent": key_ring_name,
             "crypto_key_id": crypto_key_id,
             "crypto_key": key,
+             # Do not allow KMS to generate an initial version of this key.
+            "skip_initial_version_creation": True,
         }
     )
     print(f"Created hsm key: {created_key.name}")

--- a/kms/snippets/create_key_for_import.py
+++ b/kms/snippets/create_key_for_import.py
@@ -56,7 +56,7 @@ def create_key_for_import(
             "parent": key_ring_name,
             "crypto_key_id": crypto_key_id,
             "crypto_key": key,
-             # Do not allow KMS to generate an initial version of this key.
+            # Do not allow KMS to generate an initial version of this key.
             "skip_initial_version_creation": True,
         }
     )


### PR DESCRIPTION
## Description

Replaces #12160 

As per #12160, @tdbhacks noted that for the other languages for this sample, https://cloud.google.com/kms/docs/importing-a-key#create_targets, this change ensures that all languages show the same functionality for the same sample. 


## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved