### PR TITLE
feat(vertex-ai): function-calling api: convert 'example syntax' from markdown

### DIFF
--- a/generative_ai/function_calling/example_syntax.py
+++ b/generative_ai/function_calling/example_syntax.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+import vertexai
+
+from vertexai.generative_models import GenerativeModel
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+vertexai.init(project=PROJECT_ID, location="us-central1")
+
+
+def create_model_with_toolbox() -> GenerativeModel:
+    # [START generativeaionvertexai_function_calling_example_syntax]
+    from vertexai.generative_models import FunctionDeclaration, GenerationConfig, GenerativeModel, Tool
+
+    gemini_model = GenerativeModel(
+        "gemini-1.5-flash-002",
+        generation_config=GenerationConfig(temperature=0),
+        tools=[
+            Tool(
+                function_declarations=[
+                    FunctionDeclaration(
+                        name="get_current_weather",
+                        description="Get the current weather in a given location",
+                        parameters={
+                            "type": "object",
+                            "properties": {"location": {"type": "string", "description": "Location"}},
+                        },
+                    )
+                ]
+            )
+        ],
+    )
+    # [END generativeaionvertexai_function_calling_example_syntax]
+    return gemini_model
+
+
+if __name__ == "__main__":
+    create_model_with_toolbox()

--- a/generative_ai/function_calling/test_function_calling.py
+++ b/generative_ai/function_calling/test_function_calling.py
@@ -21,6 +21,7 @@ import basic_example
 import chat_example
 import chat_function_calling_basic
 import chat_function_calling_config
+import example_syntax
 import parallel_function_calling_example
 
 
@@ -85,3 +86,8 @@ def test_function_calling_chat() -> None:
 def test_parallel_function_calling() -> None:
     response = parallel_function_calling_example.parallel_function_calling_example()
     assert response is not None
+
+
+def test_example_syntax() -> None:
+    model = example_syntax.create_model_with_toolbox()
+    assert model is not None


### PR DESCRIPTION
## Description

Convert the Markdown sample from the "Function Calling API -> Example Syntax" [section](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/function-calling#python).
The original "sample" is not runnable in its current state, as it doesn't use real values and omits details like imports, function body, etc..

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` && `nox -s py-3.12`
- [x] **Lint** pass:   `nox -s lint`