### PR TITLE
fix incorrect import used in v2 code samples

### DIFF
--- a/securitycenter/snippets_v2/snippets_findings_v2.py
+++ b/securitycenter/snippets_v2/snippets_findings_v2.py
@@ -403,10 +403,10 @@ def update_source(source_name) -> Dict:
     Returns:
          Dict: returns the details of updated source.
     """
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v2
     from google.protobuf import field_mask_pb2
 
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v2.SecurityCenterClient()
 
     # Field mask to only update the display name.
     field_mask = field_mask_pb2.FieldMask(paths=["display_name"])
@@ -440,10 +440,10 @@ def list_source(organization_id) -> int:
          Dict: returns the count of the findings source
     """
     count = -1
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v2
 
     # Create a new client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v2.SecurityCenterClient()
     # 'parent' must be in one of the following formats:
     #   "organizations/{organization_id}"
     #   "projects/{project_id}"


### PR DESCRIPTION
## Description

This PR aims to fix the incorrect import used in code samples, issue raised in https://github.com/GoogleCloudPlatform/python-docs-samples/issues/12713

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved