### PR TITLE
feat(datastore): add datastore vector search samples

### DIFF
--- a/datastore/cloud-client/index.yaml
+++ b/datastore/cloud-client/index.yaml
@@ -57,3 +57,18 @@ indexes:
     direction: desc
   - name: experience
     direction: desc
+- kind: coffee-beans
+  properties:
+  - name: __key__
+  - name: embedding_field
+    vectorConfig:
+      dimension: 3
+      flat: {}
+- kind: coffee-beans
+  properties:
+  - name: color
+  - name: __key__
+  - name: embedding_field
+    vectorConfig:
+      dimension: 3
+      flat: {}

--- a/datastore/cloud-client/vector_search.py
+++ b/datastore/cloud-client/vector_search.py
@@ -117,3 +117,34 @@ def vector_search_distance_threshold(db):
         print(f"{entity.id}")
     # [END datastore_vector_search_distance_threshold]
     return vector_query
+
+
+def vector_search_large_query(db):
+    # [START datastore_vector_search_large_query]
+    from google.cloud.datastore.vector import DistanceMeasure
+    from google.cloud.datastore.vector import Vector
+    from google.cloud.datastore.vector import FindNearest
+
+    # first, perform a vector search query retrieving just the keys
+    vector_query = db.query(
+        kind="coffee-beans",
+        find_nearest=FindNearest(
+            vector_property="embedding_field",
+            query_vector=Vector([3.0, 1.0, 2.0]),
+            distance_measure=DistanceMeasure.EUCLIDEAN,
+            limit=100,
+            distance_result_property="vector_distance",
+        )
+    )
+    vector_query.keys_only()
+    vector_results = list(vector_query.fetch())
+    key_list = [entity.key for entity in vector_results]
+    # next, perfrom a second query for the remaining data
+    full_results = db.get_multi(key_list)
+    # combine and print results
+    vector_map = {entity.key: entity for entity in vector_results}
+    full_map = {entity.key: entity for entity in full_results}
+    for key in key_list:
+        print(f"distance: {vector_map[key]['vector_distance']} entity: {full_map[key]}")
+    # [END datastore_vector_search_large_query]
+    return key_list, vector_results, full_results

--- a/datastore/cloud-client/vector_search.py
+++ b/datastore/cloud-client/vector_search.py
@@ -95,6 +95,29 @@ def vector_search_distance_result_property(db):
     # [END datastore_vector_search_distance_result_property]
     return vector_query
 
+def vector_search_distance_result_property_projection(db):
+    # [START datastore_vector_search_distance_result_property_projection]
+    from google.cloud.datastore.vector import DistanceMeasure
+    from google.cloud.datastore.vector import Vector
+    from google.cloud.datastore.vector import FindNearest
+
+    vector_query = db.query(
+        kind="coffee-beans",
+        find_nearest=FindNearest(
+            vector_property="embedding_field",
+            query_vector=Vector([3.0, 1.0, 2.0]),
+            distance_measure=DistanceMeasure.EUCLIDEAN,
+            limit=5,
+            distance_result_property="vector_distance",
+        )
+    )
+    vector_query.projection = ["color"]
+
+    for entity in vector_query.fetch():
+        print(f"{entity.id}, Distance: {entity['vector_distance']}")
+    # [END datastore_vector_search_distance_result_property_projection]
+    return vector_query
+
 
 def vector_search_distance_threshold(db):
     # [START datastore_vector_search_distance_threshold]

--- a/datastore/cloud-client/vector_search.py
+++ b/datastore/cloud-client/vector_search.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+def store_vectors():
+    # [START datastore_store_vectors]
+    from google.cloud import datastore
+    from google.cloud.datastore.vector import Vector
+
+    client = datastore.Client()
+
+    key = client.key("coffee-beans")
+    entity = datastore.Entity(key=key)
+    entity.update(
+        {
+            "name": "Kahawa coffee beans",
+            "description": "Information about the Kahawa coffee beans.",
+            "embedding_field": Vector([1.0, 2.0, 3.0]),
+        }
+    )
+
+    client.put(entity)
+    # [END datastore_store_vectors]
+    return client
+
+
+def vector_search_basic(db):
+    # [START datastore_vector_search_basic]
+    from google.cloud.datastore.vector import DistanceMeasure
+    from google.cloud.datastore.vector import Vector
+    from google.cloud.datastore.vector import FindNearest
+
+    vector_query = db.query(
+        kind="coffee-beans",
+        find_nearest=FindNearest(
+            vector_property="embedding_field",
+            query_vector=Vector([3.0, 1.0, 2.0]),
+            distance_measure=DistanceMeasure.EUCLIDEAN,
+            limit=5,
+        )
+    )
+    # [END datastore_vector_search_basic]
+    return vector_query
+
+
+def vector_search_prefilter(db):
+    # [START datastore_vector_search_prefilter]
+    from google.cloud.datastore.vector import DistanceMeasure
+    from google.cloud.datastore.vector import Vector
+    from google.cloud.datastore.vector import FindNearest
+    from google.cloud.datastore.query import PropertyFilter
+
+    vector_query = db.query(
+        kind="coffee-beans",
+        filters=PropertyFilter("color", "=", "red"),
+        find_nearest=FindNearest(
+            vector_property="embedding_field",
+            query_vector=Vector([3.0, 1.0, 2.0]),
+            distance_measure=DistanceMeasure.EUCLIDEAN,
+            limit=5,
+        )
+    )
+    # [END datastore_vector_search_prefilter]
+    return vector_query
+
+
+def vector_search_distance_result_field(db):
+    # [START datastore_vector_search_distance_result_field]
+    from google.cloud.datastore.vector import DistanceMeasure
+    from google.cloud.datastore.vector import Vector
+    from google.cloud.datastore.vector import FindNearest
+
+    vector_query = db.query(
+        kind="coffee-beans",
+        find_nearest=FindNearest(
+            vector_property="embedding_field",
+            query_vector=Vector([3.0, 1.0, 2.0]),
+            distance_measure=DistanceMeasure.EUCLIDEAN,
+            limit=5,
+            distance_result_property="vector_distance",
+        )
+    )
+
+    for entity in vector_query.fetch():
+        print(f"{entity.id}, Distance: {entity['distance']}")
+    # [END datastore_vector_search_distance_result_field]
+    return vector_query
+
+
+def vector_search_distance_threshold(db):
+    # [START datastore_vector_search_distance_threshold]
+    from google.cloud.datastore.vector import DistanceMeasure
+    from google.cloud.datastore.vector import Vector
+    from google.cloud.datastore.vector import FindNearest
+
+    vector_query = db.query(
+        kind="coffee-beans",
+        find_nearest=FindNearest(
+            vector_property="embedding_field",
+            query_vector=Vector([3.0, 1.0, 2.0]),
+            distance_measure=DistanceMeasure.EUCLIDEAN,
+            limit=10,
+            distance_threshold=4.5
+        )
+    )
+
+    for entity in vector_query.fetch():
+        print(f"{entity.id}")
+    # [END datastore_vector_search_distance_threshold]
+    return vector_query

--- a/datastore/cloud-client/vector_search.py
+++ b/datastore/cloud-client/vector_search.py
@@ -120,7 +120,7 @@ def vector_search_distance_threshold(db):
 
 
 def vector_search_large_query(db):
-    # [START datastore_vector_search_large_query]
+    # [START datastore_vector_search_large_reqponse]
     from google.cloud.datastore.vector import DistanceMeasure
     from google.cloud.datastore.vector import Vector
     from google.cloud.datastore.vector import FindNearest
@@ -146,5 +146,5 @@ def vector_search_large_query(db):
     full_map = {entity.key: entity for entity in full_results}
     for key in key_list:
         print(f"distance: {vector_map[key]['vector_distance']} entity: {full_map[key]}")
-    # [END datastore_vector_search_large_query]
+    # [END datastore_vector_search_large_response]
     return key_list, vector_results, full_results

