### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,7 +53,7 @@
 /storagetransfer/**/*                  @GoogleCloudPlatform/cloud-storage-dpes @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 # ---* Infra DB
 /alloydb/**/*                          @GoogleCloudPlatform/alloydb-connectors-code-owners @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
-/cloud-sql/**/*                        @GoogleCloudPlatform/infra-db-sdk @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
+/cloud-sql/**/*                        @GoogleCloudPlatform/cloud-sql-connectors @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 
 # Self-service
 # ---* Shared with DevRel Teams


### PR DESCRIPTION
The `infra-db-sdk` alias should no longer be used, now the ownership
of the Cloud SQL samples falls to the `cloud-sql-connectors`
team who owns the Cloud SQL Connectors/Proxy.