### PR TITLE
docs(iam): Update comments and terminology in IAM samples

### DIFF
--- a/iam/cloud-client/snippets/iam_modify_policy_add_role.py
+++ b/iam/cloud-client/snippets/iam_modify_policy_add_role.py
@@ -14,10 +14,10 @@
 
 
 # [START iam_modify_policy_add_role]
-def modify_policy_add_role(policy: dict, role: str, member: str) -> dict:
+def modify_policy_add_role(policy: dict, role: str, principal: str) -> dict:
     """Adds a new role binding to a policy."""
 
-    binding = {"role": role, "members": [member]}
+    binding = {"role": role, "members": [principal]}
     policy["bindings"].append(binding)
     print(policy)
     return policy

--- a/iam/cloud-client/snippets/modify_policy_add_member.py
+++ b/iam/cloud-client/snippets/modify_policy_add_member.py
@@ -50,6 +50,6 @@ if __name__ == "__main__":
     # Your Google Cloud project ID.
     project_id = "test-project-id"
     role = "roles/viewer"
-    member = f"serviceAccount:test-service-account@{project_id}.iam.gserviceaccount.com"
+    principal = f"serviceAccount:test-service-account@{project_id}.iam.gserviceaccount.com"
 
     modify_policy_add_member(project_id, role, principal)

--- a/iam/cloud-client/snippets/modify_policy_add_member.py
+++ b/iam/cloud-client/snippets/modify_policy_add_member.py
@@ -22,20 +22,13 @@ def modify_policy_add_member(
     project_id: str, role: str, member: str
 ) -> policy_pb2.Policy:
     """
-    Add a member to certain role in project policy.
+    Add a principal to certain role in project policy.
 
     project_id: ID or number of the Google Cloud project you want to use.
-    role: role to which member need to be added.
-    member: The principals requesting access.
+    role: role to which principal need to be added.
+    member: The principal requesting access.
 
-    Possible format for member:
-        * user:{emailid}
-        * serviceAccount:{emailid}
-        * group:{emailid}
-        * deleted:user:{emailid}?uid={uniqueid}
-        * deleted:serviceAccount:{emailid}?uid={uniqueid}
-        * deleted:group:{emailid}?uid={uniqueid}
-        * domain:{domain}
+    For principal ID formats, see https://cloud.google.com/iam/docs/principal-identifiers
     """
     policy = get_project_policy(project_id)
 

--- a/iam/cloud-client/snippets/modify_policy_add_member.py
+++ b/iam/cloud-client/snippets/modify_policy_add_member.py
@@ -19,14 +19,14 @@ from snippets.set_policy import set_project_policy
 
 
 def modify_policy_add_member(
-    project_id: str, role: str, member: str
+    project_id: str, role: str, principal: str
 ) -> policy_pb2.Policy:
     """
     Add a principal to certain role in project policy.
 
     project_id: ID or number of the Google Cloud project you want to use.
     role: role to which principal need to be added.
-    member: The principal requesting access.
+    principal: The principal requesting access.
 
     For principal ID formats, see https://cloud.google.com/iam/docs/principal-identifiers
     """
