### PR TITLE
chore(gae): delete region tags from standard/migration/urlfetch and remove Python 2 refs

### DIFF
--- a/appengine/standard/migration/urlfetch/async/README.md
+++ b/appengine/standard/migration/urlfetch/async/README.md
@@ -1,6 +1,6 @@
 ## App Engine async urlfetch Replacement
 
-The runtime for App Engine standard for Python 2.7 includes the `urlfetch`
+The runtime for App Engine standard for Python 3 includes the `urlfetch`
 library, which is used to make HTTP(S) requests. There are several related
 capabilities provided by that library:
 
@@ -10,13 +10,7 @@ capabilities provided by that library:
 
 The sample in this directory provides a way to make asynchronous web requests
 using only generally available Python libraries that work in either App Engine
-standard for Python runtime, version 2.7 or 3.7. The sample code is the same
-for each environment.
-
-To deploy and run this sample in App Engine standard for Python 2.7:
-
-    pip install -t lib -r requirements.txt
-    gcloud app deploy
+standard for Python runtime, version 3.7.
 
 To deploy and run this sample in App Engine standard for Python 3.7:
 

--- a/appengine/standard/migration/urlfetch/async/main.py
+++ b/appengine/standard/migration/urlfetch/async/main.py
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START app]
 import logging
 from time import sleep
 
 from flask import Flask
 from flask import make_response
-# [START imports]
 from requests_futures.sessions import FuturesSession
-
-# [END imports]
 
 
 TIMEOUT = 10  # Wait this many seconds for background calls to finish
@@ -30,7 +26,6 @@ app = Flask(__name__)
 
 @app.route("/")  # Fetch and return remote page asynchronously
 def get_async():
-    # [START requests_get]
     session = FuturesSession()
     url = "http://www.google.com/humans.txt"
 
@@ -41,7 +36,6 @@ def get_async():
     resp = make_response(rpc.result().text)
     resp.headers["Content-type"] = "text/plain"
     return resp
-    # [END requests_get]
 
 
 @app.route("/callback")  # Fetch and return remote pages using callback
@@ -103,6 +97,3 @@ def server_error(e):
         ),
         500,
     )
-
-
-# [END app]

--- a/appengine/standard/migration/urlfetch/async/requirements-test.txt
+++ b/appengine/standard/migration/urlfetch/async/requirements-test.txt
@@ -1,2 +1,6 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+
+# pytest==8.3.4 and six==1.17.0 for Python3.
+pytest==8.3.4; python_version >= '3.0'
+six==1.17.0

--- a/appengine/standard/migration/urlfetch/requests/README.md
+++ b/appengine/standard/migration/urlfetch/requests/README.md
@@ -1,6 +1,6 @@
 ## App Engine simple urlfetch Replacement
 
-The runtime for App Engine standard for Python 2.7 includes the `urlfetch`
+The runtime for App Engine standard for Python 3 includes the `urlfetch`
 library, which is used to make HTTP(S) requests. There are several related
 capabilities provided by that library:
 
@@ -10,13 +10,7 @@ capabilities provided by that library:
 
 The sample in this directory provides a way to make straightforward web requests
 using only generally available Python libraries that work in either App Engine
-standard for Python runtime, version 2.7 or 3.7. The sample code is the same
-for each environment.
-
-To deploy and run this sample in App Engine standard for Python 2.7:
-
-    pip install -t lib -r requirements.txt
-    gcloud app deploy
+standard for Python runtime, version 3.7.
 
 To deploy and run this sample in App Engine standard for Python 3.7:
 

--- a/appengine/standard/migration/urlfetch/requests/main.py
+++ b/appengine/standard/migration/urlfetch/requests/main.py
@@ -12,27 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START app]
 import logging
 
 from flask import Flask
 
-# [START imports]
 import requests
 
-# [END imports]
 
 app = Flask(__name__)
 
 
 @app.route("/")
 def index():
-    # [START requests_get]
     url = "http://www.google.com/humans.txt"
     response = requests.get(url)
     response.raise_for_status()
     return response.text
-    # [END requests_get]
 
 
 @app.errorhandler(500)
@@ -47,9 +42,6 @@ def server_error(e):
         ),
         500,
     )
-
-
-# [END app]
 
 
 if __name__ == "__main__":

--- a/appengine/standard/migration/urlfetch/requests/requirements-test.txt
+++ b/appengine/standard/migration/urlfetch/requests/requirements-test.txt
@@ -1,2 +1,6 @@
 # pin pytest to 4.6.11 for Python2.
 pytest==4.6.11; python_version < '3.0'
+
+# pytest==8.3.4 and six==1.17.0 for Python3.
+pytest==8.3.4; python_version >= '3.0'
+six==1.17.0


### PR DESCRIPTION
## Description

Fixes Internal:
b/391880462
b/391881142

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.12` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved