### PR TITLE
fix: log error message when exception is caught

### DIFF
--- a/managedkafka/snippets/clusters/create_cluster.py
+++ b/managedkafka/snippets/clusters/create_cluster.py
@@ -33,7 +33,7 @@ def create_cluster(
         memory_bytes: The memory to provision for the cluster in bytes.
 
     Raises:
-        This method will raise the exception if the operation errors or
+        This method will raise the GoogleAPICallError exception if the operation errors or
         the timeout before the operation completes is reached.
     """
     # [START managedkafka_create_cluster]
@@ -71,6 +71,7 @@ def create_cluster(
         # The duration of this operation can vary considerably, typically taking 10-40 minutes.
         # We can set a timeout of 3000s (50 minutes).
         operation = client.create_cluster(request=request, timeout=3000)
+        print("Waiting for operation to finish...")
         response = operation.result()
         print("Created cluster:", response)
     except GoogleAPICallError:

--- a/managedkafka/snippets/clusters/delete_cluster.py
+++ b/managedkafka/snippets/clusters/delete_cluster.py
@@ -27,7 +27,7 @@ def delete_cluster(
         cluster_id: ID of the Kafka cluster.
 
     Raises:
-        This method will raise the exception if the operation errors or
+        This method will raise the GoogleAPICallError exception if the operation errors or
         the timeout before the operation completes is reached.
     """
     # [START managedkafka_delete_cluster]

--- a/managedkafka/snippets/clusters/get_cluster.py
+++ b/managedkafka/snippets/clusters/get_cluster.py
@@ -25,8 +25,12 @@ def get_cluster(
         project_id: Google Cloud project ID.
         region: Cloud region.
         cluster_id: ID of the Kafka cluster.
+
+    Raises:
+        This method will raise the NotFound exception if the cluster is not found.
     """
     # [START managedkafka_get_cluster]
+    from google.api_core.exceptions import NotFound
     from google.cloud import managedkafka_v1
 
     # TODO(developer)
@@ -41,9 +45,11 @@ def get_cluster(
         name=cluster_path,
     )
 
-    cluster = client.get_cluster(request=request)
-    print("Got cluster:", cluster)
-
-    return cluster
+    try:
+        cluster = client.get_cluster(request=request)
+        print("Got cluster:", cluster)
+        return cluster
+    except NotFound as e:
+        print(f"Failed to get cluster {cluster_id} with error: {e.message}")
 
     # [END managedkafka_get_cluster]

--- a/managedkafka/snippets/clusters/get_cluster.py
+++ b/managedkafka/snippets/clusters/get_cluster.py
@@ -48,7 +48,6 @@ def get_cluster(
     try:
         cluster = client.get_cluster(request=request)
         print("Got cluster:", cluster)
-        return cluster
     except NotFound as e:
         print(f"Failed to get cluster {cluster_id} with error: {e.message}")
 

--- a/managedkafka/snippets/clusters/list_clusters.py
+++ b/managedkafka/snippets/clusters/list_clusters.py
@@ -41,6 +41,4 @@ def list_clusters(
     for cluster in response:
         print("Got cluster:", cluster)
 
-    return [cluster.name for cluster in response]
-
     # [END managedkafka_list_clusters]

--- a/managedkafka/snippets/clusters/update_cluster.py
+++ b/managedkafka/snippets/clusters/update_cluster.py
@@ -26,7 +26,7 @@ def update_cluster(
         memory_bytes: The memory to provision for the cluster in bytes.
 
     Raises:
-        This method will raise the exception if the operation errors or
+        This method will raise the GoogleAPICallError exception if the operation errors or
         the timeout before the operation completes is reached.
     """
     # [START managedkafka_update_cluster]

--- a/managedkafka/snippets/consumergroups/delete_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/delete_consumer_group.py
@@ -29,7 +29,7 @@ def delete_consumer_group(
         consumer_group_id: ID of the Kafka consumer group.
 
     Raises:
-        This method will raise the exception if the consumer group is not found.
+        This method will raise the NotFound exception if the consumer group or the parent resource is not found.
     """
     # [START managedkafka_delete_consumergroup]
     from google.api_core.exceptions import NotFound
@@ -53,7 +53,7 @@ def delete_consumer_group(
     try:
         client.delete_consumer_group(request=request)
         print("Deleted consumer group")
-    except NotFound:
-        print(f"Consumer group {consumer_group_path} not found")
+    except NotFound as e:
+        print(f"Failed to delete consumer group {consumer_group_id} with error: {e.message}")
 
     # [END managedkafka_delete_consumergroup]

--- a/managedkafka/snippets/consumergroups/get_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/get_consumer_group.py
@@ -53,7 +53,6 @@ def get_consumer_group(
     try:
         consumer_group = client.get_consumer_group(request=request)
         print("Got consumer group:", consumer_group)
-        return consumer_group
     except NotFound as e:
         print(f"Failed to get consumer group {consumer_group_id} with error: {e.message}")
 

--- a/managedkafka/snippets/consumergroups/get_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/get_consumer_group.py
@@ -27,8 +27,12 @@ def get_consumer_group(
         region: Cloud region.
         cluster_id: ID of the Kafka cluster.
         consumer_group_id: ID of the Kafka consumer group.
+
+    Raises:
+        This method will raise the NotFound exception if the consumer group or the parent resource is not found.
     """
     # [START managedkafka_get_consumergroup]
+    from google.api_core.exceptions import NotFound
     from google.cloud import managedkafka_v1
 
     # TODO(developer)
@@ -46,9 +50,11 @@ def get_consumer_group(
         name=consumer_group_path,
     )
 
-    consumer_group = client.get_consumer_group(request=request)
-    print("Got consumer group:", consumer_group)
-
-    return consumer_group
+    try:
+        consumer_group = client.get_consumer_group(request=request)
+        print("Got consumer group:", consumer_group)
+        return consumer_group
+    except NotFound as e:
+        print(f"Failed to get consumer group {consumer_group_id} with error: {e.message}")
 
     # [END managedkafka_get_consumergroup]

--- a/managedkafka/snippets/consumergroups/list_consumer_groups.py
+++ b/managedkafka/snippets/consumergroups/list_consumer_groups.py
@@ -44,6 +44,4 @@ def list_consumer_groups(
     for consumer_group in response:
         print("Got consumer group:", consumer_group)
 
-    return [consumer_group.name for consumer_group in response]
-
     # [END managedkafka_list_consumergroups]

--- a/managedkafka/snippets/consumergroups/update_consumer_group.py
+++ b/managedkafka/snippets/consumergroups/update_consumer_group.py
@@ -33,7 +33,7 @@ def update_consumer_group(
         partition_offsets: Configuration of the topic, represented as a map of partition indexes to their offset value.
 
     Raises:
-        This method will raise the exception if the consumer group is not found.
+        This method will raise the NotFound exception if the consumer group or the parent resource is not found.
     """
     # [START managedkafka_update_consumergroup]
     from google.api_core.exceptions import NotFound
@@ -74,7 +74,7 @@ def update_consumer_group(
     try:
         response = client.update_consumer_group(request=request)
         print("Updated consumer group:", response)
-    except NotFound:
-        print(f"Consumer group {consumer_group.name} not found")
+    except NotFound as e:
+        print(f"Failed to update consumer group {consumer_group_id} with error: {e.message}")
 
     # [END managedkafka_update_consumergroup]

--- a/managedkafka/snippets/topics/create_topic.py
+++ b/managedkafka/snippets/topics/create_topic.py
@@ -35,7 +35,7 @@ def create_topic(
         configs: Configuration of the topic.
 
     Raises:
-        This method will raise the exception if the topic already exists.
+        This method will raise the AlreadyExists exception if the topic already exists.
     """
     # [START managedkafka_create_topic]
     from google.api_core.exceptions import AlreadyExists
@@ -68,7 +68,7 @@ def create_topic(
     try:
         response = client.create_topic(request=request)
         print("Created topic:", response.name)
-    except AlreadyExists:
-        print(f"{topic.name} already exists")
+    except AlreadyExists as e:
+        print(f"Failed to create topic {topic.name} with error: {e.message}")
 
     # [END managedkafka_create_topic]

--- a/managedkafka/snippets/topics/delete_topic.py
+++ b/managedkafka/snippets/topics/delete_topic.py
@@ -29,7 +29,7 @@ def delete_topic(
         topic_id: ID of the Kafka topic.
 
     Raises:
-        This method will raise the exception if the topic is not found.
+        This method will raise the NotFound exception if the topic or the parent resource is not found.
     """
     # [START managedkafka_delete_topic]
     from google.api_core.exceptions import NotFound
@@ -49,7 +49,7 @@ def delete_topic(
     try:
         client.delete_topic(request=request)
         print("Deleted topic")
-    except NotFound:
-        print(f"Topic {topic_path} not found")
+    except NotFound as e:
+        print(f"Failed to delete topic {topic_id} with error: {e.message}")
 
     # [END managedkafka_delete_topic]

--- a/managedkafka/snippets/topics/get_topic.py
+++ b/managedkafka/snippets/topics/get_topic.py
@@ -27,8 +27,12 @@ def get_topic(
         region: Cloud region.
         cluster_id: ID of the Kafka cluster.
         topic_id: ID of the Kafka topic.
+
+    Raises:
+        This method will raise the NotFound exception if the topic or the parent resource is not found.
     """
     # [START managedkafka_get_topic]
+    from google.api_core.exceptions import NotFound
     from google.cloud import managedkafka_v1
 
     # TODO(developer)
@@ -44,9 +48,11 @@ def get_topic(
         name=topic_path,
     )
 
-    topic = client.get_topic(request=request)
-    print("Got topic:", topic)
-
-    return topic
+    try:
+        topic = client.get_topic(request=request)
+        print("Got topic:", topic)
+        return topic
+    except NotFound as e:
+        print(f"Failed to get topic {topic_id} with error: {e.message}")
 
     # [END managedkafka_get_topic]

--- a/managedkafka/snippets/topics/get_topic.py
+++ b/managedkafka/snippets/topics/get_topic.py
@@ -51,7 +51,6 @@ def get_topic(
     try:
         topic = client.get_topic(request=request)
         print("Got topic:", topic)
-        return topic
     except NotFound as e:
         print(f"Failed to get topic {topic_id} with error: {e.message}")
 

--- a/managedkafka/snippets/topics/list_topics.py
+++ b/managedkafka/snippets/topics/list_topics.py
@@ -44,6 +44,4 @@ def list_topics(
     for topic in response:
         print("Got topic:", topic)
 
-    return [topic.name for topic in response]
-
     # [END managedkafka_list_topics]

--- a/managedkafka/snippets/topics/update_topic.py
+++ b/managedkafka/snippets/topics/update_topic.py
@@ -33,7 +33,7 @@ def update_topic(
         configs: Configuration of the topic.
 
     Raises:
-        This method will raise the exception if the topic is not found.
+        This method will raise the NotFound exception if the topic or the parent resource is not found.
     """
     # [START managedkafka_update_topic]
     from google.api_core.exceptions import NotFound
@@ -66,7 +66,7 @@ def update_topic(
     try:
         response = client.update_topic(request=request)
         print("Updated topic:", response)
-    except NotFound:
-        print(f"Topic {topic.name} not found")
+    except NotFound as e:
+        print(f"Failed to update topic {topic_id} with error: {e.message}")
 
     # [END managedkafka_update_topic]


### PR DESCRIPTION
## Description

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [n/a] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [n/a] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [n/a] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [n/a] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved