### PR TITLE
refactor: (GenAI) Reorganized Embeddings Samples (Group A)

### DIFF
--- a/generative_ai/embedding.py
+++ b/generative_ai/embedding.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# TODO Delete this file after approving /embeddings/document_retrieval_example.py
 
 # [START generativeaionvertexai_sdk_embedding]
 from typing import List, Optional

--- a/generative_ai/embedding_batch.py
+++ b/generative_ai/embedding_batch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: Delete this file after approving /embeddings/batch_example.py
 import os
 
 from google.cloud.aiplatform import BatchPredictionJob

--- a/generative_ai/embedding_batch_test.py
+++ b/generative_ai/embedding_batch_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Delete this file after approving /embeddings/batch_example_test.py
 import os
 
 import backoff

--- a/generative_ai/embedding_model_tuning.py
+++ b/generative_ai/embedding_model_tuning.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO Delete this file after approving /embeddings/model_tuning_example.py
 # [START generativeaionvertexai_sdk_embedding]
 import re
 

--- a/generative_ai/embedding_model_tuning_test.py
+++ b/generative_ai/embedding_model_tuning_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO Delete this file after approving /embeddings/model_tuning_test.py
 import os
 
 import backoff

--- a/generative_ai/embedding_preview.py
+++ b/generative_ai/embedding_preview.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Delete this file after approving /embeddings/code_retrieval_example.py
 from __future__ import annotations
 
 # [START generativeaionvertexai_sdk_embedding]

--- a/generative_ai/embedding_test.py
+++ b/generative_ai/embedding_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Delete this file after approving /embeddings/retrievals_test.py
 import backoff
 
 from google.api_core.exceptions import ResourceExhausted

