### PR TITLE
chore(gke): migrate region step 1 - update regions adding gke_ prefix and _python suffix

### DIFF
--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -22,8 +22,7 @@
 # For more info about Deployments:
 #   https://kubernetes.io/docs/user-guide/deployments/
 
-# [START gke_kubernetes_deployment]
-# [START kubernetes_deployment]
+# [START gke_kubernetes_deployment_python]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -50,7 +49,6 @@ spec:
         imagePullPolicy: Always
         env:
             # [START gke_cloudsql_secrets_python]
-            # [START cloudsql_secrets]
             - name: DATABASE_NAME
               valueFrom:
                 secretKeyRef:
@@ -66,13 +64,11 @@ spec:
                 secretKeyRef:
                   name: cloudsql
                   key: password
-            # [END cloudsql_secrets]
             # [END gke_cloudsql_secrets_python]
         ports:
         - containerPort: 8080
       
       # [START gke_proxy_container_python]
-      # [START proxy_container]
       - image: gcr.io/cloudsql-docker/gce-proxy:1.16
         name: cloudsql-proxy
         command: ["/cloud_sql_proxy", "--dir=/cloudsql",
@@ -86,10 +82,8 @@ spec:
             mountPath: /etc/ssl/certs
           - name: cloudsql
             mountPath: /cloudsql
-      # [END proxy_container]
       # [END gke_proxy_container_python]
       # [START gke_volumes_python]
-      # [START volumes]
       volumes:
         - name: cloudsql-oauth-credentials
           secret:
@@ -99,15 +93,12 @@ spec:
             path: /etc/ssl/certs
         - name: cloudsql
           emptyDir: {}
-      # [END volumes]
       # [END gke_volumes_python]
-# [END kubernetes_deployment]
-# [END gke_kubernetes_deployment]
+# [END gke_kubernetes_deployment_python]
 
 ---
 
 # [START gke_container_poll_service_python]
-# [START container_poll_service]
 # The polls service provides a load-balancing proxy over the polls app
 # pods. By specifying the type as a 'LoadBalancer', Kubernetes Engine will
 # create an external HTTP load balancer.
@@ -128,5 +119,4 @@ spec:
     targetPort: 8080
   selector:
     app: polls
-# [END container_poll_service]
 # [END gke_container_poll_service_python]

--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -49,6 +49,7 @@ spec:
         # off in production.
         imagePullPolicy: Always
         env:
+            # [START gke_cloudsql_secrets_python]
             # [START cloudsql_secrets]
             - name: DATABASE_NAME
               valueFrom:
@@ -66,9 +67,11 @@ spec:
                   name: cloudsql
                   key: password
             # [END cloudsql_secrets]
+            # [END gke_cloudsql_secrets_python]
         ports:
         - containerPort: 8080
-
+      
+      # [START gke_proxy_container_python]
       # [START proxy_container]
       - image: gcr.io/cloudsql-docker/gce-proxy:1.16
         name: cloudsql-proxy
@@ -84,6 +87,8 @@ spec:
           - name: cloudsql
             mountPath: /cloudsql
       # [END proxy_container]
+      # [END gke_proxy_container_python]
+      # [START gke_volumes_python]
       # [START volumes]
       volumes:
         - name: cloudsql-oauth-credentials
@@ -95,11 +100,13 @@ spec:
         - name: cloudsql
           emptyDir: {}
       # [END volumes]
+      # [END gke_volumes_python]
 # [END kubernetes_deployment]
 # [END gke_kubernetes_deployment]
 
 ---
 
+# [START gke_container_poll_service_python]
 # [START container_poll_service]
 # The polls service provides a load-balancing proxy over the polls app
 # pods. By specifying the type as a 'LoadBalancer', Kubernetes Engine will
@@ -122,3 +129,4 @@ spec:
   selector:
     app: polls
 # [END container_poll_service]
+# [END gke_container_poll_service_python]


### PR DESCRIPTION
## Description

Fixes [b/347826199](http://b/347826199)

Associated all region_tags with an official product (gke) and suffix _python

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup)) <- Returns 403
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved