### PR TITLE
chore(deps): update google-cloud-translate to v3.16.0

### DIFF
--- a/automl/snippets/requirements.txt
+++ b/automl/snippets/requirements.txt
@@ -1,3 +1,3 @@
-google-cloud-translate==3.11.1
+google-cloud-translate==3.16.0
 google-cloud-storage==2.9.0
 google-cloud-automl==2.11.1

--- a/bigquery/remote-function/translate/requirements-test.txt
+++ b/bigquery/remote-function/translate/requirements-test.txt
@@ -1,4 +1,4 @@
 Flask==2.2.2
 functions-framework==3.5.0
-google-cloud-translate==3.11.1
+google-cloud-translate==3.16.0
 pytest==8.2.0

--- a/bigquery/remote-function/translate/requirements.txt
+++ b/bigquery/remote-function/translate/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.2.2
 functions-framework==3.5.0
-google-cloud-translate==3.11.1
+google-cloud-translate==3.16.0
 Werkzeug==2.3.7

--- a/functions/ocr/app/requirements.txt
+++ b/functions/ocr/app/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-pubsub==2.21.5
 google-cloud-storage==2.9.0
-google-cloud-translate==3.11.1
+google-cloud-translate==3.16.0
 google-cloud-vision==3.4.2

--- a/functions/v2/ocr/requirements.txt
+++ b/functions/v2/ocr/requirements.txt
@@ -1,5 +1,5 @@
 functions-framework==3.5.0
 google-cloud-pubsub==2.21.5
 google-cloud-storage==2.9.0
-google-cloud-translate==3.11.1
+google-cloud-translate==3.16.0
 google-cloud-vision==3.4.2

--- a/translate/samples/snippets/hybrid_glossaries/requirements.txt
+++ b/translate/samples/snippets/hybrid_glossaries/requirements.txt
@@ -1,3 +1,3 @@
-google-cloud-translate==3.11.1
+google-cloud-translate==3.16.0
 google-cloud-vision==3.4.2
 google-cloud-texttospeech==2.14.1

--- a/translate/samples/snippets/requirements.txt
+++ b/translate/samples/snippets/requirements.txt
@@ -1,3 +1,3 @@
-google-cloud-translate==3.11.1
+google-cloud-translate==3.16.0
 google-cloud-storage==2.9.0
 google-cloud-automl==2.11.1

--- a/translate/samples/snippets/snippets_test.py
+++ b/translate/samples/snippets/snippets_test.py
@@ -28,13 +28,13 @@ def test_list_languages(capsys: pytest.LogCaptureFixture) -> None:
     out, _ = capsys.readouterr()
     for language in results:
         print("{name} ({language})".format(**language))
-    assert "Afrikaans" in results[0]["name"]
+    assert "Afrikaans" in [r["name"] for r in results]
 
 
 def test_list_languages_with_target(capsys: pytest.LogCaptureFixture) -> None:
     results = snippets.list_languages_with_target("is")
     out, _ = capsys.readouterr()
-    assert "afríkanska" in results[0]["name"]
+    assert "afríkanska" in [r["name"] for r in results]
 
 
 def test_translate_text(capsys: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Description

Fixes #12560

Due to https://support.google.com/translate/answer/15139004, Afrikaans is no longer the alphabetically first language that's supported in Google Translate. 

This PR updates the validation to ensure this language is part of the results, rather than the first. 



- [x] Please **merge** this PR for me once it is approved