--- a/generative_ai/embeddings/batch_example.py
+++ b/generative_ai/embeddings/batch_example.py
@@ -24,7 +24,7 @@ def embed_text_batch() -> BatchPredictionJob:
 
     Read more: https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/batch-prediction-genai-embeddings
     """
-    # [START generativeaionvertexai_sdk_embedding_batch]
+    # [START generativeaionvertexai_embedding_batch]
     import vertexai
     from vertexai.preview import language_models
 
@@ -53,7 +53,7 @@ def embed_text_batch() -> BatchPredictionJob:
     #   projects/1234567890/locations/us-central1/batchPredictionJobs/123456789012345
     #   JobState.JOB_STATE_SUCCEEDED
 
-    # [END generativeaionvertexai_sdk_embedding_batch]
+    # [END generativeaionvertexai_embedding_batch]
 
     return batch_prediction_job
 

--- a/generative_ai/embeddings/batch_example.py
+++ b/generative_ai/embeddings/batch_example.py
@@ -49,9 +49,9 @@ def embed_text_batch() -> BatchPredictionJob:
     print(batch_prediction_job.resource_name)
     print(batch_prediction_job.state)
     # Example response:
-    #   BatchPredictionJob 2024-09-10 15:47:51.336391
-    #   projects/1234567890/locations/us-central1/batchPredictionJobs/123456789012345
-    #   JobState.JOB_STATE_SUCCEEDED
+    # BatchPredictionJob 2024-09-10 15:47:51.336391
+    # projects/1234567890/locations/us-central1/batchPredictionJobs/123456789012345
+    # JobState.JOB_STATE_SUCCEEDED
 
     # [END generativeaionvertexai_embedding_batch]
 

--- a/generative_ai/embeddings/batch_example.py
+++ b/generative_ai/embeddings/batch_example.py
@@ -1,0 +1,62 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from google.cloud.aiplatform import BatchPredictionJob
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+OUTPUT_URI = os.getenv("GCS_OUTPUT_URI")
+
+
+def embed_text_batch() -> BatchPredictionJob:
+    """Example of how to generate embeddings from text using batch processing.
+
+    Read more: https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/batch-prediction-genai-embeddings
+    """
+    # [START generativeaionvertexai_sdk_embedding_batch]
+    import vertexai
+    from vertexai.preview import language_models
+
+    # TODO(developer): Uncomment and set your project ID
+    # PROJECT_ID = "your-project-id"
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+    input_uri = (
+        "gs://cloud-samples-data/generative-ai/embeddings/embeddings_input.jsonl"
+    )
+    # Format: `"gs://your-bucket-unique-name/directory/` or `bq://project_name.llm_dataset`
+    output_uri = OUTPUT_URI
+
+    textembedding_model = language_models.TextEmbeddingModel.from_pretrained(
+        "textembedding-gecko"
+    )
+
+    batch_prediction_job = textembedding_model.batch_predict(
+        dataset=[input_uri],
+        destination_uri_prefix=output_uri,
+    )
+    print(batch_prediction_job.display_name)
+    print(batch_prediction_job.resource_name)
+    print(batch_prediction_job.state)
+    # Example response:
+    #   BatchPredictionJob 2024-09-10 15:47:51.336391
+    #   projects/1234567890/locations/us-central1/batchPredictionJobs/123456789012345
+    #   JobState.JOB_STATE_SUCCEEDED
+
+    # [END generativeaionvertexai_sdk_embedding_batch]
+
+    return batch_prediction_job
+
+
+if __name__ == "__main__":
+    embed_text_batch()

--- a/generative_ai/embeddings/batch_example_test.py
+++ b/generative_ai/embeddings/batch_example_test.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import backoff
+
+import batch_example
+
+from google.api_core.exceptions import ResourceExhausted
+
+import pytest
+
+
+@backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
+@pytest.fixture(scope="session", autouse=True)
+def test_embed_text_batch() -> None:
+    os.environ["GCS_OUTPUT_URI"] = "gs://python-docs-samples-tests/"
+    batch_prediction_job = batch_example.embed_text_batch()
+    assert batch_prediction_job

--- a/generative_ai/embeddings/code_retrieval_example.py
+++ b/generative_ai/embeddings/code_retrieval_example.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-# [START generativeaionvertexai_sdk_embedding_code_retrieval]
+# [START generativeaionvertexai_embedding_code_retrieval]
 from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel
 
 MODEL_NAME = "text-embedding-preview-0815"
@@ -57,4 +57,4 @@ if __name__ == "__main__":
         texts=texts, task=task, model_name=MODEL_NAME, dimensionality=DIMENSIONALITY
     )
 
-# [END generativeaionvertexai_sdk_embedding_code_retrieval]
+# [END generativeaionvertexai_embedding_code_retrieval]

--- a/generative_ai/embeddings/code_retrieval_example.py
+++ b/generative_ai/embeddings/code_retrieval_example.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+# [START generativeaionvertexai_sdk_embedding_code_retrieval]
+from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel
+
+MODEL_NAME = "text-embedding-preview-0815"
+DIMENSIONALITY = 256
+
+
+def embed_text(
+    texts: list[str] = ["Retrieve a function that adds two numbers"],
+    task: str = "CODE_RETRIEVAL_QUERY",
+    model_name: str = "text-embedding-preview-0815",
+    dimensionality: int | None = 256,
+) -> list[list[float]]:
+    """Embeds texts with a pre-trained, foundational model."""
+    model = TextEmbeddingModel.from_pretrained(model_name)
+    inputs = [TextEmbeddingInput(text, task) for text in texts]
+    kwargs = dict(output_dimensionality=dimensionality) if dimensionality else {}
+    embeddings = model.get_embeddings(inputs, **kwargs)
+
+    return [embedding.values for embedding in embeddings]
+
+
+if __name__ == "__main__":
+    # Embeds code block with a pre-trained, foundational model.
+    # Using this function to calculate the embedding for corpus.
+    texts = ["Retrieve a function that adds two numbers"]
+    task = "CODE_RETRIEVAL_QUERY"
+    code_block_embeddings = embed_text(
+        texts=texts, task=task, model_name=MODEL_NAME, dimensionality=DIMENSIONALITY
+    )
+
+    # Embeds code retrieval with a pre-trained, foundational model.
+    # Using this function to calculate the embedding for query.
+    texts = [
+        "def func(a, b): return a + b",
+        "def func(a, b): return a - b",
+        "def func(a, b): return (a ** 2 + b ** 2) ** 0.5",
+    ]
+    task = "RETRIEVAL_DOCUMENT"
+    code_query_embeddings = embed_text(
+        texts=texts, task=task, model_name=MODEL_NAME, dimensionality=DIMENSIONALITY
+    )
+
+# [END generativeaionvertexai_sdk_embedding_code_retrieval]

--- a/generative_ai/embeddings/code_retrieval_example.py
+++ b/generative_ai/embeddings/code_retrieval_example.py
@@ -32,7 +32,8 @@ def embed_text(
     inputs = [TextEmbeddingInput(text, task) for text in texts]
     kwargs = dict(output_dimensionality=dimensionality) if dimensionality else {}
     embeddings = model.get_embeddings(inputs, **kwargs)
-
+    # Example response:
+    # [[0.025890009477734566, -0.05553026497364044, 0.006374752148985863,...],
     return [embedding.values for embedding in embeddings]
 
 

--- a/generative_ai/embeddings/document_retrieval_example.py
+++ b/generative_ai/embeddings/document_retrieval_example.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START generativeaionvertexai_sdk_embedding]
+# [START generativeaionvertexai_embedding]
 from typing import List, Optional
 
 from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel
@@ -39,7 +39,7 @@ def embed_text(
     embeddings = model.get_embeddings(inputs, **kwargs)
     return [embedding.values for embedding in embeddings]
 
-# [END generativeaionvertexai_sdk_embedding]
+# [END generativeaionvertexai_embedding]
 
 
 if __name__ == "__main__":

--- a/generative_ai/embeddings/document_retrieval_example.py
+++ b/generative_ai/embeddings/document_retrieval_example.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START generativeaionvertexai_sdk_embedding]
+from typing import List, Optional
+
+from vertexai.language_models import TextEmbeddingInput, TextEmbeddingModel
+
+
+def embed_text(
+    texts: list = None,
+    task: str = "RETRIEVAL_DOCUMENT",
+    dimensionality: Optional[int] = 256,
+) -> List[List[float]]:
+    """Embeds texts with a pre-trained, foundational model.
+    Args:
+        texts (List[str]): A list of texts to be embedded.
+        task (str): The task type for embedding. Check the available tasks in the model's documentation.
+        dimensionality (Optional[int]): The dimensionality of the output embeddings.
+    Returns:
+        List[List[float]]: A list of lists containing the embedding vectors for each input text
+    """
+    if texts is None:
+        texts = ["banana muffins? ", "banana bread? banana muffins?"]
+    model = TextEmbeddingModel.from_pretrained("text-embedding-004")
+    inputs = [TextEmbeddingInput(text, task) for text in texts]
+    kwargs = dict(output_dimensionality=dimensionality) if dimensionality else {}
+    embeddings = model.get_embeddings(inputs, **kwargs)
+    return [embedding.values for embedding in embeddings]
+
+# [END generativeaionvertexai_sdk_embedding]
+
+
+if __name__ == "__main__":
+    embed_text()

--- a/generative_ai/embeddings/document_retrieval_example.py
+++ b/generative_ai/embeddings/document_retrieval_example.py
@@ -37,7 +37,10 @@ def embed_text(
     inputs = [TextEmbeddingInput(text, task) for text in texts]
     kwargs = dict(output_dimensionality=dimensionality) if dimensionality else {}
     embeddings = model.get_embeddings(inputs, **kwargs)
+    # Example response:
+    # [[0.006135190837085247, -0.01462465338408947, 0.004978656303137541, ...],
     return [embedding.values for embedding in embeddings]
+
 
 # [END generativeaionvertexai_embedding]
 

--- a/generative_ai/embeddings/model_tuning_example.py
+++ b/generative_ai/embeddings/model_tuning_example.py
@@ -1,0 +1,59 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START generativeaionvertexai_sdk_embedding]
+import re
+
+from google.cloud.aiplatform import initializer as aiplatform_init
+from vertexai.language_models import TextEmbeddingModel
+
+
+def tune_embedding_model(
+    api_endpoint: str,
+    base_model_name: str = "text-embedding-004",
+    corpus_path: str = "gs://cloud-samples-data/ai-platform/embedding/goog-10k-2024/r11/corpus.jsonl",
+    queries_path: str = "gs://cloud-samples-data/ai-platform/embedding/goog-10k-2024/r11/queries.jsonl",
+    train_label_path: str = "gs://cloud-samples-data/ai-platform/embedding/goog-10k-2024/r11/train.tsv",
+    test_label_path: str = "gs://cloud-samples-data/ai-platform/embedding/goog-10k-2024/r11/test.tsv",
+):  # noqa: ANN201
+    """Tune an embedding model using the specified parameters.
+    Args:
+        api_endpoint (str): The API endpoint for the Vertex AI service.
+        base_model_name (str): The name of the base model to use for tuning.
+        corpus_path (str): GCS URI of the JSONL file containing the corpus data.
+        queries_path (str): GCS URI of the JSONL file containing the queries data.
+        train_label_path (str): GCS URI of the TSV file containing the training labels.
+        test_label_path (str): GCS URI of the TSV file containing the test labels.
+    """
+    match = re.search(r"^(\w+-\w+)", api_endpoint)
+    location = match.group(1) if match else "us-central1"
+    base_model = TextEmbeddingModel.from_pretrained(base_model_name)
+    tuning_job = base_model.tune_model(
+        task_type="DEFAULT",
+        corpus_data=corpus_path,
+        queries_data=queries_path,
+        training_data=train_label_path,
+        test_data=test_label_path,
+        batch_size=128,  # The batch size to use for training.
+        train_steps=1000,  # The number of training steps.
+        tuned_model_location=location,
+        output_dimensionality=768,  # The dimensionality of the output embeddings.
+        learning_rate_multiplier=1.0,  # The multiplier for the learning rate.
+    )
+    return tuning_job
+
+
+# [END generativeaionvertexai_sdk_embedding]
+if __name__ == "__main__":
+    tune_embedding_model(aiplatform_init.global_config.api_endpoint)

--- a/generative_ai/embeddings/model_tuning_example.py
+++ b/generative_ai/embeddings/model_tuning_example.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START generativeaionvertexai_sdk_embedding]
+# [START generativeaionvertexai_embedding_model_tuning]
 import re
 
 from google.cloud.aiplatform import initializer as aiplatform_init
@@ -54,6 +54,6 @@ def tune_embedding_model(
     return tuning_job
 
 
-# [END generativeaionvertexai_sdk_embedding]
+# [END generativeaionvertexai_embedding_model_tuning]
 if __name__ == "__main__":
     tune_embedding_model(aiplatform_init.global_config.api_endpoint)

--- a/generative_ai/embeddings/model_tuning_test.py
+++ b/generative_ai/embeddings/model_tuning_test.py
@@ -1,0 +1,51 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import backoff
+
+from google.api_core.exceptions import FailedPrecondition
+
+import google.auth
+from google.cloud import aiplatform
+from google.cloud.aiplatform import initializer as aiplatform_init
+
+
+import model_tuning_example
+
+
+@backoff.on_exception(backoff.expo, FailedPrecondition, max_time=300)
+def dispose(tuning_job) -> None:  # noqa: ANN001
+    if tuning_job._status.name == "PIPELINE_STATE_RUNNING":
+        tuning_job._cancel()
+
+
+def test_tune_embedding_model() -> None:
+    credentials, _ = google.auth.default(  # Set explicit credentials with Oauth scopes.
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    aiplatform.init(
+        api_endpoint="us-central1-aiplatform.googleapis.com:443",
+        project=os.getenv("GOOGLE_CLOUD_PROJECT"),
+        staging_bucket="gs://ucaip-samples-us-central1/training_pipeline_output",
+        credentials=credentials,
+    )
+    tuning_job = model_tuning_example.tune_embedding_model(
+        aiplatform_init.global_config.api_endpoint
+    )
+    try:
+        assert tuning_job._status.name != "PIPELINE_STATE_FAILED"
+    finally:
+        dispose(tuning_job)

--- a/generative_ai/embeddings/multimodal_example.py
+++ b/generative_ai/embeddings/multimodal_example.py
@@ -24,7 +24,7 @@ def get_image_video_text_embeddings() -> MultiModalEmbeddingResponse:
 
     Read more @ https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings#video-best-practices
     """
