### PR TITLE
feat: Created TPU Topology Sample

### DIFF
--- a/tpu/create_tpu_topology.py
+++ b/tpu/create_tpu_topology.py
@@ -1,0 +1,75 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.cloud.tpu_v2 import Node
+
+
+def create_cloud_tpu_with_topology(
+    project_id: str,
+    zone: str,
+    tpu_name: str,
+    runtime_version: str = "tpu-vm-tf-2.17.0-pjrt",
+) -> Node:
+    """Creates a Cloud TPU node with a specific topology.
+    Args:
+        project_id (str): The ID of the Google Cloud project.
+        zone (str): The zone where the TPU node will be created.
+        tpu_name (str): The name of the TPU node.
+        runtime_version (str, optional): The runtime version for the TPU.
+    Returns:
+        Node: The created TPU node.
+    """
+    # [START tpu_vm_create_topology]
+    from google.cloud import tpu_v2
+
+    # TODO(developer): Update and un-comment below lines
+    # project_id = "your-project-id"
+    # zone = "us-central1-b"
+    # tpu_name = "tpu-name"
+    # runtime_version = "tpu-vm-tf-2.17.0-pjrt"
+
+    node = tpu_v2.Node()
+    # Here we are creating a TPU v3-8 with 2x2 topology.
+    node.accelerator_config = tpu_v2.AcceleratorConfig(
+        type_=tpu_v2.AcceleratorConfig.Type.V3,
+        topology="2x2",
+    )
+    node.runtime_version = runtime_version
+
+    request = tpu_v2.CreateNodeRequest(
+        parent=f"projects/{project_id}/locations/{zone}",
+        node_id=tpu_name,
+        node=node,
+    )
+
+    client = tpu_v2.TpuClient()
+    operation = client.create_node(request=request)
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print(response.accelerator_config)
+    # Example response:
+    # type_: V3
+    # topology: "2x2"
+
+    # [END tpu_vm_create_topology]
+    return response
+
+
+if __name__ == "__main__":
+    PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+    ZONE = "us-central1-a"
+    create_cloud_tpu_with_topology(PROJECT_ID, ZONE, "tpu-name")

--- a/tpu/test_tpu.py
+++ b/tpu/test_tpu.py
@@ -14,17 +14,19 @@
 import os
 import uuid
 
-from google.cloud.tpu_v2.types import Node
+from google.cloud.tpu_v2.types import AcceleratorConfig, Node
 
 import pytest
 
 import create_tpu
+import create_tpu_topology
 import create_tpu_with_script
 import delete_tpu
 import get_tpu
 import list_tpu
 import start_tpu
 import stop_tpu
+
 
 TPU_NAME = "test-tpu-" + uuid.uuid4().hex[:10]
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
@@ -78,3 +80,16 @@ def test_stop_tpu() -> None:
 def test_start_tpu() -> None:
     node = start_tpu.start_cloud_tpu(PROJECT_ID, ZONE, TPU_NAME)
     assert node.state == Node.State.READY
+
+
+def test_with_topology() -> None:
+    topology_tpu_name = "topology-tpu-" + uuid.uuid4().hex[:5]
+    topology_zone = "us-central1-a"
+    try:
+        topology_tpu = create_tpu_topology.create_cloud_tpu_with_topology(
+            PROJECT_ID, topology_zone, topology_tpu_name, TPU_VERSION
+        )
+        assert topology_tpu.accelerator_config.type_ == AcceleratorConfig.Type.V3
+        assert topology_tpu.accelerator_config.topology == "2x2"
+    finally:
+        delete_tpu.delete_cloud_tpu(PROJECT_ID, topology_zone, topology_tpu_name)


### PR DESCRIPTION
## Description

Created new TPU Sample - Create TPU with a specific topology.
| Region tag    | Sample                    |
|---------------|---------------------------|
|  tpu_vm_create_topology |  `tpu/create_tpu_topology.py` |

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved