### PR TITLE
fix(gke): delete old region "gke_kubernetes_deployment_python"

### DIFF
--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -23,7 +23,6 @@
 #   https://kubernetes.io/docs/user-guide/deployments/
 
 # [START gke_kubernetes_deployment_yaml_python]
-# [START gke_kubernetes_deployment_python]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -95,7 +94,6 @@ spec:
         - name: cloudsql
           emptyDir: {}
       # [END gke_volumes_python]
-# [END gke_kubernetes_deployment_python]
 # [END gke_kubernetes_deployment_yaml_python]
 ---
 


### PR DESCRIPTION
## Description

Fixes [b/347826199](http://b/347826199)

Delete old region tag

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup)) <- Returns 403
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved