### PR TITLE
chore(gke): migrate region step 1 - update regions adding gke_ prefix and _yaml_python suffix

### DIFF
--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -22,6 +22,7 @@
 # For more info about Deployments:
 #   https://kubernetes.io/docs/user-guide/deployments/
 
+# [START gke_kubernetes_deployment_yaml_python]
 # [START gke_kubernetes_deployment_python]
 apiVersion: apps/v1
 kind: Deployment
@@ -95,7 +96,7 @@ spec:
           emptyDir: {}
       # [END gke_volumes_python]
 # [END gke_kubernetes_deployment_python]
-
+# [END gke_kubernetes_deployment_yaml_python]
 ---
 
 # [START gke_container_poll_service_python]


### PR DESCRIPTION
## Description

Fixes [b/347826199](http://b/347826199)

Associated all region tags with an official product gke and suffix yaml_python.

The yaml word is added in order to respect the pattern mentioned in the [rename region tag](https://g3doc.corp.google.com/company/teams/cloud-devrel/egg/contributing/rename-region-tag.md?cl=head#craft-a-unique-name-for-the-region-tag)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup)) <- Returns 403
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved