### PR TITLE
chore(deps): update dependency google-crc32c, update min python version

### DIFF
--- a/secretmanager/snippets/noxfile_config.py
+++ b/secretmanager/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/secretmanager/snippets/requirements.txt
+++ b/secretmanager/snippets/requirements.txt
@@ -1,3 +1,3 @@
 google-cloud-secret-manager==2.21.1
-google-crc32c==1.5.0
+google-crc32c==1.6.0
 protobuf==5.27.5 # https://github.com/googleapis/google-cloud-python/issues/13350#issuecomment-2552109593


### PR DESCRIPTION
## Description

Replaces #12930

Updates google-crc32c dependency, and updates minimum Python version tested from 3.8 (support dropped in google-crc32c 1.6.0) to Python 3.9

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] Please **merge** this PR for me once it is approved