### PR TITLE
fix: sqlalchemy dependencies

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/Dockerfile
+++ b/cloud-sql/mysql/sqlalchemy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 Google, LLC.
+# Copyright 2024 Google, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,9 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11
+FROM python:3.13
+
+RUN apt-get update
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.

--- a/cloud-sql/mysql/sqlalchemy/Dockerfile
+++ b/cloud-sql/mysql/sqlalchemy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Google, LLC.
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloud-sql/mysql/sqlalchemy/requirements.txt
+++ b/cloud-sql/mysql/sqlalchemy/requirements.txt
@@ -1,5 +1,5 @@
 Flask==2.2.2
-SQLAlchemy==2.0.24
+SQLAlchemy==2.0.36
 PyMySQL==1.1.1
 gunicorn==22.0.0
 cloud-sql-python-connector==1.2.4

--- a/cloud-sql/postgres/sqlalchemy/Dockerfile
+++ b/cloud-sql/postgres/sqlalchemy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3
+FROM python:3.13
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.

--- a/cloud-sql/postgres/sqlalchemy/Dockerfile
+++ b/cloud-sql/postgres/sqlalchemy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Google, LLC.
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloud-sql/postgres/sqlalchemy/Dockerfile
+++ b/cloud-sql/postgres/sqlalchemy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 Google, LLC.
+# Copyright 2024 Google, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 # Use the official Python image.
 # https://hub.docker.com/_/python
 FROM python:3.13
+
+RUN apt-get update
 
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.

--- a/cloud-sql/postgres/sqlalchemy/requirements.txt
+++ b/cloud-sql/postgres/sqlalchemy/requirements.txt
@@ -1,6 +1,6 @@
 Flask==2.2.2
 pg8000==1.31.2
-SQLAlchemy==2.0.24
+SQLAlchemy==2.0.36
 cloud-sql-python-connector==1.9.1
 gunicorn==22.0.0
 functions-framework==3.5.0

--- a/cloud-sql/sql-server/sqlalchemy/Dockerfile
+++ b/cloud-sql/sql-server/sqlalchemy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Google, LLC.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloud-sql/sql-server/sqlalchemy/Dockerfile
+++ b/cloud-sql/sql-server/sqlalchemy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google, LLC.
+# Copyright 2024 Google, LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-buster
+FROM python:3.13
 
 RUN apt-get update
 

--- a/cloud-sql/sql-server/sqlalchemy/requirements.txt
+++ b/cloud-sql/sql-server/sqlalchemy/requirements.txt
@@ -2,7 +2,7 @@ Flask==2.2.2
 gunicorn==22.0.0
 python-tds==1.15.0
 pyopenssl==24.0.0
-SQLAlchemy==2.0.24
+SQLAlchemy==2.0.36
 cloud-sql-python-connector==1.9.1
 sqlalchemy-pytds==1.0.2
 functions-framework==3.5.0


### PR DESCRIPTION
## Description

SQLAlchemy v2.0.24 fails with Python 3.13 with error:
```
AssertionError: Class <class 'sqlalchemy.sql.elements.SQLCoreOperations'> directly inherits TypingOnly but has additional attributes {'__static_attributes__'}.
```
[see bug #11334](https://github.com/sqlalchemy/sqlalchemy/issues/11334)

Bumping version of SQLAlchemy and fixing Python to version 3.13 to avoid such problems in the future.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved