### PR TITLE
fix(iam): add a print for visibility

### DIFF
--- a/iam/cloud-client/snippets/get_policy.py
+++ b/iam/cloud-client/snippets/get_policy.py
@@ -31,6 +31,8 @@ def get_project_policy(project_id: str) -> policy_pb2.Policy:
     request.resource = f"projects/{project_id}"
 
     policy = client.get_iam_policy(request)
+    print(f"Policy retrieved: {policy}")
+    
     return policy
 
 

--- a/iam/cloud-client/snippets/get_policy.py
+++ b/iam/cloud-client/snippets/get_policy.py
@@ -32,7 +32,7 @@ def get_project_policy(project_id: str) -> policy_pb2.Policy:
 
     policy = client.get_iam_policy(request)
     print(f"Policy retrieved: {policy}")
-    
+
     return policy
 
 

--- a/iam/cloud-client/snippets/test_service_account.py
+++ b/iam/cloud-client/snippets/test_service_account.py
@@ -33,7 +33,7 @@ PROJECT = google.auth.default()[1]
 
 
 @pytest.fixture(scope="module")
-def service_account(capsys: "pytest.CaptureFixture[str]") -> str:
+def service_account() -> str:
     name = f"test-{uuid.uuid4().hex[:25]}"
     created = False
     try:
@@ -44,8 +44,12 @@ def service_account(capsys: "pytest.CaptureFixture[str]") -> str:
     finally:
         if created:
             delete_service_account(PROJECT, email)
-            out, _ = capsys.readouterr()
-            assert re.search(f"Deleted a service account: {email}", out)
+            try:
+                get_service_account(PROJECT, email)
+            except google.api_core.exceptions.NotFound:
+                pass
+            else:
+                pytest.fail(f"The {email} service account was not deleted.")
 
 
 def test_list_service_accounts(service_account: str) -> None:

--- a/iam/cloud-client/snippets/test_service_account.py
+++ b/iam/cloud-client/snippets/test_service_account.py
@@ -32,7 +32,7 @@ from snippets.service_account_set_policy import set_service_account_iam_policy
 PROJECT = google.auth.default()[1]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def service_account(capsys: "pytest.CaptureFixture[str]") -> str:
     name = f"test-{uuid.uuid4().hex[:25]}"
     created = False

--- a/iam/cloud-client/snippets/test_service_account.py
+++ b/iam/cloud-client/snippets/test_service_account.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 import uuid
 
 import backoff


### PR DESCRIPTION
## Description

providing an example to share with folks who worked on these samples, but there is a number of feedback items on samples of "this sample doesn't do anything". 

I think an underlying issue is that while the snippet does what it's documented to do, there is no output so the sample doesn't appear to do anything. i.e., output looks like 

WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
I0000 00:00:1727410693.815942    2970 config.cc:230] gRPC experiments enabled: call_status_override_on_cancellation, event_engine_dns, event_engine_listener, http2_stats_fix, monitoring_experiment, pick_first_new, trace_record_callops, work_serializer_clears_time_cache 

For this sample 

With this update it will print out the policy to screen so folks can see that it's doing something. I suspect that there are a lot of samples that need to get some kind of treatment so that there is reduced Feedback. 
