### PR TITLE
chore: Update cloud build triggers to use cloud logging only 

### DIFF
--- a/.kokoro/docker/cloudbuild.yaml
+++ b/.kokoro/docker/cloudbuild.yaml
@@ -22,3 +22,6 @@ steps:
       args: ['tag', 'gcr.io/$PROJECT_ID/python-samples-testing-docker', 'gcr.io/$PROJECT_ID/python-samples-testing-docker:$SHORT_SHA']
 images:
      - 'gcr.io/$PROJECT_ID/python-samples-testing-docker'
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Towards b/388782093
Towards https://github.com/GoogleCloudPlatform/python-docs-samples/issues/12728