-    # [START generativeaionvertexai_sdk_multimodal_embedding_image_video_text]
+    # [START generativeaionvertexai_multimodal_embedding_image_video_text]
     import vertexai
 
     from vertexai.vision_models import Image, MultiModalEmbeddingModel, Video
@@ -68,7 +68,7 @@ def get_image_video_text_embeddings() -> MultiModalEmbeddingResponse:
     # Embedding: [-0.0206376351, 0.0345234685, ...]
     # Text Embedding: [-0.0207006838, -0.00251058186, ...]
 
-    # [END generativeaionvertexai_sdk_multimodal_embedding_image_video_text]
+    # [END generativeaionvertexai_multimodal_embedding_image_video_text]
     return embeddings
 
 

--- a/generative_ai/embeddings/multimodal_example.py
+++ b/generative_ai/embeddings/multimodal_example.py
@@ -61,7 +61,7 @@ def get_image_video_text_embeddings() -> MultiModalEmbeddingResponse:
         print(f"Embedding: {video_embedding.embedding}")
 
     print(f"Text Embedding: {embeddings.text_embedding}")
-    # Example output:
+    # Example response:
     # Image Embedding: [-0.0123144267, 0.0727186054, 0.000201397663, ...]
     # Video Embeddings:
     # Video Segment: 0.0 - 1.0

--- a/generative_ai/embeddings/multimodal_image_example.py
+++ b/generative_ai/embeddings/multimodal_image_example.py
@@ -44,7 +44,7 @@ def get_image_embeddings() -> MultiModalEmbeddingResponse:
     )
     print(f"Image Embedding: {embeddings.image_embedding}")
     print(f"Text Embedding: {embeddings.text_embedding}")
-    # Example output:
+    # Example response:
     # Image Embedding: [-0.0123147098, 0.0727171078, ...]
     # Text Embedding: [0.00230263756, 0.0278981831, ...]
 

--- a/generative_ai/embeddings/multimodal_image_example.py
+++ b/generative_ai/embeddings/multimodal_image_example.py
@@ -24,7 +24,7 @@ def get_image_embeddings() -> MultiModalEmbeddingResponse:
 
     Read more @ https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings#low-dimension
     """
-    # [START generativeaionvertexai_sdk_multimodal_embedding_image]
+    # [START generativeaionvertexai_multimodal_embedding_image]
     import vertexai
     from vertexai.vision_models import Image, MultiModalEmbeddingModel
 
@@ -48,7 +48,7 @@ def get_image_embeddings() -> MultiModalEmbeddingResponse:
     # Image Embedding: [-0.0123147098, 0.0727171078, ...]
     # Text Embedding: [0.00230263756, 0.0278981831, ...]
 
-    # [END generativeaionvertexai_sdk_multimodal_embedding_image]
+    # [END generativeaionvertexai_multimodal_embedding_image]
 
     return embeddings
 

--- a/generative_ai/embeddings/multimodal_image_example.py
+++ b/generative_ai/embeddings/multimodal_image_example.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from vertexai.vision_models import MultiModalEmbeddingResponse
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def get_image_embeddings() -> MultiModalEmbeddingResponse:
+    """Example of how to generate multimodal embeddings from image and text.
+
+    Read more @ https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings#low-dimension
+    """
+    # [START generativeaionvertexai_sdk_multimodal_embedding_image]
+    import vertexai
+    from vertexai.vision_models import Image, MultiModalEmbeddingModel
+
+    # TODO(developer): Uncomment and set your project ID
+    # PROJECT_ID = "your-project-id"
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = MultiModalEmbeddingModel.from_pretrained("multimodalembedding")
+    image = Image.load_from_file(
+        "gs://cloud-samples-data/vertex-ai/llm/prompts/landmark1.png"
+    )
+
+    embeddings = model.get_embeddings(
+        image=image,
+        contextual_text="Colosseum",
+        dimension=1408,
+    )
+    print(f"Image Embedding: {embeddings.image_embedding}")
+    print(f"Text Embedding: {embeddings.text_embedding}")
+    # Example output:
+    # Image Embedding: [-0.0123147098, 0.0727171078, ...]
+    # Text Embedding: [0.00230263756, 0.0278981831, ...]
+
+    # [END generativeaionvertexai_sdk_multimodal_embedding_image]
+
+    return embeddings
+
+
+if __name__ == "__main__":
+    get_image_embeddings()

--- a/generative_ai/embeddings/multimodal_test.py
+++ b/generative_ai/embeddings/multimodal_test.py
@@ -1,0 +1,45 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import backoff
+from google.api_core.exceptions import ResourceExhausted
+
+import multimodal_image_example
+import multimodal_video_example
+import multimopdal_example
+
+
+@backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
+def test_multimodal_embedding_image_video_text() -> None:
+    embeddings = multimopdal_example.get_image_video_text_embeddings()
+    assert embeddings is not None
+    assert embeddings.image_embedding is not None
+    assert embeddings.video_embeddings is not None
+    assert embeddings.text_embedding is not None
+
+
+@backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
+def test_multimodal_embedding_video() -> None:
+    embeddings = multimodal_video_example.get_video_embeddings()
+    assert embeddings is not None
+    assert embeddings.video_embeddings is not None
+    assert embeddings.text_embedding is not None
+
+
+@backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
+def test_multimodal_embedding_image() -> None:
+    embeddings = multimodal_image_example.get_image_embeddings()
+    assert embeddings is not None
+    assert embeddings.image_embedding is not None
+    assert embeddings.text_embedding is not None

--- a/generative_ai/embeddings/multimodal_test.py
+++ b/generative_ai/embeddings/multimodal_test.py
@@ -15,9 +15,9 @@
 import backoff
 from google.api_core.exceptions import ResourceExhausted
 
+import multimodal_example
 import multimodal_image_example
 import multimodal_video_example
-import multimodal_example
 
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)

--- a/generative_ai/embeddings/multimodal_test.py
+++ b/generative_ai/embeddings/multimodal_test.py
@@ -17,12 +17,12 @@ from google.api_core.exceptions import ResourceExhausted
 
 import multimodal_image_example
 import multimodal_video_example
-import multimopdal_example
+import multimodal_example
 
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
 def test_multimodal_embedding_image_video_text() -> None:
-    embeddings = multimopdal_example.get_image_video_text_embeddings()
+    embeddings = multimodal_example.get_image_video_text_embeddings()
     assert embeddings is not None
     assert embeddings.image_embedding is not None
     assert embeddings.video_embeddings is not None

--- a/generative_ai/embeddings/multimodal_video_example.py
+++ b/generative_ai/embeddings/multimodal_video_example.py
@@ -23,7 +23,7 @@ def get_video_embeddings() -> MultiModalEmbeddingResponse:
 
     Read more at https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings#video-best-practices
     """
-    # [START generativeaionvertexai_sdk_multimodal_embedding_video]
+    # [START generativeaionvertexai_multimodal_embedding_video]
     import vertexai
 
     from vertexai.vision_models import MultiModalEmbeddingModel, Video
@@ -58,7 +58,7 @@ def get_video_embeddings() -> MultiModalEmbeddingResponse:
     # Embedding: [-0.0206376351, 0.0123456789, ...]
     # Text Embedding: [-0.0207006913, -0.00251061679, ...]
 
-    # [END generativeaionvertexai_sdk_multimodal_embedding_video]
+    # [END generativeaionvertexai_multimodal_embedding_video]
 
     return embeddings
 

--- a/generative_ai/embeddings/multimodal_video_example.py
+++ b/generative_ai/embeddings/multimodal_video_example.py
@@ -1,0 +1,67 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from vertexai.vision_models import MultiModalEmbeddingResponse
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def get_video_embeddings() -> MultiModalEmbeddingResponse:
+    """Example of how to generate multimodal embeddings from video and text.
+
+    Read more at https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings#video-best-practices
+    """
+    # [START generativeaionvertexai_sdk_multimodal_embedding_video]
+    import vertexai
+
+    from vertexai.vision_models import MultiModalEmbeddingModel, Video
+    from vertexai.vision_models import VideoSegmentConfig
+
+    # TODO(developer): Uncomment and set your project ID
+    # PROJECT_ID = "your-project-id"
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = MultiModalEmbeddingModel.from_pretrained("multimodalembedding")
+
+    embeddings = model.get_embeddings(
+        video=Video.load_from_file(
+            "gs://cloud-samples-data/vertex-ai-vision/highway_vehicles.mp4"
+        ),
+        video_segment_config=VideoSegmentConfig(end_offset_sec=1),
+        contextual_text="Cars on Highway",
+    )
+
+    # Video Embeddings are segmented based on the video_segment_config.
+    print("Video Embeddings:")
+    for video_embedding in embeddings.video_embeddings:
+        print(
+            f"Video Segment: {video_embedding.start_offset_sec} - {video_embedding.end_offset_sec}"
+        )
+        print(f"Embedding: {video_embedding.embedding}")
+
+    print(f"Text Embedding: {embeddings.text_embedding}")
+    # Example output:
+    # Video Embeddings:
+    # Video Segment: 0.0 - 1.0
+    # Embedding: [-0.0206376351, 0.0123456789, ...]
+    # Text Embedding: [-0.0207006913, -0.00251061679, ...]
+
+    # [END generativeaionvertexai_sdk_multimodal_embedding_video]
+
+    return embeddings
+
+
+if __name__ == "__main__":
+    get_video_embeddings()

--- a/generative_ai/embeddings/multimodal_video_example.py
+++ b/generative_ai/embeddings/multimodal_video_example.py
@@ -52,7 +52,7 @@ def get_video_embeddings() -> MultiModalEmbeddingResponse:
         print(f"Embedding: {video_embedding.embedding}")
 
     print(f"Text Embedding: {embeddings.text_embedding}")
-    # Example output:
+    # Example response:
     # Video Embeddings:
     # Video Segment: 0.0 - 1.0
     # Embedding: [-0.0206376351, 0.0123456789, ...]

--- a/generative_ai/embeddings/multimopdal_example.py
+++ b/generative_ai/embeddings/multimopdal_example.py
@@ -1,0 +1,76 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from vertexai.vision_models import MultiModalEmbeddingResponse
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def get_image_video_text_embeddings() -> MultiModalEmbeddingResponse:
+    """Example of how to generate multimodal embeddings from image, video, and text.
+
+    Read more @ https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-multimodal-embeddings#video-best-practices
+    """
+    # [START generativeaionvertexai_sdk_multimodal_embedding_image_video_text]
+    import vertexai
+
+    from vertexai.vision_models import Image, MultiModalEmbeddingModel, Video
+    from vertexai.vision_models import VideoSegmentConfig
+
+    # TODO(developer): Uncomment and set your project ID
+    # PROJECT_ID = "your-project-id"
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = MultiModalEmbeddingModel.from_pretrained("multimodalembedding")
+
+    image = Image.load_from_file(
+        "gs://cloud-samples-data/vertex-ai/llm/prompts/landmark1.png"
+    )
+    video = Video.load_from_file(
+        "gs://cloud-samples-data/vertex-ai-vision/highway_vehicles.mp4"
+    )
+
+    embeddings = model.get_embeddings(
+        image=image,
+        video=video,
+        video_segment_config=VideoSegmentConfig(end_offset_sec=1),
+        contextual_text="Cars on Highway",
+    )
+
+    print(f"Image Embedding: {embeddings.image_embedding}")
+
+    # Video Embeddings are segmented based on the video_segment_config.
+    print("Video Embeddings:")
+    for video_embedding in embeddings.video_embeddings:
+        print(
+            f"Video Segment: {video_embedding.start_offset_sec} - {video_embedding.end_offset_sec}"
+        )
+        print(f"Embedding: {video_embedding.embedding}")
+
+    print(f"Text Embedding: {embeddings.text_embedding}")
+    # Example output:
+    # Image Embedding: [-0.0123144267, 0.0727186054, 0.000201397663, ...]
+    # Video Embeddings:
+    # Video Segment: 0.0 - 1.0
+    # Embedding: [-0.0206376351, 0.0345234685, ...]
+    # Text Embedding: [-0.0207006838, -0.00251058186, ...]
+
+    # [END generativeaionvertexai_sdk_multimodal_embedding_image_video_text]
+    return embeddings
+
+
+if __name__ == "__main__":
+    get_image_video_text_embeddings()

--- a/generative_ai/embeddings/retrievals_test.py
+++ b/generative_ai/embeddings/retrievals_test.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import backoff
+
+import code_retrieval_example
+import document_retrieval_example
+
+from google.api_core.exceptions import ResourceExhausted
+
+
+@backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
+def test_text_embed_text() -> None:
+    texts = [
+        "banana bread?",
+        "banana muffin?",
+        "banana?",
+    ]
+    dimensionality = 256
+    embeddings = document_retrieval_example.embed_text(
+        texts, "RETRIEVAL_QUERY", dimensionality
+    )
+    assert [len(e) for e in embeddings] == [dimensionality or 768] * len(texts)
+
+
+@backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
+def test_code_embed_text() -> None:
+    texts = [
+        "banana bread?",
+        "banana muffin?",
+        "banana?",
+    ]
+    dimensionality = 256
+    embeddings = code_retrieval_example.embed_text(
+        texts=texts,
+        task="CODE_RETRIEVAL_QUERY",
+        dimensionality=dimensionality,
+    )
+    assert [len(e) for e in embeddings] == [dimensionality or 768] * len(texts)

--- a/generative_ai/multimodal_embedding_image.py
+++ b/generative_ai/multimodal_embedding_image.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Delete this file after approving /embeddings/multimodal_image_example.py
 import os
 
 from vertexai.vision_models import MultiModalEmbeddingResponse

--- a/generative_ai/multimodal_embedding_image_test.py
+++ b/generative_ai/multimodal_embedding_image_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# TODO: Delete this file after approving /embeddings/image_example_test.py
 import backoff
 from google.api_core.exceptions import ResourceExhausted
 

--- a/generative_ai/multimodal_embedding_image_video_text.py
+++ b/generative_ai/multimodal_embedding_image_video_text.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: Delete this file after approving /embeddings/multimopdal_example.py
+# TODO: Delete this file after approving /embeddings/multimodal_example.py
 import os
 
 from vertexai.vision_models import MultiModalEmbeddingResponse

--- a/generative_ai/multimodal_embedding_image_video_text.py
+++ b/generative_ai/multimodal_embedding_image_video_text.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: Delete this file after approving /embeddings/multimopdal_example.py
 import os
 
 from vertexai.vision_models import MultiModalEmbeddingResponse

--- a/generative_ai/multimodal_embedding_image_video_text_test.py
+++ b/generative_ai/multimodal_embedding_image_video_text_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# TODO: Delete this file after approving /embeddings/multimopdal_example_test.py
 
 import backoff
 from google.api_core.exceptions import ResourceExhausted

--- a/generative_ai/multimodal_embedding_video.py
+++ b/generative_ai/multimodal_embedding_video.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Delete this file after approving /embeddings/multimodal_video_example.py
 import os
 
 from vertexai.vision_models import MultiModalEmbeddingResponse

--- a/generative_ai/multimodal_embedding_video_test.py
+++ b/generative_ai/multimodal_embedding_video_test.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# TODO: Delete this file after approving /embeddings/video_example_test.py
 import backoff
 from google.api_core.exceptions import ResourceExhausted
 


### PR DESCRIPTION
## Description

### Path for all new files is `/generative_ai/embeddings/`
|  Region Tag	| Old file | New File  	| 
|---					|---			|---				|
|	generativeaionvertexai_embedding_batch |  embedding_batch.py | batch_example.py |
|	**generativeaionvertexai_embedding_model_tuning** |  embedding_model_tuning.py | model_tuning_example.py |
|	**generativeaionvertexai_embedding_code_retrieval** | embedding_preview.py  | code_retrieval_example.py |
|	**generativeaionvertexai_embedding** |  embeddings.py |  document_retrieval_example.py |
|	generativeaionvertexai_multimodal_embedding_image_video_text |  multimodal_embedding_image_video_text.py | multimodal_example.py |
|	generativeaionvertexai_multimodal_embedding_image | multimodal_embedding_image.py  | multimodal_image_example.py |
|	generativeaionvertexai_multimodal_embedding_video |  multimodal_embedding_video.py | multimodal_video_example.py 
### Table of changes in region tags ❗(Removed word `sdk` )

| Old region tags | New region tag |
|--|--|
|  generativeaionvertexai_sdk_embedding_batch| generativeaionvertexai_embedding_batch |
|  generativeaionvertexai_sdk_embedding| generativeaionvertexai_embedding |
|  generativeaionvertexai_sdk_embedding| generativeaionvertexai_embedding_code_retrieval |
|  generativeaionvertexai_sdk_embedding| generativeaionvertexai_embedding_model_tuning |
|  generativeaionvertexai_sdk_multimodal_embedding_image_video_text| generativeaionvertexai_multimodal_embedding_image_video_text |
|  generativeaionvertexai_sdk_multimodal_embedding_image| generativeaionvertexai_multimodal_embedding_image |
|  generativeaionvertexai_sdk_multimodal_embedding_video| generativeaionvertexai_multimodal_embedding_video |

❗**Files need to be deleted after approval:**

 - embedding_batch.py
 - embedding_batch_test.py
 - embedding.py
 - embedding_test.py embedding_preview.py
 - embedding_model_tuning.py
 - embedding_model_tuning_test.py
 - multimodal_embedding_image_video_text.py
 - multimodal_embedding_image_video_text_test.py
 - multimodal_embedding_image.py
 - multimodal_embedding_image_test.py
 - multimodal_embedding_video.py
 - multimodal_embedding_video_test.py


## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved