### PR TITLE
fix: more realistic text embeddings in Firestore vector search examples

### DIFF
--- a/firestore/cloud-client/vector_search.py
+++ b/firestore/cloud-client/vector_search.py
@@ -60,7 +60,7 @@ def vector_search_prefilter(db):
     # Requires a composite vector index
     vector_query = collection.where("color", "==", "red").find_nearest(
         vector_field="embedding_field",
-        query_vector=Vector([3.0, 1.0, 2.0]),
+        query_vector=Vector([0.3416704, 0.18332680, 0.24160706]),
         distance_measure=DistanceMeasure.EUCLIDEAN,
         limit=5,
     )
@@ -77,7 +77,7 @@ def vector_search_distance_result_field(db):
 
     vector_query = collection.find_nearest(
         vector_field="embedding_field",
-        query_vector=Vector([3.0, 1.0, 2.0]),
+        query_vector=Vector([0.3416704, 0.18332680, 0.24160706]),
         distance_measure=DistanceMeasure.EUCLIDEAN,
         limit=10,
         distance_result_field="vector_distance",
@@ -97,7 +97,7 @@ def vector_search_distance_result_field_with_mask(db):
     # [START firestore_vector_search_distance_result_field_masked]
     vector_query = collection.select(["color", "vector_distance"]).find_nearest(
         vector_field="embedding_field",
-        query_vector=Vector([3.0, 1.0, 2.0]),
+        query_vector=Vector([0.3416704, 0.18332680, 0.24160706]),
         distance_measure=DistanceMeasure.EUCLIDEAN,
         limit=10,
         distance_result_field="vector_distance",
@@ -115,7 +115,7 @@ def vector_search_distance_threshold(db):
 
     vector_query = collection.find_nearest(
         vector_field="embedding_field",
-        query_vector=Vector([3.0, 1.0, 2.0]),
+        query_vector=Vector([0.3416704, 0.18332680, 0.24160706]),
         distance_measure=DistanceMeasure.EUCLIDEAN,
         limit=10,
         distance_threshold=4.5,

--- a/firestore/cloud-client/vector_search.py
+++ b/firestore/cloud-client/vector_search.py
@@ -24,7 +24,7 @@ def store_vectors():
     doc = {
         "name": "Kahawa coffee beans",
         "description": "Information about the Kahawa coffee beans.",
-        "embedding_field": Vector([1.0, 2.0, 3.0]),
+        "embedding_field": Vector([0.18332680, 0.24160706, 0.3416704]),
     }
 
     collection.add(doc)
@@ -41,7 +41,7 @@ def vector_search_basic(db):
     # Requires a single-field vector index
     vector_query = collection.find_nearest(
         vector_field="embedding_field",
-        query_vector=Vector([3.0, 1.0, 2.0]),
+        query_vector=Vector([0.3416704, 0.18332680, 0.24160706]),
         distance_measure=DistanceMeasure.EUCLIDEAN,
         limit=5,
     )
@@ -127,4 +127,3 @@ def vector_search_distance_threshold(db):
         print(f"{doc.id}")
     # [END firestore_vector_search_distance_threshold]
     return vector_query
-

--- a/firestore/cloud-client/vector_search.py
+++ b/firestore/cloud-client/vector_search.py
@@ -127,3 +127,4 @@ def vector_search_distance_threshold(db):
         print(f"{doc.id}")
     # [END firestore_vector_search_distance_threshold]
     return vector_query
+

--- a/firestore/cloud-client/vector_search_test.py
+++ b/firestore/cloud-client/vector_search_test.py
@@ -41,18 +41,18 @@ def test_store_vectors():
 def add_coffee_beans_data(db):
     coll = db.collection("coffee-beans")
     coll.document("bean1").set(
-        {"name": "Arabica", "embedding_field": Vector([10.0, 1.0, 2.0]), "color": "red"}
+        {"name": "Arabica", "embedding_field": Vector([0.80522226, 0.18332680, 0.24160706]), "color": "red"}
     )
     coll.document("bean2").set(
-        {"name": "Robusta", "embedding_field": Vector([4.0, 1.0, 2.0]), "color": "blue"}
+        {"name": "Robusta", "embedding_field": Vector([0.43979567, 0.18332680, 0.24160706]), "color": "blue"}
     )
     coll.document("bean3").set(
-        {"name": "Excelsa", "embedding_field": Vector([11.0, 1.0, 2.0]), "color": "red"}
+        {"name": "Excelsa", "embedding_field": Vector([0.90477061, 0.18332680, 0.24160706]), "color": "red"}
     )
     coll.document("bean4").set(
         {
             "name": "Liberica",
-            "embedding_field": Vector([3.0, 1.0, 2.0]),
+            "embedding_field":  Vector([0.3416704, 0.18332680, 0.24160706]),
             "color": "green",
         }
     )

--- a/firestore/cloud-client/vector_search_test.py
+++ b/firestore/cloud-client/vector_search_test.py
@@ -101,11 +101,11 @@ def test_vector_search_distance_result_field():
     assert results[0].to_dict()["name"] == "Liberica"
     assert results[0].to_dict()["vector_distance"] == 0.0
     assert results[1].to_dict()["name"] == "Robusta"
-    assert results[1].to_dict()["vector_distance"] == 1.0
+    assert results[1].to_dict()["vector_distance"] == 0.09812527000000004
     assert results[2].to_dict()["name"] == "Arabica"
-    assert results[2].to_dict()["vector_distance"] == 7.0
+    assert results[2].to_dict()["vector_distance"] == 0.46355186
     assert results[3].to_dict()["name"] == "Excelsa"
-    assert results[3].to_dict()["vector_distance"] == 8.0
+    assert results[3].to_dict()["vector_distance"] == 0.56310021
 
 
 def test_vector_search_distance_result_field_with_mask():
@@ -119,9 +119,9 @@ def test_vector_search_distance_result_field_with_mask():
 
     assert len(results) == 4
     assert results[0].to_dict() == {"color": "green", "vector_distance": 0.0}
-    assert results[1].to_dict() == {"color": "blue", "vector_distance": 1.0}
-    assert results[2].to_dict() == {"color": "red", "vector_distance": 7.0}
-    assert results[3].to_dict() == {"color": "red", "vector_distance": 8.0}
+    assert results[1].to_dict() == {"color": "blue", "vector_distance": 0.09812527000000004}
+    assert results[2].to_dict() == {"color": "red", "vector_distance": 0.46355186}
+    assert results[3].to_dict() == {"color": "red", "vector_distance": 0.56310021}
 
 
 def test_vector_search_distance_threshold():
@@ -133,6 +133,8 @@ def test_vector_search_distance_threshold():
     vector_query = vector_search_distance_threshold(db)
     results = list(vector_query.stream())
 
-    assert len(results) == 2
+    assert len(results) == 4
     assert results[0].to_dict()["name"] == "Liberica"
     assert results[1].to_dict()["name"] == "Robusta"
+    assert results[2].to_dict()["name"] == "Arabica"
+    assert results[3].to_dict()["name"] == "Excelsa"


### PR DESCRIPTION
## Description

Use more realistic text embeddings in Firestore vector search examples. eg: 
```query_vector=Vector([3.0, 1.0, 2.0])``` -> 
```query_vector=Vector([0.3416704, 0.18332680, 0.24160706])```

Fixes b/342654827