@@ -34,7 +34,7 @@ def modify_policy_add_member(
 
     for bind in policy.bindings:
         if bind.role == role:
-            bind.members.append(member)
+            bind.members.append(principal)
             break
 
     return set_project_policy(project_id, policy)
@@ -52,4 +52,4 @@ if __name__ == "__main__":
     role = "roles/viewer"
     member = f"serviceAccount:test-service-account@{project_id}.iam.gserviceaccount.com"
 
-    modify_policy_add_member(project_id, role, member)
+    modify_policy_add_member(project_id, role, principal)

--- a/iam/cloud-client/snippets/modify_policy_remove_member.py
+++ b/iam/cloud-client/snippets/modify_policy_remove_member.py
@@ -22,20 +22,13 @@ def modify_policy_remove_member(
     project_id: str, role: str, member: str
 ) -> policy_pb2.Policy:
     """
-    Remove a member from certain role in project policy.
+    Remove a principal from certain role in project policy.
 
     project_id: ID or number of the Google Cloud project you want to use.
-    role: role to which member need to be added.
-    member: The principals requesting access.
+    role: role to revoke.
+    member: The principal to revoke access from.
 
-    Possible format for member:
-        * user:{emailid}
-        * serviceAccount:{emailid}
-        * group:{emailid}
-        * deleted:user:{emailid}?uid={uniqueid}
-        * deleted:serviceAccount:{emailid}?uid={uniqueid}
-        * deleted:group:{emailid}?uid={uniqueid}
-        * domain:{domain}
+    For principal ID formats, see https://cloud.google.com/iam/docs/principal-identifiers
     """
     policy = get_project_policy(project_id)
 

--- a/iam/cloud-client/snippets/modify_policy_remove_member.py
+++ b/iam/cloud-client/snippets/modify_policy_remove_member.py
@@ -19,14 +19,14 @@ from snippets.set_policy import set_project_policy
 
 
 def modify_policy_remove_member(
-    project_id: str, role: str, member: str
+    project_id: str, role: str, principal: str
 ) -> policy_pb2.Policy:
     """
     Remove a principal from certain role in project policy.
 
     project_id: ID or number of the Google Cloud project you want to use.
     role: role to revoke.
-    member: The principal to revoke access from.
+    principal: The principal to revoke access from.
 
     For principal ID formats, see https://cloud.google.com/iam/docs/principal-identifiers
     """
@@ -35,7 +35,7 @@ def modify_policy_remove_member(
     for bind in policy.bindings:
         if bind.role == role:
             if member in bind.members:
-                bind.members.remove(member)
+                bind.members.remove(principal)
             break
 
     return set_project_policy(project_id, policy, False)
@@ -51,6 +51,6 @@ if __name__ == "__main__":
     # Your Google Cloud project ID.
     project_id = "test-project-id"
     role = "roles/viewer"
-    member = f"serviceAccount:test-service-account@{project_id}.iam.gserviceaccount.com"
+    principal = f"serviceAccount:test-service-account@{project_id}.iam.gserviceaccount.com"
 
-    modify_policy_remove_member(project_id, role, member)
+    modify_policy_remove_member(project_id, role, principal)

--- a/iam/cloud-client/snippets/modify_policy_remove_member.py
+++ b/iam/cloud-client/snippets/modify_policy_remove_member.py
@@ -34,7 +34,7 @@ def modify_policy_remove_member(
 
     for bind in policy.bindings:
         if bind.role == role:
-            if member in bind.members:
+            if principal in bind.members:
                 bind.members.remove(principal)
             break
 

--- a/iam/cloud-client/snippets/quickstart.py
+++ b/iam/cloud-client/snippets/quickstart.py
@@ -19,20 +19,20 @@ from google.iam.v1 import iam_policy_pb2, policy_pb2
 
 
 def quickstart(project_id: str, member: str) -> None:
-    """Gets a policy, adds a member, prints their permissions, and removes the member.
+    """Gets a policy, adds a principal, prints their permissions, and removes the principal.
 
     project_id: ID or number of the Google Cloud project you want to use.
-    member: The principals requesting the access.
+    member: The principal requesting the access.
     """
 
     # Role to be granted.
     role = "roles/logging.logWriter"
     crm_service = resourcemanager_v3.ProjectsClient()
 
-    # Grants your member the 'Log Writer' role for the project.
+    # Grants your principal the 'Log Writer' role for the project.
     modify_policy_add_role(crm_service, project_id, role, member)
 
-    # Gets the project's policy and prints all members with the 'Log Writer' role.
+    # Gets the project's policy and prints all principals with the 'Log Writer' role.
     policy = get_policy(crm_service, project_id)
     binding = next(b for b in policy.bindings if b.role == role)
     print(f"Role: {(binding.role)}")
@@ -40,7 +40,7 @@ def quickstart(project_id: str, member: str) -> None:
     for m in binding.members:
         print(f"[{m}]")
 
-    # Removes the member from the 'Log Writer' role.
+    # Removes the principal from the 'Log Writer' role.
     modify_policy_remove_member(crm_service, project_id, role, member)
 
 
@@ -115,7 +115,8 @@ def modify_policy_remove_member(
 if __name__ == "__main__":
     # TODO: replace with your project ID
     project_id = "your-project-id"
-    # TODO: Replace with the ID of your member in the form 'user:member@example.com'.
-    member = "your-member"
+    # TODO: Replace with the ID of your principal.
+    # For examples, see https://cloud.google.com/iam/docs/principal-identifiers
+    member = "your-principal"
     quickstart(project_id, member)
 # [END iam_quickstart]

--- a/iam/cloud-client/snippets/quickstart.py
+++ b/iam/cloud-client/snippets/quickstart.py
@@ -18,19 +18,19 @@ from google.cloud import resourcemanager_v3
 from google.iam.v1 import iam_policy_pb2, policy_pb2
 
 
-def quickstart(project_id: str, member: str) -> None:
+def quickstart(project_id: str, principal: str) -> None:
     """Demonstrates basic IAM operations.
 
 This quickstart shows how to get a project's IAM policy, add a principal to a role, list members of a role, and remove a principal from a role.
 
 Args:
     project_id: The ID or number of the Google Cloud project.
-    member: The principal ID.
+    principal: The principal ID.
 """
     """Gets a policy, adds a principal, prints their permissions, and removes the principal.
 
     project_id: ID or number of the Google Cloud project you want to use.
-    member: The principal requesting the access.
+    principal: The principal requesting the access.
     """
 
     # Role to be granted.
@@ -38,7 +38,7 @@ Args:
     crm_service = resourcemanager_v3.ProjectsClient()
 
     # Grants your principal the 'Log Writer' role for the project.
-    modify_policy_add_role(crm_service, project_id, role, member)
+    modify_policy_add_role(crm_service, project_id, role, principal)
 
     # Gets the project's policy and prints all principals with the 'Log Writer' role.
     policy = get_policy(crm_service, project_id)
@@ -49,7 +49,7 @@ Args:
         print(f"[{m}]")
 
     # Removes the principal from the 'Log Writer' role.
-    modify_policy_remove_member(crm_service, project_id, role, member)
+    modify_policy_remove_member(crm_service, project_id, role, principal)
 
 
 def get_policy(
@@ -82,7 +82,7 @@ def modify_policy_add_role(
     crm_service: resourcemanager_v3.ProjectsClient,
     project_id: str,
     role: str,
-    member: str,
+    principal: str,
 ) -> None:
     """Adds a new role binding to a policy."""
 
@@ -90,12 +90,12 @@ def modify_policy_add_role(
 
     for bind in policy.bindings:
         if bind.role == role:
-            bind.members.append(member)
+            bind.members.append(principal)
             break
     else:
         binding = policy_pb2.Binding()
         binding.role = role
-        binding.members.append(member)
+        binding.members.append(principal)
         policy.bindings.append(binding)
 
     set_policy(crm_service, project_id, policy)
@@ -105,16 +105,16 @@ def modify_policy_remove_member(
     crm_service: resourcemanager_v3.ProjectsClient,
     project_id: str,
     role: str,
-    member: str,
+    principal: str,
 ) -> None:
-    """Removes a  member from a role binding."""
+    """Removes a  principal from a role binding."""
 
     policy = get_policy(crm_service, project_id)
 
     for bind in policy.bindings:
         if bind.role == role:
-            if member in bind.members:
-                bind.members.remove(member)
+            if principal in bind.members:
+                bind.members.remove(principal)
             break
 
     set_policy(crm_service, project_id, policy)
@@ -125,6 +125,6 @@ if __name__ == "__main__":
     project_id = "your-project-id"
     # TODO: Replace with the ID of your principal.
     # For examples, see https://cloud.google.com/iam/docs/principal-identifiers
-    member = "your-principal"
-    quickstart(project_id, member)
+    principal = "your-principal"
+    quickstart(project_id, principal)
 # [END iam_quickstart]

--- a/iam/cloud-client/snippets/quickstart.py
+++ b/iam/cloud-client/snippets/quickstart.py
@@ -19,6 +19,14 @@ from google.iam.v1 import iam_policy_pb2, policy_pb2
 
 
 def quickstart(project_id: str, member: str) -> None:
+    """Demonstrates basic IAM operations.
+
+This quickstart shows how to get a project's IAM policy, add a principal to a role, list members of a role, and remove a principal from a role.
+
+Args:
+    project_id: The ID or number of the Google Cloud project.
+    member: The principal ID.
+"""
     """Gets a policy, adds a principal, prints their permissions, and removes the principal.
 
     project_id: ID or number of the Google Cloud project you want to use.


### PR DESCRIPTION
## Description

Includes changing "member" to "principal" and linking to principal identifiers page instead of specifying recommended format.

I left "member" when it referred to the field in the role binding, since that field is still called "members."

Please **merge** this PR for me once it is approved