### PR TITLE
refactor: (GenAI) Reorganized Audio Samples (Group C)

### DIFF
--- a/generative_ai/test_gemini_examples.py
+++ b/generative_ai/test_gemini_examples.py
@@ -142,11 +142,13 @@ def test_gemini_grounding_vais_example() -> None:
     assert response
 
 
+# Delete this test after approval /understand_audio/understand_audio_test.py
 def test_summarize_audio() -> None:
     text = gemini_audio.summarize_audio()
     assert len(text) > 0
 
 
+# Delete this test after approval /understand_audio/understand_audio_test.py
 def test_transcript_audio() -> None:
     text = gemini_audio.transcript_audio()
     assert len(text) > 0

--- a/generative_ai/understand_audio/summarization_example.py
+++ b/generative_ai/understand_audio/summarization_example.py
@@ -1,0 +1,58 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def summarize_audio() -> str:
+    """Summarizes the content of an audio file using a pre-trained generative model."""
+    # [START generativeaionvertexai_gemini_audio_summarization]
+
+    import vertexai
+    from vertexai.generative_models import GenerativeModel, Part
+
+    # TODO(developer): Update and un-comment below line
+    # PROJECT_ID = "your-project-id"
+
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = GenerativeModel("gemini-1.5-flash-002")
+
+    prompt = """
+    Please provide a summary for the audio.
+    Provide chapter titles, be concise and short, no need to provide chapter summaries.
+    Do not make up any information that is not part of the audio and do not be verbose.
+    """
+
+    audio_file_uri = "gs://cloud-samples-data/generative-ai/audio/pixel.mp3"
+    audio_file = Part.from_uri(audio_file_uri, mime_type="audio/mpeg")
+
+    contents = [audio_file, prompt]
+
+    response = model.generate_content(contents)
+    print(response.text)
+    # Example response:
+    # **Made By Google Podcast Summary**
+    # **Chapter Titles:**
+    # * Introduction
+    # * Transformative Pixel Features
+    # ...
+
+    # [END generativeaionvertexai_gemini_audio_summarization]
+    return response.text
+
+
+if __name__ == "__main__":
+    summarize_audio()

--- a/generative_ai/understand_audio/transcription_example.py
+++ b/generative_ai/understand_audio/transcription_example.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def transcript_audio() -> str:
+    """Transcribes the content of an audio file using a pre-trained generative model."""
+    # [START generativeaionvertexai_gemini_audio_transcription]
+
+    import vertexai
+    from vertexai.generative_models import GenerativeModel, Part
+
+    # TODO(developer): Update and un-comment below line
+    # PROJECT_ID = "your-project-id"
+
+    vertexai.init(project=PROJECT_ID, location="us-central1")
+
+    model = GenerativeModel("gemini-1.5-flash-002")
+
+    prompt = """
+    Can you transcribe this interview, in the format of timecode, speaker, caption.
+    Use speaker A, speaker B, etc. to identify speakers.
+    """
+
+    audio_file_uri = "gs://cloud-samples-data/generative-ai/audio/pixel.mp3"
+    audio_file = Part.from_uri(audio_file_uri, mime_type="audio/mpeg")
+
+    contents = [audio_file, prompt]
+
+    response = model.generate_content(contents)
+
+    print(response.text)
+    # Example response:
+    # [00:00:00] Speaker A: your devices are getting better over time...
+    # [00:00:16] Speaker B: Welcome to the Made by Google podcast, ...
+    # [00:01:00] Speaker A: So many features. I am a singer. ...
+    # [00:01:33] Speaker B: Amazing. DeCarlos, same question to you. ...
+
+    # [END generativeaionvertexai_gemini_audio_transcription]
+    return response.text
+
+
+if __name__ == "__main__":
+    transcript_audio()

--- a/generative_ai/understand_audio/understand_audio_test.py
+++ b/generative_ai/understand_audio/understand_audio_test.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import summarization_example
+import transcription_example
+
+
+def test_summarize_audio() -> None:
+    text = summarization_example.summarize_audio()
+    assert len(text) > 0
+
+
+def test_transcript_audio() -> None:
+    text = transcription_example.transcript_audio()
+    assert len(text) > 0


### PR DESCRIPTION
## Description

Created a new folder:  `/generative_ai/understand_audio`

| Region_tag                                        | New file                 |
|---------------------------------------------------|--------------------------|
| generativeaionvertexai_gemini_audio_summarization | summarization_example.py |
| generativeaionvertexai_gemini_audio_transcription | transcription_example.py |


**❗Files to be deleted after approval:**
- `/generative_ai/gemini_audio.py`
- Marked tests in `/generative_ai/test_gemini_examples.py` -> (`test_summarize_audio` and `test_transcript_audio` )


## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved