### PR TITLE
Add Firestore vector search query snippets

### DIFF
--- a/firestore/cloud-client/requirements.txt
+++ b/firestore/cloud-client/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-firestore==2.11.1
+google-cloud-firestore==2.17.2

--- a/firestore/cloud-client/vector_search.py
+++ b/firestore/cloud-client/vector_search.py
@@ -1,0 +1,77 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+
+from google.cloud import firestore
+
+
+def store_vectors():
+    # [START firestore_store_vectors]
+    from google.cloud import firestore
+    from google.cloud.firestore_v1.vector import Vector
+
+    firestore_client = firestore.Client()
+    collection = firestore_client.collection("coffee-beans")
+    doc = {
+        "name": "Kahawa coffee beans",
+        "description": "Information about the Kahawa coffee beans.",
+        "embedding_field": Vector([1.0, 2.0, 3.0]),
+    }
+
+    collection.add(doc)
+    # [END firestore_store_vectors]
+
+
+def vector_search_basic():
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
+
+    # [START firestore_vector_search_basic]
+    from google.cloud.firestore_v1.base_vector_query import DistanceMeasure
+    from google.cloud.firestore_v1.vector import Vector
+
+    collection = db.collection("coffee-beans")
+
+    # Requires a vector index
+    vector_query = collection.find_nearest(
+        vector_field="embedding_field",
+        query_vector=Vector([3.0, 1.0, 2.0]),
+        distance_measure=DistanceMeasure.EUCLIDEAN,
+        limit=5,
+    )
+    # [END firestore_vector_search_basic]
+    return vector_query
+
+
+def vector_search_prefilter():
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
+
+    # [START firestore_vector_search_basic]
+    from google.cloud.firestore_v1.base_vector_query import DistanceMeasure
+    from google.cloud.firestore_v1.vector import Vector
+
+    collection = db.collection("coffee-beans")
+
+    # Similarity search with pre-filter
+    # Requires a composite vector index
+    vector_query = collection.where("color", "==", "red").find_nearest(
+        vector_field="embedding_field",
+        query_vector=Vector([3.0, 1.0, 2.0]),
+        distance_measure=DistanceMeasure.EUCLIDEAN,
+        limit=5,
+    )
+    # [END firestore_vector_search_basic]
+    return vector_query

--- a/firestore/cloud-client/vector_search.py
+++ b/firestore/cloud-client/vector_search.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 
 
-from google.cloud import firestore
-
-
 def store_vectors():
     # [START firestore_store_vectors]
     from google.cloud import firestore
@@ -32,11 +29,7 @@ def store_vectors():
     # [END firestore_store_vectors]
 
 
-def vector_search_basic():
-    db = firestore.Client(
-        add_unique_string=False
-    )  # Flag for testing purposes, needs index to be precreated
-
+def vector_search_basic(db):
     # [START firestore_vector_search_basic]
     from google.cloud.firestore_v1.base_vector_query import DistanceMeasure
     from google.cloud.firestore_v1.vector import Vector
@@ -54,11 +47,7 @@ def vector_search_basic():
     return vector_query
 
 
-def vector_search_prefilter():
-    db = firestore.Client(
-        add_unique_string=False
-    )  # Flag for testing purposes, needs index to be precreated
-
+def vector_search_prefilter(db):
     # [START firestore_vector_search_basic]
     from google.cloud.firestore_v1.base_vector_query import DistanceMeasure
     from google.cloud.firestore_v1.vector import Vector

--- a/firestore/cloud-client/vector_search_test.py
+++ b/firestore/cloud-client/vector_search_test.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from google.cloud import firestore
+from google.cloud.firestore_v1.vector import Vector
+from vector_search import store_vectors
+from vector_search import vector_search_basic
+from vector_search import vector_search_prefilter
+
+
+os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
+PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
+
+
+def test_store_vectors():
+    db = firestore.Client()
+    store_vectors()
+
+    results = db.collection("coffee-beans").limit(5).stream()
+    results_list = list(results)
+    assert len(results_list) == 1
+
+
+def add_coffee_beans_data(db):
+    coll = db.collection("coffee-beans")
+    coll.document("bean1").set(
+        {"name": "Arabica", "embedding_field": Vector([5.0, 1.0, 2.0]), "color": "red"}
+    )
+    coll.document("bean2").set(
+        {"name": "Robusta", "embedding_field": Vector([4.0, 1.0, 2.0]), "color": "blue"}
+    )
+    coll.document("bean3").set(
+        {"name": "Excelsa", "embedding_field": Vector([6.0, 1.0, 2.0]), "color": "red"}
+    )
+    coll.document("bean4").set(
+        {
+            "name": "Liberica",
+            "embedding_field": Vector([3.0, 1.0, 2.0]),
+            "color": "green",
+        }
+    )
+
+
+def test_vector_search_basic():
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
+    add_coffee_beans_data(db)
+
+    vector_query = vector_search_basic()
+    results = list(vector_query.stream())
+
+    assert len(results) == 4
+    assert results[0].to_dict()["name"] == "Liberica"
+    assert results[1].to_dict()["name"] == "Robusta"
+    assert results[2].to_dict()["name"] == "Arabica"
+    assert results[3].to_dict()["name"] == "Excelsa"
+
+
+def test_vector_search_prefilter():
+    db = firestore.Client(
+        add_unique_string=False
+    )  # Flag for testing purposes, needs index to be precreated
+    add_coffee_beans_data(db)
+
+    vector_query = vector_search_prefilter()
+    results = list(vector_query.stream())
+
+    assert len(results) == 2
+    assert results[0].to_dict()["name"] == "Arabica"
+    assert results[1].to_dict()["name"] == "Excelsa"

--- a/firestore/cloud-client/vector_search_test.py
+++ b/firestore/cloud-client/vector_search_test.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import os
+
 from google.cloud import firestore
 from google.cloud.firestore_v1.vector import Vector
+
 from vector_search import store_vectors
 from vector_search import vector_search_basic
 from vector_search import vector_search_prefilter

--- a/firestore/cloud-client/vector_search_test.py
+++ b/firestore/cloud-client/vector_search_test.py
@@ -61,7 +61,7 @@ def test_vector_search_basic():
     )  # Flag for testing purposes, needs index to be precreated
     add_coffee_beans_data(db)
 
-    vector_query = vector_search_basic()
+    vector_query = vector_search_basic(db)
     results = list(vector_query.stream())
 
     assert len(results) == 4
@@ -77,7 +77,7 @@ def test_vector_search_prefilter():
     )  # Flag for testing purposes, needs index to be precreated
     add_coffee_beans_data(db)
 
-    vector_query = vector_search_prefilter()
+    vector_query = vector_search_prefilter(db)
     results = list(vector_query.stream())
 
     assert len(results) == 2


### PR DESCRIPTION
## Description

Add Firestore Python Vector Search query snippets.

NOTE: This needs an index setup on the test project that this runs the tests, but I'm not sure what project that is, it's unclear to me how the other tests have the FIRESTORE_PROJECT environment variable initialized in the CI environment.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved