### PR TITLE
feat(tts): add streaming synthesis sample

### DIFF
--- a/texttospeech/snippets/requirements.txt
+++ b/texttospeech/snippets/requirements.txt
@@ -1,3 +1,3 @@
 future==1.0.0
-google-cloud-texttospeech==2.14.1
+google-cloud-texttospeech==2.17.2
 google-cloud-storage==2.9.0

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -32,7 +32,7 @@ def run_streaming_tts_quickstart():
 
     # See https://cloud.google.com/text-to-speech/docs/voices for all voices.
     streaming_config = texttospeech.StreamingSynthesizeConfig(voice=texttospeech.VoiceSelectionParams(name="en-US-Journey-D", language_code="en-US"))
-    
+
     # Set the config for your stream. The first request must contain your config, and then each subsequent request must contain text.
     config_request = texttospeech.StreamingSynthesizeRequest(streaming_config=streaming_config)
 

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -32,7 +32,7 @@ def run_streaming_tts_quickstart():
     client = texttospeech.TextToSpeechClient()
 
     # Set the config for your stream. The first request must contain your config, and then each subsequent request must contain text.
-    streaming_config = texttospeech.StreamingSynthesizeConfig(voice=texttospeech.VoiceSelectionParams(name="en-US-Journey-D", language_code="en-US")
+    streaming_config = texttospeech.StreamingSynthesizeConfig(voice=texttospeech.VoiceSelectionParams(name="en-US-Journey-D", language_code="en-US"))
 
     config_request = texttospeech.StreamingSynthesizeRequest(streaming_config=streaming_config)
 

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -47,8 +47,6 @@ def run_streaming_tts_quickstart():
         # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000
         print("Audio content size in bytes is: " + len(response.audio_content))
 
-    
-
 
 if __name__ == "__main__":
     run_streaming_tts_quickstart()

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# All Rights Reserved.
 
 """Google Cloud Text-To-Speech API streaming sample application .
 

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# All Rights Reserved.
+
+"""Google Cloud Text-To-Speech API streaming sample application .
+
+Example usage:
+    python streaming_tts_quickstart.py
+"""
+
+
+def run_streaming_tts_quickstart():
+    # [START streaming_tts_quickstart]
+    """Synthesizes speech from a stream of input text.
+    """
+    from google.cloud import texttospeech
+    import itertools
+
+    # Instantiates a client
+    client = texttospeech.TextToSpeechClient()
+
+    # Set the config for your stream. The first request must contain your config, and then each subsequent request must contain text.
+    streaming_config = texttospeech.StreamingSynthesizeConfig(voice=texttospeech.VoiceSelectionParams(name="en-US-Journey-D", language_code="en-US")
+
+    config_request = texttospeech.StreamingSynthesizeRequest(streaming_config=streaming_config)
+
+    # Placeholder request generator. Consider using Gemini or another LLM with output streaming as a generator instead.
+    def request_generator():
+      for i in range(5):
+        yield texttospeech.StreamingSynthesizeRequest(input="Test sentence. ")
+
+    # Send your requests as a stream to be synthesized.
+    streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator())
+    for response in streaming_responses:
+      # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000
+      print("Audio content size in bytes is: " + len(response.audio_content))
+
+    
+
+
+if __name__ == "__main__":
+    run_streaming_tts_quickstart()

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -38,10 +38,10 @@ def run_streaming_tts_quickstart():
 
     # Request generator. Consider using Gemini or another LLM with output streaming as a generator.
     def request_generator():
-        yield texttospeech.StreamingSynthesizeRequest(input="Hello there. ")
-        yield texttospeech.StreamingSynthesizeRequest(input="How are you ")
-        yield texttospeech.StreamingSynthesizeRequest(input="today? It's ")
-        yield texttospeech.StreamingSynthesizeRequest(input="such nice weather outside.")
+        yield texttospeech.StreamingSynthesizeRequest(input=texttospeech.StreamingSynthesisInput(text="Hello there. "))
+        yield texttospeech.StreamingSynthesizeRequest(input=texttospeech.StreamingSynthesisInput(text="How are you "))
+        yield texttospeech.StreamingSynthesizeRequest(input=texttospeech.StreamingSynthesisInput(text="today? It's "))
+        yield texttospeech.StreamingSynthesizeRequest(input=texttospeech.StreamingSynthesisInput(text="such nice weather outside."))
 
     streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator()))
     for response in streaming_responses:

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -38,14 +38,14 @@ def run_streaming_tts_quickstart():
 
     # Placeholder request generator. Consider using Gemini or another LLM with output streaming as a generator instead.
     def request_generator():
-      for i in range(5):
-        yield texttospeech.StreamingSynthesizeRequest(input="Test sentence. ")
+        for i in range(5):
+            yield texttospeech.StreamingSynthesizeRequest(input="Test sentence. ")
 
     # Send your requests as a stream to be synthesized.
     streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator()))
     for response in streaming_responses:
-      # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000
-      print("Audio content size in bytes is: " + len(response.audio_content))
+        # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000
+        print("Audio content size in bytes is: " + len(response.audio_content))
 
     
 

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2018 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -36,14 +36,15 @@ def run_streaming_tts_quickstart():
     # Set the config for your stream. The first request must contain your config, and then each subsequent request must contain text.
     config_request = texttospeech.StreamingSynthesizeRequest(streaming_config=streaming_config)
 
-    # Placeholder request generator. Consider using Gemini or another LLM with output streaming as a generator instead.
+    # Request generator. Consider using Gemini or another LLM with output streaming as a generator.
     def request_generator():
-        for i in range(5):
-            yield texttospeech.StreamingSynthesizeRequest(input="Test sentence. ")
+        yield texttospeech.StreamingSynthesizeRequest(input="Hello there. ")
+        yield texttospeech.StreamingSynthesizeRequest(input="How are you ")
+        yield texttospeech.StreamingSynthesizeRequest(input="today? It's ")
+        yield texttospeech.StreamingSynthesizeRequest(input="such nice weather outside.")
 
     streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator()))
     for response in streaming_responses:
-        # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000
         print("Audio content size in bytes is: " + len(response.audio_content))
     # [END tts_synthezise_streaming]
 

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -22,6 +22,7 @@ Example usage:
 
 
 def run_streaming_tts_quickstart():
+    # [START tts_synthezise_streaming]
     """Synthesizes speech from a stream of input text.
     """
     from google.cloud import texttospeech
@@ -29,9 +30,10 @@ def run_streaming_tts_quickstart():
 
     client = texttospeech.TextToSpeechClient()
 
-    # Set the config for your stream. The first request must contain your config, and then each subsequent request must contain text.
+    # See https://cloud.google.com/text-to-speech/docs/voices for all voices.
     streaming_config = texttospeech.StreamingSynthesizeConfig(voice=texttospeech.VoiceSelectionParams(name="en-US-Journey-D", language_code="en-US"))
-
+    
+    # Set the config for your stream. The first request must contain your config, and then each subsequent request must contain text.
     config_request = texttospeech.StreamingSynthesizeRequest(streaming_config=streaming_config)
 
     # Placeholder request generator. Consider using Gemini or another LLM with output streaming as a generator instead.
@@ -43,6 +45,7 @@ def run_streaming_tts_quickstart():
     for response in streaming_responses:
         # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000
         print("Audio content size in bytes is: " + len(response.audio_content))
+    # [END tts_synthezise_streaming]
 
 
 if __name__ == "__main__":

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -23,7 +23,6 @@ Example usage:
 
 
 def run_streaming_tts_quickstart():
-    # [START streaming_tts_quickstart]
     """Synthesizes speech from a stream of input text.
     """
     from google.cloud import texttospeech

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -28,7 +28,6 @@ def run_streaming_tts_quickstart():
     from google.cloud import texttospeech
     import itertools
 
-    # Instantiates a client
     client = texttospeech.TextToSpeechClient()
 
     # Set the config for your stream. The first request must contain your config, and then each subsequent request must contain text.

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -40,7 +40,6 @@ def run_streaming_tts_quickstart():
         for i in range(5):
             yield texttospeech.StreamingSynthesizeRequest(input="Test sentence. ")
 
-    # Send your requests as a stream to be synthesized.
     streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator()))
     for response in streaming_responses:
         # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -45,7 +45,7 @@ def run_streaming_tts_quickstart():
 
     streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator()))
     for response in streaming_responses:
-        print("Audio content size in bytes is: " + len(response.audio_content))
+        print(f"Audio content size in bytes is: {len(response.audio_content)}")
     # [END tts_synthezise_streaming]
 
 

--- a/texttospeech/snippets/streaming_tts_quickstart.py
+++ b/texttospeech/snippets/streaming_tts_quickstart.py
@@ -42,7 +42,7 @@ def run_streaming_tts_quickstart():
         yield texttospeech.StreamingSynthesizeRequest(input="Test sentence. ")
 
     # Send your requests as a stream to be synthesized.
-    streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator())
+    streaming_responses = client.streaming_synthesize(itertools.chain([config_request], request_generator()))
     for response in streaming_responses:
       # Just print the audio size. Replace with your logic to play audio. Note that audio_content is headerless LINEAR16 audio with a sample rate of 24000
       print("Audio content size in bytes is: " + len(response.audio_content))

--- a/texttospeech/snippets/streaming_tts_quickstart_test.py
+++ b/texttospeech/snippets/streaming_tts_quickstart_test.py
@@ -16,7 +16,7 @@
 import streaming_tts_quickstart
 
 
-def test_streaming_synthesize():
+def test_streaming_synthesize(capsys):
     streaming_tts_quickstart.run_streaming_tts_quickstart()
 
     out, err = capsys.readouterr()

--- a/texttospeech/snippets/streaming_tts_quickstart_test.py
+++ b/texttospeech/snippets/streaming_tts_quickstart_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import streaming_tts_quickstart
+
+
+def test_streaming_synthesize():
+  streaming_tts_quickstart.run_streaming_tts_quickstart()
+
+  out, err = capsys.readouterr()
+  assert "Audio content size in bytes is" in out

--- a/texttospeech/snippets/streaming_tts_quickstart_test.py
+++ b/texttospeech/snippets/streaming_tts_quickstart_test.py
@@ -17,7 +17,7 @@ import streaming_tts_quickstart
 
 
 def test_streaming_synthesize():
-  streaming_tts_quickstart.run_streaming_tts_quickstart()
+    streaming_tts_quickstart.run_streaming_tts_quickstart()
 
-  out, err = capsys.readouterr()
-  assert "Audio content size in bytes is" in out
+    out, err = capsys.readouterr()
+    assert "Audio content size in bytes is" in out


### PR DESCRIPTION
Add quickstart documentation for new streaming synthesize API

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved