### PR TITLE
Resolving issue with regex for composer environments

### DIFF
--- a/composer/tools/composer_dags.py
+++ b/composer/tools/composer_dags.py
@@ -33,7 +33,7 @@ class DAG:
     """Provides necessary utils for Composer DAGs."""
 
     COMPOSER_AF_VERSION_RE = re.compile(
-        "composer-([0-9]+).([0-9]+).([0-9]+).*" "-airflow-([0-9]+).([0-9]+).([0-9]+).*"
+        "composer-(\d+(?:\.\d+){0,2})-airflow-(\d+(?:\.\d+){0,2}).*"
     )
 
     @staticmethod


### PR DESCRIPTION
## Description

Fixes #12580


## Checklist
- [ x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ x] Please **merge** this PR for me once it is approved