### PR TITLE
feat: make samples self runnable by moving devrel tags

### DIFF
--- a/managedkafka/snippets/clusters/create_cluster.py
+++ b/managedkafka/snippets/clusters/create_cluster.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_create_cluster]
-from google.api_core.exceptions import GoogleAPICallError
-from google.cloud import managedkafka_v1
 
 
 def create_cluster(
@@ -25,21 +22,18 @@ def create_cluster(
     cpu: int,
     memory_bytes: int,
 ) -> None:
-    """
-    Create a Kafka cluster.
-
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        subnet: VPC subnet from which the cluster is accessible. The expected format is projects/{project_id}/regions{region}/subnetworks/{subnetwork}.
-        cpu: Number of vCPUs to provision for the cluster.
-        memory_bytes: The memory to provision for the cluster in bytes.
-
-    Raises:
-        This method will raise the exception if the operation errors or
-        the timeout before the operation completes is reached.
-    """
+    """Create a Kafka cluster."""
+    # [START managedkafka_create_cluster]
+    from google.api_core.exceptions import GoogleAPICallError
+    from google.cloud import managedkafka_v1
+    
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+	# subnet = "projects/my-project-id/regions/us-central1/subnetworks/default"
+	# cpu = 3
+	# memory_bytes = 3221225472
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -67,7 +61,6 @@ def create_cluster(
         response = operation.result()
         print("Created cluster:", response)
     except GoogleAPICallError:
-        print(operation.operation.error)
+        print("The operation failed with error:", operation.operation.error)
 
-
-# [END managedkafka_create_cluster]
+    # [END managedkafka_create_cluster]

--- a/managedkafka/snippets/clusters/create_cluster.py
+++ b/managedkafka/snippets/clusters/create_cluster.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def create_cluster(
     project_id: str,
     region: str,
@@ -26,14 +25,14 @@ def create_cluster(
     # [START managedkafka_create_cluster]
     from google.api_core.exceptions import GoogleAPICallError
     from google.cloud import managedkafka_v1
-    
+
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
-	# subnet = "projects/my-project-id/regions/us-central1/subnetworks/default"
-	# cpu = 3
-	# memory_bytes = 3221225472
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
+    # subnet = "projects/my-project-id/regions/us-central1/subnetworks/default"
+    # cpu = 3
+    # memory_bytes = 3221225472
 
     client = managedkafka_v1.ManagedKafkaClient()
 

--- a/managedkafka/snippets/clusters/create_cluster.py
+++ b/managedkafka/snippets/clusters/create_cluster.py
@@ -21,7 +21,21 @@ def create_cluster(
     cpu: int,
     memory_bytes: int,
 ) -> None:
-    """Create a Kafka cluster."""
+    """
+    Create a Kafka cluster.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        subnet: VPC subnet from which the cluster is accessible. The expected format is projects/{project_id}/regions{region}/subnetworks/{subnetwork}.
+        cpu: Number of vCPUs to provision for the cluster.
+        memory_bytes: The memory to provision for the cluster in bytes.
+
+    Raises:
+        This method will raise the exception if the operation errors or
+        the timeout before the operation completes is reached.
+    """
     # [START managedkafka_create_cluster]
     from google.api_core.exceptions import GoogleAPICallError
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/clusters/delete_cluster.py
+++ b/managedkafka/snippets/clusters/delete_cluster.py
@@ -18,7 +18,18 @@ def delete_cluster(
     region: str,
     cluster_id: str,
 ) -> None:
-    """Delete a Kafka cluster."""
+    """
+    Delete a Kafka cluster.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+
+    Raises:
+        This method will raise the exception if the operation errors or
+        the timeout before the operation completes is reached.
+    """
     # [START managedkafka_delete_cluster]
     from google.api_core.exceptions import GoogleAPICallError
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/clusters/delete_cluster.py
+++ b/managedkafka/snippets/clusters/delete_cluster.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_delete_cluster]
-from google.api_core.exceptions import GoogleAPICallError
-from google.cloud import managedkafka_v1
 
 
 def delete_cluster(
@@ -22,18 +19,15 @@ def delete_cluster(
     region: str,
     cluster_id: str,
 ) -> None:
-    """
-    Delete a Kafka cluster.
-
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-
-    Raises:
-        This method will raise the exception if the operation errors or
-        the timeout before the operation completes is reached.
-    """
+    """Delete a Kafka cluster."""
+    # [START managedkafka_delete_cluster]
+    from google.api_core.exceptions import GoogleAPICallError
+    from google.cloud import managedkafka_v1
+    
+    # TODO(developer)
+    # project_id = "my-project-id"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -46,7 +40,6 @@ def delete_cluster(
         operation.result()
         print("Deleted cluster")
     except GoogleAPICallError:
-        print(operation.operation.error)
+        print("The operation failed with error:", operation.operation.error)
 
-
-# [END managedkafka_delete_cluster]
+    # [END managedkafka_delete_cluster]

--- a/managedkafka/snippets/clusters/delete_cluster.py
+++ b/managedkafka/snippets/clusters/delete_cluster.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def delete_cluster(
     project_id: str,
     region: str,
@@ -23,7 +22,7 @@ def delete_cluster(
     # [START managedkafka_delete_cluster]
     from google.api_core.exceptions import GoogleAPICallError
     from google.cloud import managedkafka_v1
-    
+
     # TODO(developer)
     # project_id = "my-project-id"
     # region = "us-central1"

--- a/managedkafka/snippets/clusters/get_cluster.py
+++ b/managedkafka/snippets/clusters/get_cluster.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def get_cluster(
     project_id: str,
     region: str,

--- a/managedkafka/snippets/clusters/get_cluster.py
+++ b/managedkafka/snippets/clusters/get_cluster.py
@@ -18,7 +18,14 @@ def get_cluster(
     region: str,
     cluster_id: str,
 ):
-    """Get a Kafka cluster."""
+    """
+    Get a Kafka cluster.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+    """
     # [START managedkafka_get_cluster]
     from google.cloud import managedkafka_v1
 

--- a/managedkafka/snippets/clusters/get_cluster.py
+++ b/managedkafka/snippets/clusters/get_cluster.py
@@ -12,23 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_get_cluster]
-from google.cloud import managedkafka_v1
 
 
 def get_cluster(
     project_id: str,
     region: str,
     cluster_id: str,
-) -> managedkafka_v1.Cluster:
-    """
-    Get a Kafka cluster.
+):
+    """Get a Kafka cluster."""
+    # [START managedkafka_get_cluster]
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -42,5 +40,4 @@ def get_cluster(
 
     return cluster
 
-
-# [END managedkafka_get_cluster]
+    # [END managedkafka_get_cluster]

--- a/managedkafka/snippets/clusters/list_clusters.py
+++ b/managedkafka/snippets/clusters/list_clusters.py
@@ -12,23 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_list_clusters]
-from typing import List
-
-from google.cloud import managedkafka_v1
 
 
 def list_clusters(
     project_id: str,
     region: str,
-) -> List[str]:
-    """
-    List Kafka clusters in a given project ID and region.
+):
+    """List Kafka clusters in a given project ID and region."""
+    # [START managedkafka_list_clusters]
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+    # region = "us-central1"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -42,5 +38,4 @@ def list_clusters(
 
     return [cluster.name for cluster in response]
 
-
-# [END managedkafka_list_clusters]
+    # [END managedkafka_list_clusters]

--- a/managedkafka/snippets/clusters/list_clusters.py
+++ b/managedkafka/snippets/clusters/list_clusters.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def list_clusters(
     project_id: str,
     region: str,

--- a/managedkafka/snippets/clusters/list_clusters.py
+++ b/managedkafka/snippets/clusters/list_clusters.py
@@ -17,7 +17,13 @@ def list_clusters(
     project_id: str,
     region: str,
 ):
-    """List Kafka clusters in a given project ID and region."""
+    """
+    List Kafka clusters in a given project ID and region.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+    """
     # [START managedkafka_list_clusters]
     from google.cloud import managedkafka_v1
 

--- a/managedkafka/snippets/clusters/update_cluster.py
+++ b/managedkafka/snippets/clusters/update_cluster.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def update_cluster(
     project_id: str, region: str, cluster_id: str, memory_bytes: int
 ) -> None:
@@ -22,12 +21,12 @@ def update_cluster(
     from google.api_core.exceptions import GoogleAPICallError
     from google.cloud import managedkafka_v1
     from google.protobuf import field_mask_pb2
-    
+
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
-	# memory_bytes = 4295000000
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
+    # memory_bytes = 4295000000
 
     client = managedkafka_v1.ManagedKafkaClient()
 

--- a/managedkafka/snippets/clusters/update_cluster.py
+++ b/managedkafka/snippets/clusters/update_cluster.py
@@ -16,7 +16,19 @@
 def update_cluster(
     project_id: str, region: str, cluster_id: str, memory_bytes: int
 ) -> None:
-    """Update a Kafka cluster."""
+    """
+    Update a Kafka cluster.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        memory_bytes: The memory to provision for the cluster in bytes.
+
+    Raises:
+        This method will raise the exception if the operation errors or
+        the timeout before the operation completes is reached.
+    """
     # [START managedkafka_update_cluster]
     from google.api_core.exceptions import GoogleAPICallError
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/clusters/update_cluster.py
+++ b/managedkafka/snippets/clusters/update_cluster.py
@@ -12,28 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_update_cluster]
-from google.api_core.exceptions import GoogleAPICallError
-from google.cloud import managedkafka_v1
-from google.protobuf import field_mask_pb2
 
 
 def update_cluster(
     project_id: str, region: str, cluster_id: str, memory_bytes: int
 ) -> None:
-    """
-    Update a Kafka cluster. For a list of editable fields, one can check https://cloud.google.com/managed-kafka/docs/create-cluster#properties.
-
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        memory_bytes: The memory to provision for the cluster in bytes.
-
-    Raises:
-        This method will raise the exception if the operation errors or
-        the timeout before the operation completes is reached.
-    """
+    """Update a Kafka cluster."""
+    # [START managedkafka_update_cluster]
+    from google.api_core.exceptions import GoogleAPICallError
+    from google.cloud import managedkafka_v1
+    from google.protobuf import field_mask_pb2
+    
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+	# memory_bytes = 4295000000
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -43,6 +37,7 @@ def update_cluster(
     update_mask = field_mask_pb2.FieldMask()
     update_mask.paths.append("capacity_config.memory_bytes")
 
+    # For a list of editable fields, one can check https://cloud.google.com/managed-kafka/docs/create-cluster#properties.
     request = managedkafka_v1.UpdateClusterRequest(
         update_mask=update_mask,
         cluster=cluster,
@@ -53,7 +48,6 @@ def update_cluster(
         response = operation.result()
         print("Updated cluster:", response)
     except GoogleAPICallError:
-        print(operation.operation.error)
+        print("The operation failed with error:", operation.operation.error)
 
-
-# [END managedkafka_update_cluster]
+    # [END managedkafka_update_cluster]

--- a/managedkafka/snippets/consumergroups/delete_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/delete_consumer_group.py
@@ -19,7 +19,18 @@ def delete_consumer_group(
     cluster_id: str,
     consumer_group_id: str,
 ) -> None:
-    """Delete a Kafka consumer group."""
+    """
+    Delete a Kafka consumer group.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        consumer_group_id: ID of the Kafka consumer group.
+
+    Raises:
+        This method will raise the exception if the consumer group is not found.
+    """
     # [START managedkafka_delete_consumergroup]
     from google.api_core.exceptions import NotFound
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/consumergroups/delete_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/delete_consumer_group.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_delete_consumergroup]
-from google.api_core.exceptions import NotFound
-from google.cloud import managedkafka_v1
 
 
 def delete_consumer_group(
@@ -23,18 +20,16 @@ def delete_consumer_group(
     cluster_id: str,
     consumer_group_id: str,
 ) -> None:
-    """
-    Delete a Kafka consumer group.
+    """Delete a Kafka consumer group."""
+    # [START managedkafka_delete_consumergroup]
+    from google.api_core.exceptions import NotFound
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        consumer_group_id: ID of the Kafka consumer group.
-
-    Raises:
-        This method will raise the exception if the consumer group is not found.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+    # consumer_group_id = "my-consumer-group"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -51,5 +46,4 @@ def delete_consumer_group(
     except NotFound:
         print(f"Consumer group {consumer_group_path} not found")
 
-
-# [END managedkafka_delete_consumergroup]
+    # [END managedkafka_delete_consumergroup]

--- a/managedkafka/snippets/consumergroups/delete_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/delete_consumer_group.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def delete_consumer_group(
     project_id: str,
     region: str,
@@ -27,8 +26,8 @@ def delete_consumer_group(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
     # consumer_group_id = "my-consumer-group"
 
     client = managedkafka_v1.ManagedKafkaClient()

--- a/managedkafka/snippets/consumergroups/get_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/get_consumer_group.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def get_consumer_group(
     project_id: str,
     region: str,
@@ -26,8 +25,8 @@ def get_consumer_group(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
     # consumer_group_id = "my-consumer-group"
 
     client = managedkafka_v1.ManagedKafkaClient()

--- a/managedkafka/snippets/consumergroups/get_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/get_consumer_group.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_get_consumergroup]
-from google.cloud import managedkafka_v1
 
 
 def get_consumer_group(
@@ -21,16 +19,16 @@ def get_consumer_group(
     region: str,
     cluster_id: str,
     consumer_group_id: str,
-) -> managedkafka_v1.ConsumerGroup:
-    """
-    Get a Kafka consumer group.
+):
+    """Get a Kafka consumer group."""
+    # [START managedkafka_get_consumergroup]
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        consumer_group_id: ID of the Kafka consumer group.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+    # consumer_group_id = "my-consumer-group"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -46,5 +44,4 @@ def get_consumer_group(
 
     return consumer_group
 
-
-# [END managedkafka_get_consumergroup]
+    # [END managedkafka_get_consumergroup]

--- a/managedkafka/snippets/consumergroups/get_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/get_consumer_group.py
@@ -19,7 +19,15 @@ def get_consumer_group(
     cluster_id: str,
     consumer_group_id: str,
 ):
-    """Get a Kafka consumer group."""
+    """
+    Get a Kafka consumer group.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        consumer_group_id: ID of the Kafka consumer group.
+    """
     # [START managedkafka_get_consumergroup]
     from google.cloud import managedkafka_v1
 

--- a/managedkafka/snippets/consumergroups/list_consumer_groups.py
+++ b/managedkafka/snippets/consumergroups/list_consumer_groups.py
@@ -18,7 +18,14 @@ def list_consumer_groups(
     region: str,
     cluster_id: str,
 ):
-    """List Kafka consumer groups in a cluster."""
+    """
+    List Kafka consumer groups in a cluster.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+    """
     # [START managedkafka_list_consumergroups]
     from google.cloud import managedkafka_v1
 

--- a/managedkafka/snippets/consumergroups/list_consumer_groups.py
+++ b/managedkafka/snippets/consumergroups/list_consumer_groups.py
@@ -12,25 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_list_consumergroups]
-from typing import List
-
-from google.cloud import managedkafka_v1
 
 
 def list_consumer_groups(
     project_id: str,
     region: str,
     cluster_id: str,
-) -> List[str]:
-    """
-    List Kafka consumer groups in a cluster.
+):
+    """List Kafka consumer groups in a cluster."""
+    # [START managedkafka_list_consumergroups]
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -44,4 +40,4 @@ def list_consumer_groups(
 
     return [consumer_group.name for consumer_group in response]
 
-# [END managedkafka_list_consumergroups]
+    # [END managedkafka_list_consumergroups]

--- a/managedkafka/snippets/consumergroups/list_consumer_groups.py
+++ b/managedkafka/snippets/consumergroups/list_consumer_groups.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def list_consumer_groups(
     project_id: str,
     region: str,
@@ -25,8 +24,8 @@ def list_consumer_groups(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
 
     client = managedkafka_v1.ManagedKafkaClient()
 

--- a/managedkafka/snippets/consumergroups/update_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/update_consumer_group.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_update_consumergroup]
-from google.api_core.exceptions import NotFound
-from google.cloud import managedkafka_v1
-from google.protobuf import field_mask_pb2
 
 
 def update_consumer_group(
@@ -26,20 +22,19 @@ def update_consumer_group(
     topic_path: str,
     partition_offsets: dict[int, int],
 ) -> None:
-    """
-    Update a single partition's offset in a Kafka consumer group.
+    """Update a single partition's offset in a Kafka consumer group."""
+    # [START managedkafka_update_consumergroup]
+    from google.api_core.exceptions import NotFound
+    from google.cloud import managedkafka_v1
+    from google.protobuf import field_mask_pb2
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        consumer_group_id: ID of the Kafka consumer group.
-        topic_path: Name of the Kafka topic.
-        partition_offsets: Configuration of the topic, represented as a map of partition indexes to their offset value.
-
-    Raises:
-        This method will raise the exception if the consumer group is not found.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+    # consumer_group_id = "my-consumer-group"
+    # topic_path = "my-topic-path"
+    # partition_offsets = {10: 10}
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -70,5 +65,4 @@ def update_consumer_group(
     except NotFound:
         print(f"Consumer group {consumer_group.name} not found")
 
-
-# [END managedkafka_update_consumergroup]
+    # [END managedkafka_update_consumergroup]

--- a/managedkafka/snippets/consumergroups/update_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/update_consumer_group.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def update_consumer_group(
     project_id: str,
     region: str,
@@ -30,8 +29,8 @@ def update_consumer_group(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
     # consumer_group_id = "my-consumer-group"
     # topic_path = "my-topic-path"
     # partition_offsets = {10: 10}

--- a/managedkafka/snippets/consumergroups/update_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/update_consumer_group.py
@@ -21,7 +21,20 @@ def update_consumer_group(
     topic_path: str,
     partition_offsets: dict[int, int],
 ) -> None:
-    """Update a single partition's offset in a Kafka consumer group."""
+    """
+    Update a single partition's offset in a Kafka consumer group.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        consumer_group_id: ID of the Kafka consumer group.
+        topic_path: Name of the Kafka topic.
+        partition_offsets: Configuration of the topic, represented as a map of partition indexes to their offset value.
+
+    Raises:
+        This method will raise the exception if the consumer group is not found.
+    """
     # [START managedkafka_update_consumergroup]
     from google.api_core.exceptions import NotFound
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/requirements.txt
+++ b/managedkafka/snippets/requirements.txt
@@ -1,4 +1,6 @@
 protobuf==5.27.2
 pytest==8.2.2
 google-api-core==2.23.0
+google-auth==2.36.0
 google-cloud-managedkafka==0.1.4
+googleapis-common-protos==1.65.0

--- a/managedkafka/snippets/requirements.txt
+++ b/managedkafka/snippets/requirements.txt
@@ -1,2 +1,4 @@
 protobuf==5.27.2
 pytest==8.2.2
+google-api-core==2.23.0
+google-cloud-managedkafka==0.1.4

--- a/managedkafka/snippets/topics/create_topic.py
+++ b/managedkafka/snippets/topics/create_topic.py
@@ -22,7 +22,21 @@ def create_topic(
     replication_factor: int,
     configs: dict[str, str],
 ) -> None:
-    """Create a Kafka topic."""
+    """
+    Create a Kafka topic.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        topic_id: ID of the Kafka topic.
+        partition_count: Number of partitions in a topic..
+        replication_factor: Number of replicas of each partition.
+        configs: Configuration of the topic.
+
+    Raises:
+        This method will raise the exception if the topic already exists.
+    """
     # [START managedkafka_create_topic]
     from google.api_core.exceptions import AlreadyExists
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/topics/create_topic.py
+++ b/managedkafka/snippets/topics/create_topic.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_create_topic]
-from google.api_core.exceptions import AlreadyExists
-from google.cloud import managedkafka_v1
 
 
 def create_topic(
@@ -26,21 +23,19 @@ def create_topic(
     replication_factor: int,
     configs: dict[str, str],
 ) -> None:
-    """
-    Create a Kafka topic.
-
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        topic_id: ID of the Kafka topic.
-        partition_count: Number of partitions in a topic..
-        replication_factor: Number of replicas of each partition.
-        configs: Configuration of the topic. For a list of configs, one can check https://kafka.apache.org/documentation/#topicconfigs.
-
-    Raises:
-        This method will raise the exception if the topic already exists.
-    """
+    """Create a Kafka topic."""
+    # [START managedkafka_create_topic]
+    from google.api_core.exceptions import AlreadyExists
+    from google.cloud import managedkafka_v1
+    
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+    # topic_id = "my-topic"
+    # partition_count = 10
+    # replication_factor = 3
+    # configs = {"min.insync.replicas": "1"}
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -48,6 +43,7 @@ def create_topic(
     topic.name = client.topic_path(project_id, region, cluster_id, topic_id)
     topic.partition_count = partition_count
     topic.replication_factor = replication_factor
+    # For a list of configs, one can check https://kafka.apache.org/documentation/#topicconfigs
     topic.configs = configs
 
     request = managedkafka_v1.CreateTopicRequest(
@@ -62,5 +58,4 @@ def create_topic(
     except AlreadyExists:
         print(f"{topic.name} already exists")
 
-
-# [END managedkafka_create_topic]
+    # [END managedkafka_create_topic]

--- a/managedkafka/snippets/topics/create_topic.py
+++ b/managedkafka/snippets/topics/create_topic.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def create_topic(
     project_id: str,
     region: str,
@@ -27,11 +26,11 @@ def create_topic(
     # [START managedkafka_create_topic]
     from google.api_core.exceptions import AlreadyExists
     from google.cloud import managedkafka_v1
-    
+
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
     # topic_id = "my-topic"
     # partition_count = 10
     # replication_factor = 3

--- a/managedkafka/snippets/topics/delete_topic.py
+++ b/managedkafka/snippets/topics/delete_topic.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_delete_topic]
-from google.api_core.exceptions import NotFound
-from google.cloud import managedkafka_v1
 
 
 def delete_topic(
@@ -23,18 +20,16 @@ def delete_topic(
     cluster_id: str,
     topic_id: str,
 ) -> None:
-    """
-    Delete a Kafka topic.
+    """Delete a Kafka topic."""
+    # [START managedkafka_delete_topic]
+    from google.api_core.exceptions import NotFound
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        topic_id: ID of the Kafka topic.
-
-    Raises:
-        This method will raise the exception if the topic is not found.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+    # topic_id = "my-topic"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -47,5 +42,4 @@ def delete_topic(
     except NotFound:
         print(f"Topic {topic_path} not found")
 
-
-# [END managedkafka_delete_topic]
+    # [END managedkafka_delete_topic]

--- a/managedkafka/snippets/topics/delete_topic.py
+++ b/managedkafka/snippets/topics/delete_topic.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def delete_topic(
     project_id: str,
     region: str,
@@ -27,8 +26,8 @@ def delete_topic(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
     # topic_id = "my-topic"
 
     client = managedkafka_v1.ManagedKafkaClient()

--- a/managedkafka/snippets/topics/delete_topic.py
+++ b/managedkafka/snippets/topics/delete_topic.py
@@ -19,7 +19,18 @@ def delete_topic(
     cluster_id: str,
     topic_id: str,
 ) -> None:
-    """Delete a Kafka topic."""
+    """
+    Delete a Kafka topic.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        topic_id: ID of the Kafka topic.
+
+    Raises:
+        This method will raise the exception if the topic is not found.
+    """
     # [START managedkafka_delete_topic]
     from google.api_core.exceptions import NotFound
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/topics/get_topic.py
+++ b/managedkafka/snippets/topics/get_topic.py
@@ -19,7 +19,15 @@ def get_topic(
     cluster_id: str,
     topic_id: str,
 ):
-    """Get a Kafka topic."""
+    """
+    Get a Kafka topic.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        topic_id: ID of the Kafka topic.
+    """
     # [START managedkafka_get_topic]
     from google.cloud import managedkafka_v1
 

--- a/managedkafka/snippets/topics/get_topic.py
+++ b/managedkafka/snippets/topics/get_topic.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_get_topic]
-from google.cloud import managedkafka_v1
 
 
 def get_topic(
@@ -21,16 +19,16 @@ def get_topic(
     region: str,
     cluster_id: str,
     topic_id: str,
-) -> managedkafka_v1.Topic:
-    """
-    Get a Kafka topic.
+):
+    """Get a Kafka topic."""
+    # [START managedkafka_get_topic]
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        topic_id: ID of the Kafka topic.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+    # topic_id = "my-topic"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -44,5 +42,4 @@ def get_topic(
 
     return topic
 
-
-# [END managedkafka_get_topic]
+    # [END managedkafka_get_topic]

--- a/managedkafka/snippets/topics/get_topic.py
+++ b/managedkafka/snippets/topics/get_topic.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-
 def get_topic(
     project_id: str,
     region: str,
@@ -26,8 +25,8 @@ def get_topic(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
     # topic_id = "my-topic"
 
     client = managedkafka_v1.ManagedKafkaClient()

--- a/managedkafka/snippets/topics/list_topics.py
+++ b/managedkafka/snippets/topics/list_topics.py
@@ -12,25 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_list_topics]
-from typing import List
-
-from google.cloud import managedkafka_v1
-
 
 def list_topics(
     project_id: str,
     region: str,
     cluster_id: str,
-) -> List[str]:
-    """
-    List Kafka topics in a cluster.
+):
+    """List Kafka topics in a cluster."""
+    # [START managedkafka_list_topics]
+    from google.cloud import managedkafka_v1
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -44,4 +39,4 @@ def list_topics(
 
     return [topic.name for topic in response]
 
-# [END managedkafka_list_topics]
+    # [END managedkafka_list_topics]

--- a/managedkafka/snippets/topics/list_topics.py
+++ b/managedkafka/snippets/topics/list_topics.py
@@ -24,8 +24,8 @@ def list_topics(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
 
     client = managedkafka_v1.ManagedKafkaClient()
 

--- a/managedkafka/snippets/topics/list_topics.py
+++ b/managedkafka/snippets/topics/list_topics.py
@@ -18,7 +18,14 @@ def list_topics(
     region: str,
     cluster_id: str,
 ):
-    """List Kafka topics in a cluster."""
+    """
+    List Kafka topics in a cluster.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+    """
     # [START managedkafka_list_topics]
     from google.cloud import managedkafka_v1
 

--- a/managedkafka/snippets/topics/update_topic.py
+++ b/managedkafka/snippets/topics/update_topic.py
@@ -21,7 +21,20 @@ def update_topic(
     partition_count: int,
     configs: dict[str, str],
 ) -> None:
-    """Update a Kafka topic."""
+    """
+    Update a Kafka topic.
+
+    Args:
+        project_id: Google Cloud project ID.
+        region: Cloud region.
+        cluster_id: ID of the Kafka cluster.
+        topic_id: ID of the Kafka topic.
+        partition_count: Number of partitions in a topic..
+        configs: Configuration of the topic.
+
+    Raises:
+        This method will raise the exception if the topic is not found.
+    """
     # [START managedkafka_update_topic]
     from google.api_core.exceptions import NotFound
     from google.cloud import managedkafka_v1

--- a/managedkafka/snippets/topics/update_topic.py
+++ b/managedkafka/snippets/topics/update_topic.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START managedkafka_update_topic]
-from google.api_core.exceptions import NotFound
-from google.cloud import managedkafka_v1
-from google.protobuf import field_mask_pb2
-
 
 def update_topic(
     project_id: str,
@@ -26,20 +21,19 @@ def update_topic(
     partition_count: int,
     configs: dict[str, str],
 ) -> None:
-    """
-    Update a Kafka topic. For a list of editable fields, one can check https://cloud.google.com/managed-kafka/docs/create-topic#properties.
+    """Update a Kafka topic."""
+    # [START managedkafka_update_topic]
+    from google.api_core.exceptions import NotFound
+    from google.cloud import managedkafka_v1
+    from google.protobuf import field_mask_pb2
 
-    Args:
-        project_id: Google Cloud project ID.
-        region: Cloud region.
-        cluster_id: ID of the Kafka cluster.
-        topic_id: ID of the Kafka topic.
-        partition_count: Number of partitions in a topic..
-        configs: Configuration of the topic.
-
-    Raises:
-        This method will raise the exception if the topic is not found.
-    """
+    # TODO(developer)
+    # project_id = "my-project-id"
+	# region = "us-central1"
+	# cluster_id = "my-cluster"
+    # topic_id = "my-topic"
+    # partition_count = 20
+    # configs = {"min.insync.replicas": "1"}
 
     client = managedkafka_v1.ManagedKafkaClient()
 
@@ -50,6 +44,7 @@ def update_topic(
     update_mask = field_mask_pb2.FieldMask()
     update_mask.paths.extend(["partition_count", "configs"])
 
+    # For a list of editable fields, one can check https://cloud.google.com/managed-kafka/docs/create-topic#properties.
     request = managedkafka_v1.UpdateTopicRequest(
         update_mask=update_mask,
         topic=topic,
@@ -61,5 +56,4 @@ def update_topic(
     except NotFound:
         print(f"Topic {topic.name} not found")
 
-
-# [END managedkafka_update_topic]
+    # [END managedkafka_update_topic]

--- a/managedkafka/snippets/topics/update_topic.py
+++ b/managedkafka/snippets/topics/update_topic.py
@@ -29,8 +29,8 @@ def update_topic(
 
     # TODO(developer)
     # project_id = "my-project-id"
-	# region = "us-central1"
-	# cluster_id = "my-cluster"
+    # region = "us-central1"
+    # cluster_id = "my-cluster"
     # topic_id = "my-topic"
     # partition_count = 20
     # configs = {"min.insync.replicas": "1"}


### PR DESCRIPTION
## Description

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [N/a] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [N/a] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [N/a] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [N/a] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved