### PR TITLE
docs(samples): Remove Beam version from requirements.txt file

### DIFF
--- a/dataflow/flex-templates/getting_started/requirements.txt
+++ b/dataflow/flex-templates/getting_started/requirements.txt
@@ -1,1 +1,1 @@
-apache-beam[gcp]
+apache-beam[gcp] # Version not pinned to use the latest Beam SDK provided by the base image

--- a/dataflow/flex-templates/getting_started/requirements.txt
+++ b/dataflow/flex-templates/getting_started/requirements.txt
@@ -1,1 +1,1 @@
-apache-beam[gcp]==2.60.0
+apache-beam[gcp]


### PR DESCRIPTION
## Description

This sample pinned the Beam SDK version number. However, the latest template base image always uses the latest Beam, so it's not needed and can cause errors;

More information: b/374216225

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved