### PR TITLE
fix: activate service account needed for tests

### DIFF
--- a/.kokoro/tests/run_single_test.sh
+++ b/.kokoro/tests/run_single_test.sh
@@ -18,7 +18,6 @@
 # The current directory is the test target directory.
 # Env var `PROJECT_ROOT` is defined.
 
-# testing
 echo "------------------------------------------------------------"
 echo "- testing ${PWD}"
 echo "------------------------------------------------------------"

--- a/.kokoro/tests/run_single_test.sh
+++ b/.kokoro/tests/run_single_test.sh
@@ -18,6 +18,7 @@
 # The current directory is the test target directory.
 # Env var `PROJECT_ROOT` is defined.
 
+# testing
 echo "------------------------------------------------------------"
 echo "- testing ${PWD}"
 echo "------------------------------------------------------------"

--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -98,6 +98,13 @@ fi
 # install nox for testing
 pip install --user -q nox
 
+# Use secrets acessor service account to get secrets
+if [[ -f "${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" ]]; then
+    gcloud auth activate-service-account \
+	   --key-file="${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" \
+	   --project="cloud-devrel-kokoro-resources"
+fi
+
 # On kokoro, we should be able to use the default service account. We
 # need to somehow bootstrap the secrets on other CI systems.
 if [[ "${TRAMPOLINE_CI}" == "kokoro" ]]; then


### PR DESCRIPTION
Fixes the error `ERROR: (gcloud.secrets.versions.access) PERMISSION_DENIED: Permission 'secretmanager.versions.access' denied...` which appears in presubmits