### PR TITLE
chore(gae): rename regions in standard/storage/appengine-client/main.py

### DIFF
--- a/appengine/standard/storage/appengine-client/main.py
+++ b/appengine/standard/storage/appengine-client/main.py
@@ -95,7 +95,7 @@ class MainPage(webapp2.RequestHandler):
             cloudstorage_file.write("abcde\n")
             cloudstorage_file.write("f" * 1024 * 4 + "\n")
         self.tmp_filenames_to_clean_up.append(filename)
-    # [END wrigae_storage_writete]
+    # [END gae_storage_write]
 
     # [START gae_storage_read]
     def read_file(self, filename):

--- a/appengine/standard/storage/appengine-client/main.py
+++ b/appengine/standard/storage/appengine-client/main.py
@@ -14,32 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START sample]
+# [START gae_storage_sample]
 """A sample app that uses GCS client to operate on bucket and file."""
 
-# [START imports]
+# [START gae_storage_imports]
 import os
 
 import cloudstorage
 from google.appengine.api import app_identity
 
 import webapp2
+# [END gae_storage_imports]
 
-# [END imports]
-
-# [START retries]
 cloudstorage.set_default_retry_params(
     cloudstorage.RetryParams(
         initial_delay=0.2, max_delay=5.0, backoff_factor=2, max_retry_period=15
     )
 )
-# [END retries]
 
 
 class MainPage(webapp2.RequestHandler):
     """Main page for GCS demo application."""
 
-    # [START get_default_bucket]
+    # [START gae_storage_get_default_bucket]
     def get(self):
         bucket_name = os.environ.get(
             "BUCKET_NAME", app_identity.get_default_gcs_bucket_name()
@@ -52,7 +49,7 @@ class MainPage(webapp2.RequestHandler):
             )
         )
         self.response.write("Using bucket name: {}\n\n".format(bucket_name))
-        # [END get_default_bucket]
+        # [END gae_storage_get_default_bucket]
 
         bucket = "/" + bucket_name
         filename = bucket + "/demo-testfile"
@@ -79,7 +76,7 @@ class MainPage(webapp2.RequestHandler):
         self.delete_files()
         self.response.write("\n\nThe demo ran successfully!\n")
 
-    # [START write]
+    # [START gae_storage_write]
     def create_file(self, filename):
         """Create a file."""
 
@@ -98,10 +95,9 @@ class MainPage(webapp2.RequestHandler):
             cloudstorage_file.write("abcde\n")
             cloudstorage_file.write("f" * 1024 * 4 + "\n")
         self.tmp_filenames_to_clean_up.append(filename)
+    # [END wrigae_storage_writete]
 
-    # [END write]
-
-    # [START read]
+    # [START gae_storage_read]
     def read_file(self, filename):
         self.response.write("Abbreviated file content (first line and last 1K):\n")
 
@@ -109,8 +105,7 @@ class MainPage(webapp2.RequestHandler):
             self.response.write(cloudstorage_file.readline())
             cloudstorage_file.seek(-1024, os.SEEK_END)
             self.response.write(cloudstorage_file.read())
-
-    # [END read]
+    # [END gae_storage_read]
 
     def stat_file(self, filename):
         self.response.write("File stat:\n")
@@ -126,7 +121,7 @@ class MainPage(webapp2.RequestHandler):
         for f in filenames:
             self.create_file(f)
 
-    # [START list_bucket]
+    # [START gae_storage_list_bucket]
     def list_bucket(self, bucket):
         """Create several files and paginate through them."""
 
@@ -147,8 +142,7 @@ class MainPage(webapp2.RequestHandler):
             stats = cloudstorage.listbucket(
                 bucket + "/foo", max_keys=page_size, marker=stat.filename
             )
-
-    # [END list_bucket]
+    # [END gae_storage_list_bucket]
 
     def list_bucket_directory_mode(self, bucket):
         self.response.write("Listbucket directory mode result:\n")
@@ -162,7 +156,6 @@ class MainPage(webapp2.RequestHandler):
                     self.response.write("  {}".format(subdir_file))
                     self.response.write("\n")
 
-    # [START delete_files]
     def delete_files(self):
         self.response.write("Deleting files...\n")
         for filename in self.tmp_filenames_to_clean_up:
@@ -173,8 +166,5 @@ class MainPage(webapp2.RequestHandler):
                 pass
 
 
-# [END delete_files]
-
-
 app = webapp2.WSGIApplication([("/", MainPage)], debug=True)
-# [END sample]
+# [END gae_storage_sample]

--- a/appengine/standard/storage/appengine-client/requirements-test.txt
+++ b/appengine/standard/storage/appengine-client/requirements-test.txt
@@ -1,3 +1,8 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
 WebTest==2.0.35; python_version < '3.0'
+# 2025-01-14 - Added support for Python 3
+pytest==8.3.2; python_version >= '3.0'
+WebTest==3.0.1; python_version >= '3.0'
+six==1.16.0
+


### PR DESCRIPTION
## Description

Fixes Internal:
b/347350771
b/347350870
b/347349966
b/347350558
b/347350538
b/347350224
b/347350515

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.12` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved