### PR TITLE
fix: remove dataproc/README.md

### DIFF
--- a/dataproc/README.md
+++ b/dataproc/README.md
@@ -1,3 +1,0 @@
-These samples have been moved.
-
-https://github.com/googleapis/python-dataproc/tree/main/samples


### PR DESCRIPTION
these samples were moved to the API directory and then moved back. the readme is incorrect and points to an archived repo