--- a/datastore/cloud-client/vector_search.py
+++ b/datastore/cloud-client/vector_search.py
@@ -61,7 +61,7 @@ def vector_search_prefilter(db):
 
     vector_query = db.query(
         kind="coffee-beans",
-        filters=PropertyFilter("color", "=", "red"),
+        filters=[PropertyFilter("color", "=", "red")],
         find_nearest=FindNearest(
             vector_property="embedding_field",
             query_vector=Vector([3.0, 1.0, 2.0]),
@@ -91,7 +91,7 @@ def vector_search_distance_result_field(db):
     )
 
     for entity in vector_query.fetch():
-        print(f"{entity.id}, Distance: {entity['distance']}")
+        print(f"{entity.id}, Distance: {entity['vector_distance']}")
     # [END datastore_vector_search_distance_result_field]
     return vector_query
 

--- a/datastore/cloud-client/vector_search.py
+++ b/datastore/cloud-client/vector_search.py
@@ -73,8 +73,8 @@ def vector_search_prefilter(db):
     return vector_query
 
 
-def vector_search_distance_result_field(db):
-    # [START datastore_vector_search_distance_result_field]
+def vector_search_distance_result_property(db):
+    # [START datastore_vector_search_distance_result_property]
     from google.cloud.datastore.vector import DistanceMeasure
     from google.cloud.datastore.vector import Vector
     from google.cloud.datastore.vector import FindNearest
@@ -92,7 +92,7 @@ def vector_search_distance_result_field(db):
 
     for entity in vector_query.fetch():
         print(f"{entity.id}, Distance: {entity['vector_distance']}")
-    # [END datastore_vector_search_distance_result_field]
+    # [END datastore_vector_search_distance_result_property]
     return vector_query
 
 
@@ -119,8 +119,8 @@ def vector_search_distance_threshold(db):
     return vector_query
 
 
-def vector_search_large_query(db):
-    # [START datastore_vector_search_large_reqponse]
+def vector_search_large_response(db):
+    # [START datastore_vector_search_large_response]
     from google.cloud.datastore.vector import DistanceMeasure
     from google.cloud.datastore.vector import Vector
     from google.cloud.datastore.vector import FindNearest

--- a/datastore/cloud-client/vector_search.py
+++ b/datastore/cloud-client/vector_search.py
@@ -30,7 +30,7 @@ def store_vectors():
 
     client.put(entity)
     # [END datastore_store_vectors]
-    return client
+    return client, entity
 
 
 def vector_search_basic(db):

--- a/datastore/cloud-client/vector_search_test.py
+++ b/datastore/cloud-client/vector_search_test.py
@@ -107,3 +107,28 @@ def test_vector_search_distance_threshold(db):
     assert len(results) == 2
     assert results[0].key.name == "Liberica"
     assert results[1].key.name == "Robusta"
+
+def test_vector_search_large_query(db):
+    key_list, vector_results, full_results = vector_search_large_query(db)
+    assert len(key_list) == 4
+    # each list should have same number of elements
+    assert len(key_list) == len(vector_results)
+    assert len(key_list) == len(full_results)
+    # should all have the same keys
+    vector_map = {entity.key: entity for entity in vector_results}
+    full_map = {entity.key: entity for entity in full_results}
+    for key in key_list:
+        assert key in vector_map.keys()
+        assert key in full_map.keys()
+    # vector_results should just contain key and distance
+    for entity in vector_results:
+        assert entity.key is not None
+        assert entity["vector_distance"] is not None
+        with pytest.raises(KeyError):
+            entity["embedding_field"]
+    # full_results should have other fields, but no vector_distance
+    for entity in full_results:
+        assert entity.key is not None
+        assert isinstance(entity["embedding_field"], Vector)
+        with pytest.raises(KeyError):
+            entity["vector_distance"]

--- a/datastore/cloud-client/vector_search_test.py
+++ b/datastore/cloud-client/vector_search_test.py
@@ -1,0 +1,105 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.cloud import datastore
+from google.cloud.datastore.vector import Vector
+
+from vector_search import store_vectors
+from vector_search import vector_search_basic
+from vector_search import vector_search_distance_result_field
+from vector_search import vector_search_distance_threshold
+from vector_search import vector_search_prefilter
+
+
+os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
+PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
+
+
+def test_store_vectors():
+    client = store_vectors()
+
+    results = client.query("coffee-beans", limit=5).fetch()
+
+    assert len(list(results)) == 1
+
+
+def add_coffee_beans_data(db):
+    entity1 = datastore.Entity(db.key("coffee-beans", "Arabica"))
+    entity1.update({"embedding_field": Vector([10.0, 1.0, 2.0]), "color": "red"})
+    entity2 = datastore.Entity(db.key("coffee-beans", "Robusta"))
+    entity2.update({"embedding_field": Vector([4.0, 1.0, 2.0]), "color": ""})
+    entity3 = datastore.Entity(db.key("coffee-beans", "Excelsa"))
+    entity3.update({"embedding_field": Vector([11.0, 1.0, 2.0]), "color": "red"})
+    entity4 = datastore.Entity(db.key("coffee-beans", "Liberica"))
+    entity4.update({"embedding_field": Vector([3.0, 1.0, 2.0]), "color": "green"})
+
+    db.put_multi([entity1, entity2, entity3, entity4])
+
+
+def test_vector_search_basic():
+    db = datastore.Client()
+    add_coffee_beans_data(db)
+
+    vector_query = vector_search_basic(db)
+    results = list(vector_query.fetch())
+
+    assert len(results) == 4
+    assert results[0].name == "Liberica"
+    assert results[1].name == "Robusta"
+    assert results[2].name == "Arabica"
+    assert results[3].name == "Excelsa"
+
+
+def test_vector_search_prefilter():
+    db = datastore.Client()
+    add_coffee_beans_data(db)
+
+    vector_query = vector_search_prefilter(db)
+    results = list(vector_query.fetch())
+
+    assert len(results) == 2
+    assert results[0].name == "Arabica"
+    assert results[1].name == "Excelsa"
+
+
+def test_vector_search_distance_result_field():
+    db = datastore.Client()
+    add_coffee_beans_data(db)
+
+    vector_query = vector_search_distance_result_field(db)
+    results = list(vector_query.fetch())
+
+    assert len(results) == 4
+    assert results[0].name == "Liberica"
+    assert results[0]["vector_distance"] == 0.0
+    assert results[1].name == "Robusta"
+    assert results[1]["vector_distance"] == 1.0
+    assert results[2].name == "Arabica"
+    assert results[2]["vector_distance"] == 7.0
+    assert results[3].name == "Excelsa"
+    assert results[3]["vector_distance"] == 8.0
+
+
+def test_vector_search_distance_threshold():
+    db = datastore.Client()
+    add_coffee_beans_data(db)
+
+    vector_query = vector_search_distance_threshold(db)
+    results = list(vector_query.fetch())
+
+    assert len(results) == 2
+    assert results[0].name == "Liberica"
+    assert results[1].name == "Robusta"

--- a/datastore/cloud-client/vector_search_test.py
+++ b/datastore/cloud-client/vector_search_test.py
@@ -93,12 +93,33 @@ def test_vector_search_distance_result_property(db):
     assert len(results) == 4
     assert results[0].key.name == "Liberica"
     assert results[0]["vector_distance"] == 0.0
+    assert results[0]["embedding_field"] == Vector([3.0, 1.0, 2.0])
+    assert results[1].key.name == "Robusta"
+    assert results[1]["vector_distance"] == 1.0
+    assert results[1]["embedding_field"] == Vector([4.0, 1.0, 2.0])
+    assert results[2].key.name == "Arabica"
+    assert results[2]["vector_distance"] == 7.0
+    assert results[2]["embedding_field"] == Vector([10.0, 1.0, 2.0])
+    assert results[3].key.name == "Excelsa"
+    assert results[3]["vector_distance"] == 8.0
+    assert results[3]["embedding_field"] == Vector([11.0, 1.0, 2.0])
+
+
+def test_vector_search_distance_result_property_projection(db):
+    vector_query = vector_search_distance_result_property_projection(db)
+    results = list(vector_query.fetch())
+
+    assert len(results) == 4
+    assert results[0].key.name == "Liberica"
+    assert results[0]["vector_distance"] == 0.0
     assert results[1].key.name == "Robusta"
     assert results[1]["vector_distance"] == 1.0
     assert results[2].key.name == "Arabica"
     assert results[2]["vector_distance"] == 7.0
     assert results[3].key.name == "Excelsa"
     assert results[3]["vector_distance"] == 8.0
+
+    assert all("embedding_field" not in d for d in results)
 
 
 def test_vector_search_distance_threshold(db):

--- a/datastore/cloud-client/vector_search_test.py
+++ b/datastore/cloud-client/vector_search_test.py
@@ -20,9 +20,10 @@ from google.cloud.datastore.vector import Vector
 
 from vector_search import store_vectors
 from vector_search import vector_search_basic
-from vector_search import vector_search_distance_result_field
+from vector_search import vector_search_distance_result_property
 from vector_search import vector_search_distance_threshold
 from vector_search import vector_search_prefilter
+from vector_search import vector_search_large_response
 
 
 os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
@@ -85,8 +86,8 @@ def test_vector_search_prefilter(db):
     assert results[1].key.name == "Excelsa"
 
 
-def test_vector_search_distance_result_field(db):
-    vector_query = vector_search_distance_result_field(db)
+def test_vector_search_distance_result_property(db):
+    vector_query = vector_search_distance_result_property(db)
     results = list(vector_query.fetch())
 
     assert len(results) == 4
@@ -108,8 +109,8 @@ def test_vector_search_distance_threshold(db):
     assert results[0].key.name == "Liberica"
     assert results[1].key.name == "Robusta"
 
-def test_vector_search_large_query(db):
-    key_list, vector_results, full_results = vector_search_large_query(db)
+def test_vector_search_large_response(db):
+    key_list, vector_results, full_results = vector_search_large_response(db)
     assert len(key_list) == 4
     # each list should have same number of elements
     assert len(key_list) == len(vector_results)

--- a/datastore/cloud-client/vector_search_test.py
+++ b/datastore/cloud-client/vector_search_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pytest
 
 from google.cloud import datastore
 from google.cloud.datastore.vector import Vector
@@ -28,12 +29,21 @@ os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
 PROJECT_ID = os.environ["GOOGLE_CLOUD_PROJECT"]
 
 
-def test_store_vectors():
-    client = store_vectors()
+@pytest.fixture(scope="module")
+def db():
+    client = datastore.Client()
+    _clear_db(client)
+    entity_list = add_coffee_beans_data(client)
+    yield client
+    for e in entity_list:
+        client.delete(e)
 
-    results = client.query("coffee-beans", limit=5).fetch()
-
-    assert len(list(results)) == 1
+def _clear_db(db):
+    """remove all entities with kind-coffee-beans, so we have a new databse"""
+    query = db.query(kind="coffee-beans")
+    query.keys_only()
+    keys = list(query.fetch())
+    db.delete_multi(keys)
 
 
 def add_coffee_beans_data(db):
@@ -46,60 +56,54 @@ def add_coffee_beans_data(db):
     entity4 = datastore.Entity(db.key("coffee-beans", "Liberica"))
     entity4.update({"embedding_field": Vector([3.0, 1.0, 2.0]), "color": "green"})
 
-    db.put_multi([entity1, entity2, entity3, entity4])
+    entity_list = [entity1, entity2, entity3, entity4]
+    db.put_multi(entity_list)
+    return entity_list
 
+def test_store_vectors():
+    # run an ensure there are no exceptions
+    client, entity = store_vectors()
+    client.delete(entity)
 
-def test_vector_search_basic():
-    db = datastore.Client()
-    add_coffee_beans_data(db)
-
+def test_vector_search_basic(db):
     vector_query = vector_search_basic(db)
     results = list(vector_query.fetch())
 
     assert len(results) == 4
-    assert results[0].name == "Liberica"
-    assert results[1].name == "Robusta"
-    assert results[2].name == "Arabica"
-    assert results[3].name == "Excelsa"
+    assert results[0].key.name == "Liberica"
+    assert results[1].key.name == "Robusta"
+    assert results[2].key.name == "Arabica"
+    assert results[3].key.name == "Excelsa"
 
 
-def test_vector_search_prefilter():
-    db = datastore.Client()
-    add_coffee_beans_data(db)
-
+def test_vector_search_prefilter(db):
     vector_query = vector_search_prefilter(db)
     results = list(vector_query.fetch())
 
     assert len(results) == 2
-    assert results[0].name == "Arabica"
-    assert results[1].name == "Excelsa"
+    assert results[0].key.name == "Arabica"
+    assert results[1].key.name == "Excelsa"
 
 
-def test_vector_search_distance_result_field():
-    db = datastore.Client()
-    add_coffee_beans_data(db)
-
+def test_vector_search_distance_result_field(db):
     vector_query = vector_search_distance_result_field(db)
     results = list(vector_query.fetch())
 
     assert len(results) == 4
-    assert results[0].name == "Liberica"
+    assert results[0].key.name == "Liberica"
     assert results[0]["vector_distance"] == 0.0
-    assert results[1].name == "Robusta"
+    assert results[1].key.name == "Robusta"
     assert results[1]["vector_distance"] == 1.0
-    assert results[2].name == "Arabica"
+    assert results[2].key.name == "Arabica"
     assert results[2]["vector_distance"] == 7.0
-    assert results[3].name == "Excelsa"
+    assert results[3].key.name == "Excelsa"
     assert results[3]["vector_distance"] == 8.0
 
 
-def test_vector_search_distance_threshold():
-    db = datastore.Client()
-    add_coffee_beans_data(db)
-
+def test_vector_search_distance_threshold(db):
     vector_query = vector_search_distance_threshold(db)
     results = list(vector_query.fetch())
 
     assert len(results) == 2
-    assert results[0].name == "Liberica"
-    assert results[1].name == "Robusta"
+    assert results[0].key.name == "Liberica"
+    assert results[1].key.name == "Robusta"


### PR DESCRIPTION
Add samples for datastore's new vector search feature

marked as draft for now, as tests will fail until the backend feature is released