### PR TITLE
add samples for using a regional endpoint with SCC v2 API

### DIFF
--- a/securitycenter/snippets/noxfile_config.py
+++ b/securitycenter/snippets/noxfile_config.py
@@ -32,6 +32,7 @@ TEST_CONFIG_OVERRIDE = {
     # A dictionary you want to inject into your test. Don't put any
     # secrets here. These values will override predefined values.
     "envs": {
+        "DRZ_SA_ORGANIZATION": "172173830708",
         "GCLOUD_ORGANIZATION": "1081635000895",
         "GCLOUD_PROJECT": "project-a-id",
         "GCLOUD_PUBSUB_TOPIC": "projects/project-a-id/topics/notifications-sample-topic",

--- a/securitycenter/snippets_v2/regional_endpoint_snippet.py
+++ b/securitycenter/snippets_v2/regional_endpoint_snippet.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START securitycenter_regional_endpoint_list_findings]
+def rep_list_finding(parent, endpoint) -> int:
+    """
+    lists all findings for a parent
+    Args:
+        parent: Parent resource for which findings to be listed. Must be in one of the following formats:
+                "organizations/{organization_id}/sources/{sources}/locations/{location}"
+                "projects/{project_id}/sources/{sources}/locations/{location}"
+                "folders/{folder_id}/sources/{sources}/locations/{location}"
+        endpoint: Endpoint for this request. For example "securitycenter.googleapis.com", "securitycenter.me-central2.rep.googleapis.com"
+    Returns:
+        int: return the count of all findings for a source
+    """
+    from google.cloud import securitycenter_v2 as securitycenter
+    from google.api_core.client_options import ClientOptions
+    # Override endpoint and create a client.
+    options = ClientOptions(api_endpoint=endpoint)
+    client = securitycenter.SecurityCenterClient(client_options=options)
+
+    finding_result_iterator = client.list_findings(request={"parent": parent})
+    for count, finding_result in enumerate(finding_result_iterator):
+        print(
+            "{}: name: {} resource: {}".format(
+                count, finding_result.finding.name, finding_result.finding.resource_name
+            )
+        )
+    return count
+
+# [END securitycenter_regional_endpoint_list_findings]

--- a/securitycenter/snippets_v2/regional_endpoint_snippet_test.py
+++ b/securitycenter/snippets_v2/regional_endpoint_snippet_test.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import regional_endpoint_snippet
+import pytest
+
+@pytest.fixture(scope="module")
+def parent():
+    return f"{(os.environ["DRZ_SA_ORGANIZATION"])}/sources/-/locations/sa"
+
+def endpoint():
+    return "securitycenter.me-central2.rep.googleapis.com"
+
+def test_rep_list_finding():
+    count = regional_endpoint_snippet.rep_list_finding(parent, endpoint)
+    assert count > 0


### PR DESCRIPTION
## Description

The SCC API can be accessed via Regional Endpoints to meet customer data residency requirements. This sample shows how to override the endpoint for an API client. See https://cloud.google.com/security-command-center/docs/data-residency-support.md#regional-urls for more information on data residency

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved