### PR TITLE
chore(deps): bump google-cloud-securitycenter to v1.36.0

### DIFF
--- a/securitycenter/snippets/requirements.txt
+++ b/securitycenter/snippets/requirements.txt
@@ -1,2 +1,2 @@
 google-cloud-pubsub==2.21.5
-google-cloud-securitycenter==1.21.0
+google-cloud-securitycenter==1.36.0


### PR DESCRIPTION
Bumping google-cloud-securitycenter version to latest