### PR TITLE
chore(generativeai): Update the cache time to 2 hr

### DIFF
--- a/generative_ai/context_caching/update_context_cache.py
+++ b/generative_ai/context_caching/update_context_cache.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
 
 def update_context_cache(project_id: str, cache_id: str) -> str:
     # [START generativeaionvertexai_gemini_update_context_cache]
@@ -24,12 +28,12 @@ def update_context_cache(project_id: str, cache_id: str) -> str:
     # project_id = "PROJECT_ID"
     # cache_id = "CACHE_ID"
 
-    vertexai.init(project=project_id, location="us-central1")
+    vertexai.init(project=PROJECT_ID, location="us-central1")
 
     cached_content = caching.CachedContent(cached_content_name=cache_id)
 
-    # Update the expiration time by 1 hour
-    cached_content.update(ttl=datetime.timedelta(hours=1))
+    # Update the expiration time by 2 hour
+    cached_content.update(ttl=datetime.timedelta(hours=2))
 
     cached_content.refresh()
     print(cached_content.expire_time)


### PR DESCRIPTION
The default time is 1 hr.

## Description

Fixes: [b/352482094](http://b/352482094)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved