### PR TITLE
fix(securitycenter): update docstring for create_client_with_endpoint()

### DIFF
--- a/securitycenter/snippets_v2/snippets_create_client_v2.py
+++ b/securitycenter/snippets_v2/snippets_create_client_v2.py
@@ -28,6 +28,12 @@ def create_client_with_endpoint(api_endpoint) -> securitycenter_v2.SecurityCente
     regional_client = securitycenter_v2.SecurityCenterClient(
         client_options={"api_endpoint": api_endpoint}
     )
-    print("Regional client initiated with endpoint: {}".format(regional_client.api_endpoint))
+    print(
+        "Regional client initiated with endpoint: {}".format(
+            regional_client.api_endpoint
+        )
+    )
     return regional_client
+
+
 # [END securitycenter_set_client_endpoint_v2]

--- a/securitycenter/snippets_v2/snippets_create_client_v2.py
+++ b/securitycenter/snippets_v2/snippets_create_client_v2.py
@@ -23,7 +23,7 @@ def create_client_with_endpoint(api_endpoint) -> securitycenter_v2.SecurityCente
     Args:
         api_endpoint: the regional endpoint's hostname, like 'securitycenter.REGION.rep.googleapis.com'
     Returns:
-        Dict: Returns clients with the default and regional endpoints; each key is a hostname
+        securitycenter_v2.SecurityCenterClient: returns a client for the regional endpoint
     """
     regional_client = securitycenter_v2.SecurityCenterClient(
         client_options={"api_endpoint": api_endpoint}

--- a/securitycenter/snippets_v2/snippets_create_client_v2_test.py
+++ b/securitycenter/snippets_v2/snippets_create_client_v2_test.py
@@ -16,5 +16,6 @@ import snippets_create_client_v2
 
 def test_create_client_with_endpoint():
     client = snippets_create_client_v2.create_client_with_endpoint(
-        "securitycenter.me-central2.rep.googleapis.com")
+        "securitycenter.me-central2.rep.googleapis.com"
+    )
     assert client.api_endpoint == "securitycenter.me-central2.rep.googleapis.com"


### PR DESCRIPTION
## Description

I changed the return type for `create_client_with_endpoint()` shortly before I merged https://github.com/GoogleCloudPlatform/python-docs-samples/pull/12671, but I forgot to update the docstring.

Also formats the sample and its test with `black`.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved