### PR TITLE
chore: refactored samples, to make them follow copy-paste-run approach

### DIFF
--- a/texttospeech/snippets/audio_profile.py
+++ b/texttospeech/snippets/audio_profile.py
@@ -27,10 +27,13 @@ import argparse
 
 # [START tts_synthesize_text_audio_profile]
 # [START tts_synthesize_text_audio_profile_beta]
-def synthesize_text_with_audio_profile(text, output, effects_profile_id):
+def synthesize_text_with_audio_profile():
     """Synthesizes speech from the input string of text."""
     from google.cloud import texttospeech
 
+    text = "hello"
+    output = "output.mp3"
+    effects_profile_id = "telephony-class-application"
     client = texttospeech.TextToSpeechClient()
 
     input_text = texttospeech.SynthesisInput(text=text)

--- a/texttospeech/snippets/audio_profile_test.py
+++ b/texttospeech/snippets/audio_profile_test.py
@@ -18,16 +18,14 @@ import os.path
 
 import audio_profile
 
-TEXT = "hello"
 OUTPUT = "output.mp3"
-EFFECTS_PROFILE_ID = "telephony-class-application"
 
 
 def test_audio_profile(capsys):
     if os.path.exists(OUTPUT):
         os.remove(OUTPUT)
     assert not os.path.exists(OUTPUT)
-    audio_profile.synthesize_text_with_audio_profile(TEXT, OUTPUT, EFFECTS_PROFILE_ID)
+    audio_profile.synthesize_text_with_audio_profile()
     out, err = capsys.readouterr()
 
     assert ('Audio content written to file "%s"' % OUTPUT) in out

--- a/texttospeech/snippets/long_audio_quickstart.py
+++ b/texttospeech/snippets/long_audio_quickstart.py
@@ -15,17 +15,17 @@
 from google.cloud import texttospeech
 
 
-def synthesize_long_audio(project_id, location, output_gcs_uri):
+def synthesize_long_audio(project_id: str, output_gcs_uri: str) -> None:
     """
     Synthesizes long input, writing the resulting audio to `output_gcs_uri`.
 
-    Example usage: synthesize_long_audio('12345', 'us-central1', 'gs://{BUCKET_NAME}/{OUTPUT_FILE_NAME}.wav')
-
+    Args:
+        project_id: ID or number of the Google Cloud project you want to use.
+        output_gcs_uri: Specifies a Cloud Storage URI for the synthesis results.
+            Must be specified in the format:
+            ``gs://bucket_name/object_name``, and the bucket must
+            already exist.
     """
-    # TODO(developer): Uncomment and set the following variables
-    # project_id = 'YOUR_PROJECT_ID'
-    # location = 'YOUR_LOCATION'
-    # output_gcs_uri = 'YOUR_OUTPUT_GCS_URI'
 
     client = texttospeech.TextToSpeechLongAudioSynthesizeClient()
 
@@ -41,7 +41,7 @@ def synthesize_long_audio(project_id, location, output_gcs_uri):
         language_code="en-US", name="en-US-Standard-A"
     )
 
-    parent = f"projects/{project_id}/locations/{location}"
+    parent = f"projects/{project_id}/locations/us-central1"
 
     request = texttospeech.SynthesizeLongAudioRequest(
         parent=parent,

--- a/texttospeech/snippets/long_audio_quickstart_test.py
+++ b/texttospeech/snippets/long_audio_quickstart_test.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import uuid
 
+import google.auth
 from google.cloud import storage
 import pytest
 
 from long_audio_quickstart import synthesize_long_audio
-
-
-PROJECT_NUMBER = os.environ["GOOGLE_CLOUD_PROJECT_NUMBER"]
 
 
 @pytest.fixture(scope="module")
@@ -39,6 +36,7 @@ def test_bucket():
 def test_synthesize_long_audio(capsys, test_bucket):
     file_name = "fake_file.wav"
     output_gcs_uri = f"gs://{test_bucket.name}/{file_name}"
-    synthesize_long_audio(str(PROJECT_NUMBER), "us-central1", output_gcs_uri)
+    _, project_id = google.auth.default()
+    synthesize_long_audio(project_id, output_gcs_uri)
     out, _ = capsys.readouterr()
     assert "Finished processing, check your GCS bucket to find your audio file!" in out

--- a/texttospeech/snippets/ssml_addresses.py
+++ b/texttospeech/snippets/ssml_addresses.py
@@ -25,20 +25,17 @@ from google.cloud import texttospeech
 
 
 # [START tts_ssml_address_audio]
-def ssml_to_audio(ssml_text, outfile):
-    # Generates SSML text from plaintext.
-    #
-    # Given a string of SSML text and an output file name, this function
-    # calls the Text-to-Speech API. The API returns a synthetic audio
-    # version of the text, formatted according to the SSML commands. This
-    # function saves the synthetic audio to the designated output file.
-    #
-    # Args:
-    # ssml_text: string of SSML text
-    # outfile: string name of file under which to save audio output
-    #
-    # Returns:
-    # nothing
+def ssml_to_audio(ssml_text: str) -> None:
+    """
+    Generates SSML text from plaintext.
+    Given a string of SSML text and an output file name, this function
+    calls the Text-to-Speech API. The API returns a synthetic audio
+    version of the text, formatted according to the SSML commands. This
+    function saves the synthetic audio to the designated output file.
+
+    Args:
+        ssml_text: string of SSML text
+    """
 
     # Instantiates a client
     client = texttospeech.TextToSpeechClient()
@@ -64,26 +61,26 @@ def ssml_to_audio(ssml_text, outfile):
     )
 
     # Writes the synthetic audio to the output file.
