### PR TITLE
fix: rasterio and update dependencies

### DIFF
--- a/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.10_sdk:2.47.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.10_sdk:2.58.1 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/main.py
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/main.py
@@ -206,7 +206,7 @@ def load_as_rgb(
 
     def read_band(band_path: str) -> np.ndarray:
         # Use rasterio to read the GeoTIFF values from the band files.
-        with tf.io.gfile.GFile(band_path, "rb") as f, rasterio.open(f) as data:
+        with rasterio.open(band_path) as data:
             return data.read(1).astype(np.float32)
 
     logging.info(

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/requirements.txt
@@ -1,4 +1,4 @@
-Pillow==10.3.0
-apache-beam[gcp]==2.46.0
+Pillow==10.4.0
+apache-beam[gcp]==2.58.1
 rasterio==1.3.10
 tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu

--- a/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.10_sdk:2.47.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.10_sdk:2.58.1 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-landsat/main.py
+++ b/dataflow/gpu-examples/tensorflow-landsat/main.py
@@ -169,7 +169,7 @@ def load_values(scene: str, band_paths: list[str]) -> tuple[str, np.ndarray]:
 
     def read_band(band_path: str) -> np.array:
         # Use rasterio to read the GeoTIFF values from the band files.
-        with tf.io.gfile.GFile(band_path, "rb") as f, rasterio.open(f) as data:
+        with rasterio.open(band_path) as data:
             return data.read(1)
 
     logging.info(f"{scene}: load_values({band_paths})")

--- a/dataflow/gpu-examples/tensorflow-landsat/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat/requirements.txt
@@ -1,4 +1,4 @@
-Pillow==10.3.0
-apache-beam[gcp]==2.46.0
+Pillow==10.4.0
+apache-beam[gcp]==2.58.1
 rasterio==1.3.10
 tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu


### PR DESCRIPTION
## Description

Fixes b/361414289

Rasterio changed the way they read files. It seems like now they support [virtual filesystems](https://rasterio.readthedocs.io/en/latest/topics/vsi.html) and Cloud Storage seems to be supported out of the box.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved