### PR TITLE
feat: New Samples for TPU: Start, Stop, List

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -82,6 +82,7 @@ path:
         storagetransfer: "storagetransfer"
         talent: "jobs"
         texttospeech: "texttospeech"
+        tpu: "tpu"
         trace: "cloudtrace"
         translate: "translate"
         vision: "vision"

--- a/tpu/list_tpu.py
+++ b/tpu/list_tpu.py
@@ -1,0 +1,54 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.cloud.tpu_v2.services.tpu.pagers import ListNodesPager
+
+
+def list_cloud_tpu(project_id: str, zone: str) -> ListNodesPager:
+    """List all TPU nodes in the project and zone.
+    Args:
+        project_id (str): The ID of Google Cloud project.
+        zone (str): The zone of the TPU nodes.
+    Returns:
+        ListNodesPager: The list of TPU nodes.
+    """
+    # [START tpu_vm_list]
+    from google.cloud import tpu_v2
+
+    # TODO(developer): Update and un-comment below lines
+    # project_id = "your-project-id"
+    # zone = "us-central1-b"
+
+    client = tpu_v2.TpuClient()
+
+    nodes = client.list_nodes(parent=f"projects/{project_id}/locations/{zone}")
+    for node in nodes:
+        print(node.name)
+        print(node.state)
+        print(node.accelerator_type)
+    # Example response:
+    # projects/[project_id]/locations/[zone]/nodes/node-name
+    # State.READY
+    # v2-8
+
+    # [END tpu_vm_list]
+    return nodes
+
+
+if __name__ == "__main__":
+    PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+    ZONE = "us-central1-b"
+    list_cloud_tpu(PROJECT_ID, ZONE)

--- a/tpu/start_tpu.py
+++ b/tpu/start_tpu.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.cloud.tpu_v2 import Node
+
+
+def start_cloud_tpu(project_id: str, zone: str, tpu_name: str = "tpu-name") -> Node:
+    """Start a TPU node.
+    Args:
+        project_id (str): The ID of Google Cloud project.
+        zone (str): The zone of the TPU node.
+        tpu_name (str): The name of the TPU node to start.
+    Returns:
+        Node: The started TPU node.
+    """
+    # [START tpu_vm_start]
+    from google.cloud import tpu_v2
+
+    # TODO(developer): Update and un-comment below lines
+    # project_id = "your-project-id"
+    # zone = "us-central1-b"
+    # tpu_name = "tpu-name"
+
+    client = tpu_v2.TpuClient()
+
+    request = tpu_v2.StartNodeRequest(
+        name=f"projects/{project_id}/locations/{zone}/nodes/{tpu_name}",
+    )
+    try:
+        operation = client.start_node(request=request)
+        print("Waiting for start operation to complete...")
+        response = operation.result()
+        print(f"TPU {tpu_name} has been started")
+        print(response.state)
+        # Example response:
+        # State.READY
+
+        return response
+    except Exception as e:
+        print(e)
+
+    # [END tpu_vm_start]
+
+
+if __name__ == "__main__":
+    PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+    ZONE = "us-central1-b"
+    start_cloud_tpu(PROJECT_ID, ZONE, "tpu-name")

--- a/tpu/stop_tpu.py
+++ b/tpu/stop_tpu.py
@@ -1,0 +1,62 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.cloud.tpu_v2 import Node
+
+
+def stop_cloud_tpu(project_id: str, zone: str, tpu_name: str = "tpu-name") -> Node:
+    """Stop a TPU node.
+    Args:
+        project_id (str): The ID of Google Cloud project.
+        zone (str): The zone of the TPU node.
+        tpu_name (str): The name of the TPU node to stop.
+    Returns:
+        Node: The stopped TPU node.
+    """
+
+    # [START tpu_vm_stop]
+    from google.cloud import tpu_v2
+
+    # TODO(developer): Update and un-comment below lines
+    # project_id = "your-project-id"
+    # zone = "us-central1-b"
+    # tpu_name = "tpu-name"
+
+    client = tpu_v2.TpuClient()
+
+    request = tpu_v2.StopNodeRequest(
+        name=f"projects/{project_id}/locations/{zone}/nodes/{tpu_name}",
+    )
+    try:
+        operation = client.stop_node(request=request)
+        print("Waiting for stop operation to complete...")
+        response = operation.result()
+        print(f"This TPU {tpu_name} has been stopped")
+        print(response.state)
+        # Example response:
+        # State.STOPPED
+
+        return response
+    except Exception as e:
+        print(e)
+
+    # [END tpu_vm_stop]
+
+
+if __name__ == "__main__":
+    PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+    ZONE = "us-central1-b"
+    stop_cloud_tpu(PROJECT_ID, ZONE, "tpu-name")

--- a/tpu/test_tpu.py
+++ b/tpu/test_tpu.py
@@ -32,15 +32,6 @@ ZONE = "us-south1-a"
 TPU_TYPE = "v5litepod-1"
 TPU_VERSION = "tpu-vm-tf-2.17.0-pjrt"
 
-# For tests and checking the TPU in different zones
-list_of_zones = [
-    "us-central1-a",
-    "us-central1-b",
-    "us-central1-c",
-    "us-central1-f",
-    "us-south1-a",
-]
-
 
 # Instance of TPU
 @pytest.fixture(scope="session")
@@ -51,42 +42,39 @@ def tpu_instance() -> Node:
     except Exception as e:
         print(f"Error during cleanup: {e}")
 
-#
-# def test_creating_tpu(tpu_instance: Node) -> None:
-#     assert tpu_instance.state == Node.State.READY
-#
-#
-# def test_creating_with_startup_script() -> None:
-#     tpu_name_with_script = "script-tpu-" + uuid.uuid4().hex[:5]
-#     try:
-#         tpu_with_script = create_tpu_with_script.create_cloud_tpu_with_script(
-#             PROJECT_ID, ZONE, tpu_name_with_script, TPU_TYPE, TPU_VERSION
-#         )
-#         assert "--upgrade numpy" in tpu_with_script.metadata["startup-script"]
-#     finally:
-#         print(f"\n\n ------------ Deleting TPU {TPU_NAME}\n ------------" )
-#         delete_tpu.delete_cloud_tpu(PROJECT_ID, ZONE, tpu_name_with_script)
-#
-#
-# def test_get_tpu() -> None:
-#     tpu = get_tpu.get_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
-#     assert tpu.state == Node.State.READY
-#     assert tpu.name == f"projects/{PROJECT_ID}/locations/{ZONE}/nodes/{TPU_NAME}"
+
+def test_creating_tpu(tpu_instance: Node) -> None:
+    assert tpu_instance.state == Node.State.READY
+
+
+def test_creating_with_startup_script() -> None:
+    tpu_name_with_script = "script-tpu-" + uuid.uuid4().hex[:5]
+    try:
+        tpu_with_script = create_tpu_with_script.create_cloud_tpu_with_script(
+            PROJECT_ID, ZONE, tpu_name_with_script, TPU_TYPE, TPU_VERSION
+        )
+        assert "--upgrade numpy" in tpu_with_script.metadata["startup-script"]
+    finally:
+        print(f"\n\n ------------ Deleting TPU {TPU_NAME}\n ------------")
+        delete_tpu.delete_cloud_tpu(PROJECT_ID, ZONE, tpu_name_with_script)
+
+
+def test_get_tpu() -> None:
+    tpu = get_tpu.get_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
+    assert tpu.state == Node.State.READY
+    assert tpu.name == f"projects/{PROJECT_ID}/locations/{ZONE}/nodes/{TPU_NAME}"
 
 
 def test_list_tpu() -> None:
     nodes = list_tpu.list_cloud_tpu(PROJECT_ID, ZONE)
-    for zone in list_of_zones:
-        nodes = list_tpu.list_cloud_tpu(PROJECT_ID, zone)
-        print("KEYWORD: NODES", nodes)
     assert len(list(nodes)) > 0
 
 
-# def test_stop_tpu() -> None:
-#     node = stop_tpu.stop_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
-#     assert node.state == Node.State.STOPPED
-#
-#
-# def test_start_tpu() -> None:
-#     node = start_tpu.start_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
-#     assert node.state == Node.State.READY
+def test_stop_tpu() -> None:
+    node = stop_tpu.stop_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
+    assert node.state == Node.State.STOPPED
+
+
+def test_start_tpu() -> None:
+    node = start_tpu.start_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
+    assert node.state == Node.State.READY

--- a/tpu/test_tpu.py
+++ b/tpu/test_tpu.py
@@ -22,12 +22,24 @@ import create_tpu
 import create_tpu_with_script
 import delete_tpu
 import get_tpu
+import list_tpu
+import start_tpu
+import stop_tpu
 
 TPU_NAME = "test-tpu-" + uuid.uuid4().hex[:10]
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
 ZONE = "us-south1-a"
 TPU_TYPE = "v5litepod-1"
 TPU_VERSION = "tpu-vm-tf-2.17.0-pjrt"
+
+# For tests and checking the TPU in different zones
+list_of_zones = [
+    "us-central1-a",
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
+    "us-south1-a",
+]
 
 
 # Instance of TPU
@@ -39,23 +51,41 @@ def tpu_instance() -> Node:
     except Exception as e:
         print(f"Error during cleanup: {e}")
 
+#
+# def test_creating_tpu(tpu_instance: Node) -> None:
+#     assert tpu_instance.state == Node.State.READY
+#
+#
+# def test_creating_with_startup_script() -> None:
+#     tpu_name_with_script = "script-tpu-" + uuid.uuid4().hex[:5]
+#     try:
+#         tpu_with_script = create_tpu_with_script.create_cloud_tpu_with_script(
+#             PROJECT_ID, ZONE, tpu_name_with_script, TPU_TYPE, TPU_VERSION
+#         )
+#         assert "--upgrade numpy" in tpu_with_script.metadata["startup-script"]
+#     finally:
+#         print(f"\n\n ------------ Deleting TPU {TPU_NAME}\n ------------" )
+#         delete_tpu.delete_cloud_tpu(PROJECT_ID, ZONE, tpu_name_with_script)
+#
+#
+# def test_get_tpu() -> None:
+#     tpu = get_tpu.get_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
+#     assert tpu.state == Node.State.READY
+#     assert tpu.name == f"projects/{PROJECT_ID}/locations/{ZONE}/nodes/{TPU_NAME}"
 
-def test_creating_tpu(tpu_instance: Node) -> None:
-    assert tpu_instance.state == Node.State.READY
+
+def test_list_tpu() -> None:
+    nodes = list_tpu.list_cloud_tpu(PROJECT_ID, ZONE)
+    for zone in list_of_zones:
+        list_tpu.list_cloud_tpu(PROJECT_ID, zone)
+    # assert len(list(nodes)) > 0
 
 
-def test_creating_with_startup_script() -> None:
-    tpu_name_with_script = "script-tpu-" + uuid.uuid4().hex[:5]
-    try:
-        tpu_with_script = create_tpu_with_script.create_cloud_tpu_with_script(
-            PROJECT_ID, ZONE, tpu_name_with_script, TPU_TYPE, TPU_VERSION
-        )
-        assert "--upgrade numpy" in tpu_with_script.metadata["startup-script"]
-    finally:
-        delete_tpu.delete_cloud_tpu(PROJECT_ID, ZONE, tpu_name_with_script)
-
-
-def test_get_tpu() -> None:
-    tpu = get_tpu.get_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
-    assert tpu.state == Node.State.READY
-    assert tpu.name == f"projects/{PROJECT_ID}/locations/{ZONE}/nodes/{TPU_NAME}"
+# def test_stop_tpu() -> None:
+#     node = stop_tpu.stop_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
+#     assert node.state == Node.State.STOPPED
+#
+#
+# def test_start_tpu() -> None:
+#     node = start_tpu.start_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
+#     assert node.state == Node.State.READY

--- a/tpu/test_tpu.py
+++ b/tpu/test_tpu.py
@@ -77,8 +77,9 @@ def tpu_instance() -> Node:
 def test_list_tpu() -> None:
     nodes = list_tpu.list_cloud_tpu(PROJECT_ID, ZONE)
     for zone in list_of_zones:
-        list_tpu.list_cloud_tpu(PROJECT_ID, zone)
-    # assert len(list(nodes)) > 0
+        nodes = list_tpu.list_cloud_tpu(PROJECT_ID, zone)
+        print("KEYWORD: NODES", nodes)
+    assert len(list(nodes)) > 0
 
 
 # def test_stop_tpu() -> None:


### PR DESCRIPTION
## Description
Created new Samples for TPU. **Start**, **Stop**, **List** operations.
Doc page -> [here](https://cloud.google.com/tpu/docs/managing-tpus-tpu-vm#gcloud)

| Region tag    | Sample                    |
|---------------|---------------------------|
|  tpu_vm_list |  `tpu/list_tpu.py` |
|  tpu_vm_start | `tpu/start_tpu.py`  |
|  tpu_vm_stop | `tpu/stop_tpu.py`  |

Updated tests in `tpu/test_tpu.py`

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved