### PR TITLE
fix: remove arbitrary equality comparisons (not supported by renovate)

### DIFF
--- a/appengine/flexible/websockets/requirements.txt
+++ b/appengine/flexible/websockets/requirements.txt
@@ -2,5 +2,5 @@ Flask==1.1.4 # it seems like Flask-sockets doesn't play well with 2.0+
 Flask-Sockets==0.2.1
 gunicorn==22.0.0
 requests==2.31.0
-markupsafe===2.0.1
+markupsafe==2.0.1
 Werkzeug==1.0.1;

--- a/appengine/flexible_python37_and_earlier/websockets/requirements.txt
+++ b/appengine/flexible_python37_and_earlier/websockets/requirements.txt
@@ -2,5 +2,5 @@ Flask==1.1.4 # it seems like Flask-sockets doesn't play well with 2.0+
 Flask-Sockets==0.2.1
 gunicorn==22.0.0
 requests==2.31.0
-markupsafe===2.0.1
+markupsafe==2.0.1
 Werkzeug==1.0.1;

--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements-test.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements-test.txt
@@ -1,3 +1,5 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 mock==3.0.5; python_version < '3.0'
+mock==5.1.0; python_version >= '3.0'

--- a/appengine/standard/endpoints-frameworks-v2/echo/requirements-test.txt
+++ b/appengine/standard/endpoints-frameworks-v2/echo/requirements-test.txt
@@ -1,3 +1,3 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
-mock===3.0.5; python_version < '3.0'
+mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/endpoints-frameworks-v2/quickstart/requirements-test.txt
+++ b/appengine/standard/endpoints-frameworks-v2/quickstart/requirements-test.txt
@@ -1,3 +1,5 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 mock==3.0.5; python_version < '3.0'
+mock==5.1.0; python_version >= '3.0'

--- a/appengine/standard/endpoints-frameworks-v2/quickstart/requirements-test.txt
+++ b/appengine/standard/endpoints-frameworks-v2/quickstart/requirements-test.txt
@@ -1,3 +1,3 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
-mock===3.0.5; python_version < '3.0'
+mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/firebase/firenotes/backend/requirements-test.txt
+++ b/appengine/standard/firebase/firenotes/backend/requirements-test.txt
@@ -1,3 +1,5 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 mock==3.0.5; python_version < '3.0'
+mock==5.1.0; python_version >= '3.0'

--- a/appengine/standard/firebase/firenotes/backend/requirements-test.txt
+++ b/appengine/standard/firebase/firenotes/backend/requirements-test.txt
@@ -1,3 +1,3 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
-mock===3.0.5; python_version < '3.0'
+mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/firebase/firetactoe/firetactoe.py
+++ b/appengine/standard/firebase/firetactoe/firetactoe.py
@@ -20,21 +20,19 @@ try:
     from functools import lru_cache
 except ImportError:
     from functools32 import lru_cache
+
 import json
 import os
 import re
 import time
 import urllib
 
-
 import flask
 from flask import request
-from google.appengine.api import app_identity
-from google.appengine.api import users
+from google.appengine.api import app_identity, users
 from google.appengine.ext import ndb
-from google.auth.transport.requests import AuthorizedSession
 import google.auth
-
+from google.auth.transport.requests import AuthorizedSession
 
 _FIREBASE_CONFIG = "_firebase_config.html"
 

--- a/appengine/standard/firebase/firetactoe/firetactoe_test.py
+++ b/appengine/standard/firebase/firetactoe/firetactoe_test.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
 import re
 
 from google.appengine.api import users
 from google.appengine.ext import ndb
-from six.moves import http_client
+import mock
 import pytest
+from six.moves import http_client
 import webtest
 
 import firetactoe

--- a/appengine/standard/firebase/firetactoe/requirements-test.txt
+++ b/appengine/standard/firebase/firetactoe/requirements-test.txt
@@ -1,4 +1,6 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 WebTest==2.0.35; python_version < '3.0'
 mock==3.0.5; python_version < "3"
+mock==5.1.0; python_version >= '3.0'

--- a/appengine/standard/firebase/firetactoe/requirements-test.txt
+++ b/appengine/standard/firebase/firetactoe/requirements-test.txt
@@ -1,4 +1,4 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'
-mock===3.0.5; python_version < "3"
+mock==3.0.5; python_version < "3"

--- a/appengine/standard/firebase/firetactoe/rest_api.py
+++ b/appengine/standard/firebase/firetactoe/rest_api.py
@@ -21,8 +21,8 @@ except ImportError:
 # [START rest_writing_data]
 import json
 
-from google.auth.transport.requests import AuthorizedSession
 import google.auth
+from google.auth.transport.requests import AuthorizedSession
 
 _FIREBASE_SCOPES = [
     "https://www.googleapis.com/auth/firebase.database",

--- a/appengine/standard/iap/main_test.py
+++ b/appengine/standard/iap/main_test.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import main
 import webtest
+
+import main
 
 
 def test_index(testbed, login):

--- a/appengine/standard/iap/requirements-test.txt
+++ b/appengine/standard/iap/requirements-test.txt
@@ -1,3 +1,4 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/iap/requirements-test.txt
+++ b/appengine/standard/iap/requirements-test.txt
@@ -2,3 +2,4 @@
 pytest==4.6.11; python_version < '3.0'
 pytest==8.3.2; python_version >= '3.0'
 WebTest==2.0.35; python_version < '3.0'
+six==1.16.0

--- a/appengine/standard/mailgun/requirements-test.txt
+++ b/appengine/standard/mailgun/requirements-test.txt
@@ -1,5 +1,7 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 google-api-python-client==1.12.11; python_version < '3.0'
 mock==3.0.5; python_version < '3.0'
+mock==5.1.0; python_version >= '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/mailgun/requirements-test.txt
+++ b/appengine/standard/mailgun/requirements-test.txt
@@ -5,3 +5,4 @@ google-api-python-client==1.12.11; python_version < '3.0'
 mock==3.0.5; python_version < '3.0'
 mock==5.1.0; python_version >= '3.0'
 WebTest==2.0.35; python_version < '3.0'
+six==1.16.0

--- a/appengine/standard/mailgun/requirements-test.txt
+++ b/appengine/standard/mailgun/requirements-test.txt
@@ -1,5 +1,5 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 google-api-python-client==1.12.11; python_version < '3.0'
-mock===3.0.5; python_version < '3.0'
+mock==3.0.5; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/migration/memorystore/appengine_config.py
+++ b/appengine/standard/migration/memorystore/appengine_config.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
 from google.appengine.ext import vendor
+import pkg_resources
 
 # Set path to your libraries folder.
 path = "lib"

--- a/appengine/standard/migration/memorystore/main.py
+++ b/appengine/standard/migration/memorystore/main.py
@@ -24,10 +24,11 @@
 
 ## from google.appengine.api import memcache
 import os
-import redis
 import time
 
 from flask import Flask, redirect, render_template, request
+import redis
+
 
 redis_host = os.environ.get("REDIS_HOST", "localhost")
 redis_port = os.environ.get("REDIS_PORT", "6379")

--- a/appengine/standard/migration/memorystore/main_test.py
+++ b/appengine/standard/migration/memorystore/main_test.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import uuid
+
 from mock import patch
 import pytest
 import redis
-import uuid
 
 import main
 

--- a/appengine/standard/migration/memorystore/requirements-test.txt
+++ b/appengine/standard/migration/memorystore/requirements-test.txt
@@ -1,4 +1,5 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 mock==5.0.2; python_version > '3.0'
 mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/migration/memorystore/requirements-test.txt
+++ b/appengine/standard/migration/memorystore/requirements-test.txt
@@ -3,3 +3,4 @@ pytest==4.6.11; python_version < '3.0'
 pytest==8.3.2; python_version >= '3.0'
 mock==5.0.2; python_version > '3.0'
 mock==3.0.5; python_version < '3.0'
+six==1.16.0

--- a/appengine/standard/migration/memorystore/requirements-test.txt
+++ b/appengine/standard/migration/memorystore/requirements-test.txt
@@ -1,4 +1,4 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 mock==5.0.2; python_version > '3.0'
-mock===3.0.5; python_version < '3.0'
+mock==3.0.5; python_version < '3.0'

--- a/appengine/standard/sendgrid/requirements-test.txt
+++ b/appengine/standard/sendgrid/requirements-test.txt
@@ -4,3 +4,5 @@ pytest==8.3.2; python_version >= '3.0'
 mock==3.0.5; python_version < '3.0'
 mock==5.1.0; python_version >= '3.0'
 WebTest==2.0.35; python_version < '3.0'
+WebTest==3.0.1; python_version >= '3.0'
+six==1.16.0

--- a/appengine/standard/sendgrid/requirements-test.txt
+++ b/appengine/standard/sendgrid/requirements-test.txt
@@ -1,4 +1,4 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
-mock===3.0.5; python_version < '3.0'
+mock==3.0.5; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'

--- a/appengine/standard/sendgrid/requirements-test.txt
+++ b/appengine/standard/sendgrid/requirements-test.txt
@@ -1,4 +1,6 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+pytest==8.3.2; python_version >= '3.0'
 mock==3.0.5; python_version < '3.0'
+mock==5.1.0; python_version >= '3.0'
 WebTest==2.0.35; python_version < '3.0'


### PR DESCRIPTION
Should help resolves errors while running renovate

Currently, #4745 reports "Unexpected range error"

![Unexpected range error](https://github.com/user-attachments/assets/cb07ff1d-729d-448a-8606-523235eeaf42)


Running `npx renovate --platform local` gives more details: 


```
 WARN: Unexpected range error (repository=local)
       "currentValue": "===2.0.1",
       "err": {
         "message": "PEP440 arbitrary equality (===) not supported",
         "stack": "TypeError: PEP440 arbitrary equality (===) not supported [...]"
```

Checking all `requirements*.txt` files, I've removed all `===` references (markupsafe and mock)

While this is valid in [PEP440](https://peps.python.org/pep-0440/#arbitrary-equality), per the message it's not supported in Renovate. 

This may help unblock a number of pending dependency updates (e.g. https://github.com/GoogleCloudPlatform/python-docs-samples/pull/12093#issuecomment-2327875438)
