### PR TITLE
chore(gae): remove region tag 'form' from HTML templates

### DIFF
--- a/appengine/standard/mailjet/requirements-test.txt
+++ b/appengine/standard/mailjet/requirements-test.txt
@@ -1,4 +1,9 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+
 responses==0.17.0; python_version < '3.7'
 responses==0.23.1; python_version > '3.6'
+
+# pytest==8.3.4 and six==1.17.0 for Python3.
+pytest==8.3.4; python_version >= '3.0'
+six==1.17.0

--- a/appengine/standard/mailjet/templates/index.html
+++ b/appengine/standard/mailjet/templates/index.html
@@ -19,11 +19,9 @@
   <title>Mailjet on Google App Engine</title>
 </head>
 <body>
-<!-- [START form] -->
 <form method="post" action="/send/email">
   <input type="text" name="to" placeholder="Enter recipient email">
   <input type="submit" name="submit" value="Send email">
 </form>
-<!-- [END form] -->
 </body>
 </html>

--- a/appengine/standard/pubsub/requirements-test.txt
+++ b/appengine/standard/pubsub/requirements-test.txt
@@ -1,2 +1,6 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+
+# pytest==8.3.4 and six==1.17.0 for Python3.
+pytest==8.3.4; python_version >= '3.0'
+six==1.17.0

--- a/appengine/standard/pubsub/templates/index.html
+++ b/appengine/standard/pubsub/templates/index.html
@@ -28,11 +28,9 @@
   </ul>
   <p><small>Note: because your application is likely running multiple instances, each instance will have a different list of messages.</small></p>
 </div>
-<!-- [START form] -->
 <form method="post">
   <textarea name="payload" placeholder="Enter message here"></textarea>
   <input type="submit">
 </form>
-<!-- [END form] -->
 </body>
 </html>

--- a/appengine/standard_python3/pubsub/templates/index.html
+++ b/appengine/standard_python3/pubsub/templates/index.html
@@ -42,11 +42,9 @@
   </ul>
   <p><small>Note: because your application is likely running multiple instances, each instance will have a different list of messages.</small></p>
 </div>
-<!-- [START form] -->
 <form method="post">
   <textarea name="payload" placeholder="Enter message here"></textarea>
   <input type="submit">
 </form>
-<!-- [END form] -->
 </body>
 </html>


### PR DESCRIPTION
## Description

Fixes Internal:
b/347350411
b/347349898
b/347350194

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.12` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved