### PR TITLE
Update generate_self_signed_jwt.py

### DIFF
--- a/iap/generate_self_signed_jwt.py
+++ b/iap/generate_self_signed_jwt.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
 import json
+import time
 
 import google.auth
 from google.cloud import iam_credentials_v1
@@ -35,15 +35,15 @@ def generate_jwt_payload(service_account_email: str, resource_url: str) -> str:
       Access the application with the JWT in the Authorization Header.
       curl --verbose --header 'Authorization: Bearer SIGNED_JWT' URL
     """
-    iat = datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
-    exp = iat + 3600
+    now = int(time.time())
+
     return json.dumps(
         {
             "iss": service_account_email,
             "sub": service_account_email,
             "aud": resource_url,
-            "iat": iat,
-            "exp": exp,
+            "iat": now,
+            "exp": now + 3600,
         }
     )
 

--- a/iap/generate_self_signed_jwt.py
+++ b/iap/generate_self_signed_jwt.py
@@ -35,7 +35,7 @@ def generate_jwt_payload(service_account_email: str, resource_url: str) -> str:
       Access the application with the JWT in the Authorization Header.
       curl --verbose --header 'Authorization: Bearer SIGNED_JWT' URL
     """
-    iat = datetime.datetime.now(tz=datetime.timezone.utc)
+    iat = datetime.datetime.now(tz=datetime.timezone.utc).timestamp()
     exp = iat + 3600
     return json.dumps(
         {


### PR DESCRIPTION
This is a bug fix in response to a listener report. The datetime object needs to return the current time in epoch

## Description

Fixes b/366503744

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X ] Please **merge** this PR for me once it is approved