### PR TITLE
fix: remove invalid video/cloud-client directory

### DIFF
--- a/video/cloud-client/README.rst
+++ b/video/cloud-client/README.rst
@@ -1,3 +1,0 @@
-These samples have been moved.
-
-https://github.com/googleapis/python-videointelligence/tree/main/samples


### PR DESCRIPTION
these samples moved to a different repo and then migrated back under the top level directory of videointelligence. The other directories should probably be examined and merged over to videointelligence as well (and potentially de-duplicated)
