### PR TITLE
test(privateca): cleanup policies created during testing

### DIFF
--- a/privateca/snippets/monitor_certificate_authority.py
+++ b/privateca/snippets/monitor_certificate_authority.py
@@ -72,6 +72,15 @@ def create_ca_monitor_policy(project_id: str) -> None:
     )
 
     print("Monitoring policy successfully created!", policy.name)
+    # [END privateca_monitor_ca_expiry]
+    return policy.name
 
 
-# [END privateca_monitor_ca_expiry]
+def delete_ca_monitor_policy(policy_name: str) -> None:
+    """Deletes a named policy in the project
+    Args:
+        policy_name: fully qualified name of a policy
+    """
+
+    alert_policy_client = monitoring_v3.AlertPolicyServiceClient()
+    alert_policy_client.delete_alert_policy(name=policy_name.name)

--- a/privateca/snippets/monitor_certificate_authority.py
+++ b/privateca/snippets/monitor_certificate_authority.py
@@ -83,4 +83,4 @@ def delete_ca_monitor_policy(policy_name: str) -> None:
     """
 
     alert_policy_client = monitoring_v3.AlertPolicyServiceClient()
-    alert_policy_client.delete_alert_policy(name=policy_name.name)
+    alert_policy_client.delete_alert_policy(name=policy_name)

--- a/privateca/snippets/test_certificate_authorities.py
+++ b/privateca/snippets/test_certificate_authorities.py
@@ -26,7 +26,7 @@ from delete_ca_pool import delete_ca_pool
 from delete_certificate_authority import delete_certificate_authority
 from disable_certificate_authority import disable_certificate_authority
 from enable_certificate_authority import enable_certificate_authority
-from monitor_certificate_authority import create_ca_monitor_policy
+from monitor_certificate_authority import create_ca_monitor_policy, delete_ca_monitor_policy
 from undelete_certificate_authority import undelete_certificate_authority
 from update_certificate_authority import update_ca_label
 
@@ -126,8 +126,10 @@ def test_update_certificate_authority(
 
 @backoff.on_exception(backoff_expo_wrapper, Exception, max_tries=3)
 def test_create_monitor_ca_policy(capsys: typing.Any) -> None:
-    create_ca_monitor_policy(PROJECT)
+    policy = create_ca_monitor_policy(PROJECT)
 
     out, _ = capsys.readouterr()
 
     assert "Monitoring policy successfully created!" in out
+
+    delete_ca_monitor_policy(policy)


### PR DESCRIPTION
## Description

Resolves issues raised in #12896

Updates privateca_monitor_ca_expiry sample to delete created sample (outside the region tags)


## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved