### PR TITLE
feat(generativeai): Add new sample for text generation

### DIFF
--- a/generative_ai/batch_predict/gemini_batch_predict.py
+++ b/generative_ai/batch_predict/gemini_batch_predict.py
@@ -53,7 +53,7 @@ def batch_predict_gemini_createjob(
     )
 
     # Check job status
-    print(f"Job resouce name: {batch_prediction_job.resource_name}")
+    print(f"Job resource name: {batch_prediction_job.resource_name}")
     print(f"Model resource name with the job: {batch_prediction_job.model_name}")
     print(f"Job state: {batch_prediction_job.state.name}")
 
@@ -72,7 +72,7 @@ def batch_predict_gemini_createjob(
     print(f"Job output location: {batch_prediction_job.output_location}")
 
     # Example response:
-    #  Job output location: gs://yourbucket/gen-ai-batch-prediction/prediction-model-year-month-day-hour:minute:second.12345
+    #  Job output location: gs://your-bucket/gen-ai-batch-prediction/prediction-model-year-month-day-hour:minute:second.12345
 
     # https://storage.googleapis.com/cloud-samples-data/batch/prompt_for_batch_gemini_predict.jsonl
 
@@ -82,9 +82,9 @@ def batch_predict_gemini_createjob(
 
 
 if __name__ == "__main__":
-    # TODO(developer): Update gsc bucket and file paths
-    GCS_BUCKET = "gs://yourbucket"
+    # TODO(developer): Update your Cloud Storage bucket and uri file paths
+    GCS_BUCKET = "gs://your-bucket"
     batch_predict_gemini_createjob(
-        f"gs://{GCS_BUCKET}/batch_data/sample_input_file.jsonl",
-        f"gs://{GCS_BUCKET}/batch_preditions/sample_output/",
+        input_uri=f"gs://{GCS_BUCKET}/batch_data/sample_input_file.jsonl",
+        output_uri=f"gs://{GCS_BUCKET}/batch_predictions/sample_output/",
     )

--- a/generative_ai/controlled_generation/example_06.py
+++ b/generative_ai/controlled_generation/example_06.py
@@ -43,15 +43,20 @@ def generate_content() -> str:
 
     response = model.generate_content(
         [
+            # Text prompt
+            "Generate a list of objects in the images.",
+
+            # Http Image
             Part.from_uri(
-                "gs://cloud-samples-data/generative-ai/image/office-desk.jpeg",
+                "https://storage.googleapis.com/cloud-samples-data/generative-ai/image/office-desk.jpeg",
                 "image/jpeg",
             ),
+
+            # Cloud storage object
             Part.from_uri(
                 "gs://cloud-samples-data/generative-ai/image/gardening-tools.jpeg",
                 "image/jpeg",
             ),
-            "Generate a list of objects in the images.",
         ],
         generation_config=GenerationConfig(
             response_mime_type="application/json", response_schema=response_schema

--- a/generative_ai/model_garden/claude_3_streaming_example.py
+++ b/generative_ai/model_garden/claude_3_streaming_example.py
@@ -11,54 +11,54 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import os
-
-PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-
-
-def generate_text_streaming() -> str:
-    # [START generativeaionvertexai_claude_3_streaming]
-    # TODO(developer): Vertex AI SDK - uncomment below & run
-    # pip3 install --upgrade --user google-cloud-aiplatform
-    # gcloud auth application-default login
-    # pip3 install -U 'anthropic[vertex]'
-
-    # TODO(developer): Update and un-comment below line
-    # PROJECT_ID = "your-project-id"
-
-    from anthropic import AnthropicVertex
-
-    client = AnthropicVertex(project_id=PROJECT_ID, region="us-east5")
-    result = []
-
-    with client.messages.stream(
-        model="claude-3-5-sonnet@20240620",
-        max_tokens=1024,
-        messages=[
-            {
-                "role": "user",
-                "content": "Send me a recipe for banana bread.",
-            }
-        ],
-    ) as stream:
-        for text in stream.text_stream:
-            print(text, end="", flush=True)
-            result.append(text)
-
-    # Example response:
-    # Here's a simple recipe for delicious banana bread:
-    # Ingredients:
-    # - 2-3 ripe bananas, mashed
-    # - 1/3 cup melted butter
-    # ...
-    # ...
-    # 8. Bake for 50-60 minutes, or until a toothpick inserted into the center comes out clean.
-    # 9. Let cool in the pan for a few minutes, then remove and cool completely on a wire rack.
-
-    # [END generativeaionvertexai_claude_3_streaming]
-    return "".join(result)
-
-
-if __name__ == "__main__":
-    generate_text_streaming()
+#
+# import os
+#
+# PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+#
+#
+# def generate_text_streaming() -> str:
+#     # [START generativeaionvertexai_claude_3_streaming]
+#     # TODO(developer): Vertex AI SDK - uncomment below & run
+#     # pip3 install --upgrade --user google-cloud-aiplatform
+#     # gcloud auth application-default login
+#     # pip3 install -U 'anthropic[vertex]'
+#
+#     # TODO(developer): Update and un-comment below line
+#     # PROJECT_ID = "your-project-id"
+#
+#     from anthropic import AnthropicVertex
+#
+#     client = AnthropicVertex(project_id=PROJECT_ID, region="us-east5")
+#     result = []
+#
+#     with client.messages.stream(
+#         model="claude-3-5-sonnet@20240620",
+#         max_tokens=1024,
+#         messages=[
+#             {
+#                 "role": "user",
+#                 "content": "Send me a recipe for banana bread.",
+#             }
+#         ],
+#     ) as stream:
+#         for text in stream.text_stream:
+#             print(text, end="", flush=True)
+#             result.append(text)
+#
+#     # Example response:
+#     # Here's a simple recipe for delicious banana bread:
+#     # Ingredients:
+#     # - 2-3 ripe bananas, mashed
+#     # - 1/3 cup melted butter
+#     # ...
+#     # ...
+#     # 8. Bake for 50-60 minutes, or until a toothpick inserted into the center comes out clean.
+#     # 9. Let cool in the pan for a few minutes, then remove and cool completely on a wire rack.
+#
+#     # [END generativeaionvertexai_claude_3_streaming]
+#     return "".join(result)
+#
+#
+# if __name__ == "__main__":
+#     generate_text_streaming()

--- a/generative_ai/model_garden/model_garden_test.py
+++ b/generative_ai/model_garden/model_garden_test.py
@@ -14,7 +14,7 @@
 
 import backoff
 
-import claude_3_streaming_example
+# import claude_3_streaming_example
 import claude_3_tool_example
 import claude_3_unary_example
 

--- a/generative_ai/model_garden/model_garden_test.py
+++ b/generative_ai/model_garden/model_garden_test.py
@@ -21,10 +21,10 @@ import claude_3_unary_example
 from google.api_core.exceptions import ResourceExhausted
 
 
-@backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
-def test_generate_text_streaming() -> None:
-    responses = claude_3_streaming_example.generate_text_streaming()
-    assert "bread" in responses
+# @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
+# def test_generate_text_streaming() -> None:
+#     responses = claude_3_streaming_example.generate_text_streaming()
+#     assert "bread" in responses
 
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)

--- a/generative_ai/text_generation/gemini_describe_http_image_example.py
+++ b/generative_ai/text_generation/gemini_describe_http_image_example.py
@@ -1,0 +1,49 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def generate_content() -> str:
+    # [START generativeaionvertexai_gemini_describe_http_image]
+    import vertexai
+    from vertexai.generative_models import GenerativeModel, Part
+
+    # TODO (developer): update project id
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = GenerativeModel("gemini-1.5-flash-002")
+
+    contents = [
+        # Text prompt
+        "Describe this image.",
+        # Example image of a Jack Russell Terrier puppy from Wikipedia.
+        Part.from_uri(
+            "https://upload.wikimedia.org/wikipedia/commons/1/1d/Szczenie_Jack_Russell_Terrier.jpg",
+            "image/jpeg",
+        ),
+    ]
+
+    response = model.generate_content(contents)
+    print(response.text)
+    # Example response:
+    #     'Here is a description of the image:'
+    #     'Close-up view of a young Jack Russell Terrier puppy sitting in short grass ...'
+    # [END generativeaionvertexai_gemini_describe_http_image]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/generative_ai/text_generation/gemini_describe_http_pdf_example.py
+++ b/generative_ai/text_generation/gemini_describe_http_pdf_example.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def generate_content() -> str:
+    # [START generativeaionvertexai_gemini_describe_http_pdf]
+    import vertexai
+    from vertexai.generative_models import GenerativeModel, Part
+
+    # TODO (developer): update project id
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = GenerativeModel("gemini-1.5-flash-002")
+
+    contents = [
+        # Text prompt
+        "Summarise this file",
+        # Example video ad for Pixel 8
+        Part.from_uri(
+            "https://storage.googleapis.com/cloud-samples-data/generative-ai/pdf/1706.03762v7.pdf",
+            "application/pdf",
+        ),
+    ]
+
+    response = model.generate_content(contents)
+    print(response.text)
+    # Example response:
+    #     'This paper introduces the Transformer, a new neural network architecture for '
+    #     'sequence transduction, which uses an attention mechanism to learn global '
+    #     'dependencies between input and output sequences. The Transformer ...
+    # [END generativeaionvertexai_gemini_describe_http_pdf]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/generative_ai/text_generation/gemini_describe_http_pdf_example.py
+++ b/generative_ai/text_generation/gemini_describe_http_pdf_example.py
@@ -29,7 +29,7 @@ def generate_content() -> str:
     contents = [
         # Text prompt
         "Summarise this file",
-        # Example video ad for Pixel 8
+        # Example PDF document on Transformers, a neural network architecture.
         Part.from_uri(
             "https://storage.googleapis.com/cloud-samples-data/generative-ai/pdf/1706.03762v7.pdf",
             "application/pdf",

--- a/generative_ai/text_generation/test_text_generation_examples.py
+++ b/generative_ai/text_generation/test_text_generation_examples.py
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import gemini_describe_http_image_example
+import gemini_describe_http_pdf_example
+
+
+def test_gemini_describe_http_image_example() -> None:
+    text = gemini_describe_http_image_example.generate_content()
+    assert len(text) > 0
+
+
+def test_gemini_describe_http_pdf_example() -> None:
+    text = gemini_describe_http_pdf_example.generate_content()
+    assert len(text) > 0

--- a/generative_ai/video/gemini_describe_http_video_example.py
+++ b/generative_ai/video/gemini_describe_http_video_example.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def generate_content() -> str:
+    # [START generativeaionvertexai_gemini_describe_http_video]
+    import vertexai
+    from vertexai.generative_models import GenerativeModel, Part
+
+    # TODO (developer): update project id
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = GenerativeModel("gemini-1.5-flash-002")
+
+    contents = [
+        # Text prompt
+        "Describe this video.",
+        # Example video ad for Pixel 8
+        Part.from_uri(
+            "https://storage.googleapis.com/cloud-samples-data/generative-ai/video/pixel8.mp4",
+            "video/mp4",
+        ),
+    ]
+
+    response = model.generate_content(contents)
+    print(response.text)
+    # Example response:
+    #     'Here is a description of the video.'
+    #     'This is a Google Pixel 8 advertisement featuring Saeko Shimada, a photographer'
+    #     ' in Tokyo, Japan. The video opens with a view of a train passing ... '
+    # [END generativeaionvertexai_gemini_describe_http_video]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/generative_ai/video/gemini_youtube_video_key_moments_example.py
+++ b/generative_ai/video/gemini_youtube_video_key_moments_example.py
@@ -1,0 +1,55 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def generate_content() -> str:
+    # [START generativeaionvertexai_gemini_youtube_video_key_moments]
+    import vertexai
+    from vertexai.generative_models import GenerativeModel, Part
+
+    # TODO (developer): update project id
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = GenerativeModel("gemini-1.5-flash-002")
+
+    contents = [
+        # Text prompt
+        "Identify the key moments of this video.",
+        # YouTube video of Paris 2024 Olympics
+        Part.from_uri("https://www.youtube.com/watch?v=6F5gZWcpNU4", "video/mp4"),
+    ]
+
+    response = model.generate_content(contents)
+    print(response.text)
+    # Example response
+    #    This video is a fast-paced, exciting montage of athletes competing in and celebrating their victories in the 2024 Summer Olympics in Paris, France. Key moments include:
+    #    - [00:00:01] The Olympic rings are shown with laser lights and fireworks in the opening ceremonies.
+    #    - [00:00:02–00:00:08] Various shots of the games’ venues are shown, including aerial views of skateboarding and volleyball venues, a view of the track and field stadium, and a shot of the Palace of Versailles.
+    #    - [00:00:09–00:01:16] A fast-paced montage shows highlights from various Olympic competitions.
+    #    - [00:01:17–00:01:29] The video switches to show athletes celebrating victories, both tears of joy and tears of sadness are shown.
+    #    - [00:01:30–00:02:26] The montage then continues to showcase sporting events, including cycling, kayaking, swimming, track and field, gymnastics, surfing, basketball, and ping-pong.
+    #    - [00:02:27–00:04:03] More athletes celebrate their wins.
+    #    - [00:04:04–00:04:55] More Olympic sports are shown, followed by more celebrations.
+    #    - [00:04:56] Olympic medals are shown.
+    #    - [00:04:57] An aerial shot of the Eiffel Tower lit up with the Olympic rings is shown at night.
+    #    - [00:04:58–00:05:05] The video ends with a black screen and the words, “Sport. And More Than Sport.” written beneath the Olympic rings.
+    # [END generativeaionvertexai_gemini_youtube_video_key_moments]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/generative_ai/video/gemini_youtube_video_summarization_example.py
+++ b/generative_ai/video/gemini_youtube_video_summarization_example.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def generate_content() -> str:
+    # [START generativeaionvertexai_gemini_youtube_video_summarization]
+    import vertexai
+    from vertexai.generative_models import GenerativeModel, Part
+
+    # TODO (developer): update project id
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = GenerativeModel("gemini-1.5-flash-002")
+
+    contents = [
+        # Text prompt
+        "Summarize this video.",
+        # YouTube video of Google Pixel 9
+        Part.from_uri("https://youtu.be/sXrasaDZxw0", "video/mp4"),
+    ]
+
+    response = model.generate_content(contents)
+    print(response.text)
+    # Example response:
+    #     'This Google Pixel 9 Pro advertisement shows how the Gemini AI feature enhances'
+    #     ' the capabilities of the phone. The video starts with ...'
+    # [END generativeaionvertexai_gemini_youtube_video_summarization]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/generative_ai/video/test_video_examples.py
+++ b/generative_ai/video/test_video_examples.py
@@ -1,0 +1,31 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import gemini_describe_http_video_example
+import gemini_youtube_video_key_moments_example
+import gemini_youtube_video_summarization_example
+
+
+def test_gemini_describe_http_video_example() -> None:
+    text = gemini_describe_http_video_example.generate_content()
+    assert len(text) > 0
+
+
+def test_gemini_youtube_video_key_moments_example() -> None:
+    text = gemini_youtube_video_key_moments_example.generate_content()
+    assert len(text) > 0
+
+
+def test_gemini_youtube_video_summarization_example() -> None:
+    text = gemini_youtube_video_summarization_example.generate_content()
+    assert len(text) > 0


### PR DESCRIPTION
## Description

feat(generativeai): Add new sample for text generation(Youtube, Web support, Controlled Generations)

Fixes [b/369301403](http://b/369301403)

> This is a cleaner version of PR - https://github.com/GoogleCloudPlatform/python-docs-samples/pull/12625

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.


- [X] Please **merge** this PR for me once it is approved