### PR TITLE
Fix KPO sample imports

### DIFF
--- a/composer/workflows/kubernetes_pod_operator_c2.py
+++ b/composer/workflows/kubernetes_pod_operator_c2.py
@@ -18,7 +18,7 @@ import datetime
 
 from airflow import models
 from airflow.kubernetes.secret import Secret
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import (
+from airflow.providers.cncf.kubernetes.operators.pod import (
     KubernetesPodOperator,
 )
 from kubernetes.client import models as k8s_models


### PR DESCRIPTION
## Description

The `airflow.providers.cncf.kubernetes.operators.kubernetes_pod` module was deprecated and now was removed.
Update the example to use its up-to-date alternative, `airflow.providers.cncf.kubernetes.operators.pod`.


## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] Please **merge** this PR for me once it is approved