-    with open(outfile, "wb") as out:
+    with open("test_example.mp3", "wb") as out:
         out.write(response.audio_content)
-        print("Audio content written to file " + outfile)
+        print("Audio content written to file " + "test_example.mp3")
     # [END tts_ssml_address_audio]
 
 
 # [START tts_ssml_address_ssml]
-def text_to_ssml(inputfile):
-    # Generates SSML text from plaintext.
-    # Given an input filename, this function converts the contents of the text
-    # file into a string of formatted SSML text. This function formats the SSML
-    # string so that, when synthesized, the synthetic audio will pause for two
-    # seconds between each line of the text file. This function also handles
-    # special text characters which might interfere with SSML commands.
-    #
-    # Args:
-    # inputfile: string name of plaintext file
-    #
-    # Returns:
-    # A string of SSML text based on plaintext input
+def text_to_ssml(inputfile: str) -> str:
+    """
+    Generates SSML text from plaintext.
+    Given an input filename, this function converts the contents of the text
+    file into a string of formatted SSML text. This function formats the SSML
+    string so that, when synthesized, the synthetic audio will pause for two
+    seconds between each line of the text file. This function also handles
+    special text characters which might interfere with SSML commands.
+
+    Args:
+        inputfile: name of plaintext file
+    Returns: SSML text based on plaintext input
+    """
 
     # Parses lines of input file
     with open(inputfile) as f:

--- a/texttospeech/snippets/ssml_addresses_test.py
+++ b/texttospeech/snippets/ssml_addresses_test.py
@@ -37,7 +37,7 @@ def test_ssml_to_audio(capsys):
         input_ssml = f.read()
 
     # Assert audio file generated
-    ssml_to_audio(input_ssml, "test_example.mp3")
+    ssml_to_audio(input_ssml)
     out, err = capsys.readouterr()
 
     # Assert MP3 file created

--- a/texttospeech/snippets/synthesize_text.py
+++ b/texttospeech/snippets/synthesize_text.py
@@ -26,10 +26,11 @@ import argparse
 
 
 # [START tts_synthesize_text]
-def synthesize_text(text):
+def synthesize_text():
     """Synthesizes speech from the input string of text."""
     from google.cloud import texttospeech
 
+    text = "Hello there."
     client = texttospeech.TextToSpeechClient()
 
     input_text = texttospeech.SynthesisInput(text=text)
@@ -60,16 +61,16 @@ def synthesize_text(text):
 
 
 # [START tts_synthesize_ssml]
-def synthesize_ssml(ssml):
+def synthesize_ssml():
     """Synthesizes speech from the input string of ssml.
 
     Note: ssml must be well-formed according to:
         https://www.w3.org/TR/speech-synthesis/
 
-    Example: <speak>Hello there.</speak>
     """
     from google.cloud import texttospeech
 
+    ssml = "<speak>Hello there.</speak>"
     client = texttospeech.TextToSpeechClient()
 
     input_text = texttospeech.SynthesisInput(ssml=ssml)

--- a/texttospeech/snippets/synthesize_text_test.py
+++ b/texttospeech/snippets/synthesize_text_test.py
@@ -19,12 +19,9 @@ import os
 
 import synthesize_text
 
-TEXT = "Hello there."
-SSML = "<speak>Hello there.</speak>"
-
 
 def test_synthesize_text(capsys):
-    synthesize_text.synthesize_text(text=TEXT)
+    synthesize_text.synthesize_text()
     out, err = capsys.readouterr()
 
     assert "Audio content written to file" in out
@@ -33,7 +30,7 @@ def test_synthesize_text(capsys):
 
 
 def test_synthesize_ssml(capsys):
-    synthesize_text.synthesize_ssml(ssml=SSML)
+    synthesize_text.synthesize_ssml()
     out, err = capsys.readouterr()
 
     assert "Audio content written to file" in out


### PR DESCRIPTION
## Description

Get rid of hidden variables in texttospeach samples

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved