### PR TITLE
chore: add Cloud SQL samples env vars as secrets

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -108,16 +108,18 @@ fi
 # On kokoro, we should be able to use the default service account. We
 # need to somehow bootstrap the secrets on other CI systems.
 if [[ "${TRAMPOLINE_CI}" == "kokoro" ]]; then
-    # This script will create 4 files:
+    # This script will create 5 files:
     # - testing/test-env.sh
     # - testing/service-account.json
     # - testing/client-secrets.json
     # - testing/cloudai-samples-secrets.sh
+    # - testing/cloudsql-samples-secrets.sh
     ./scripts/decrypt-secrets.sh
 fi
 
 source ./testing/test-env.sh
 source ./testing/cloudai-samples-secrets.sh
+source ./testing/cloudsql-samples-secrets.sh
 export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/testing/service-account.json
 
 # For cloud-run session, we activate the service account for gcloud sdk.
@@ -209,7 +211,7 @@ cd "$ROOT"
 
 # Remove secrets if we used decrypt-secrets.sh.
 if [[ -f "${KOKORO_GFILE_DIR}/secrets_viewer_service_account.json" ]]; then
-    rm testing/{test-env.sh,client-secrets.json,service-account.json,cloudai-samples-secrets.sh}
+    rm testing/{test-env.sh,client-secrets.json,service-account.json,cloudai-samples-secrets.sh,cloudsql-samples-secrets.sh}
 fi
 
 exit "$RTN"

--- a/scripts/decrypt-secrets.sh
+++ b/scripts/decrypt-secrets.sh
@@ -46,3 +46,7 @@ gcloud secrets versions access latest \
        --secret="cloudai-samples-secrets" \
        --project="python-docs-samples-tests" \
        > testing/cloudai-samples-secrets.sh
+gcloud secrets versions access latest \
+       --secret="python-docs-samples-cloud-sql-secrets" \
+       --project="cloud-sql-connector-testing" \
+       > testing/cloudsql-samples-secrets.sh


### PR DESCRIPTION
Add a new secret to store Cloud SQL samples secrets. This secret will be setup as part of the build setup script.

The secret manager secrets live in a project owned by @GoogleCloudPlatform/cloud-sql-connectors who maintain the `/cloud-sql` samples.

Fixes #12987 