### PR TITLE
chore(gae): delete old region tags at django_cloudsql

### DIFF
--- a/appengine/flexible/django_cloudsql/app.yaml
+++ b/appengine/flexible/django_cloudsql/app.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# [START runtime]
 # [START gaeflex_py_django_app_yaml]
 runtime: python
 env: flex
@@ -24,4 +23,3 @@ beta_settings:
 runtime_config:
   python_version: 3.7
 # [END gaeflex_py_django_app_yaml]
-# [END runtime]

--- a/appengine/flexible/django_cloudsql/mysite/settings.py
+++ b/appengine/flexible/django_cloudsql/mysite/settings.py
@@ -109,7 +109,6 @@ WSGI_APPLICATION = "mysite.wsgi.application"
 
 # Database
 
-# [START dbconfig]
 # [START gaeflex_py_django_database_config]
 # Use django-environ to parse the connection string
 DATABASES = {"default": env.db()}
@@ -120,7 +119,6 @@ if os.getenv("USE_CLOUD_SQL_AUTH_PROXY", None):
     DATABASES["default"]["PORT"] = 5432
 
 # [END gaeflex_py_django_database_config]
-# [END dbconfig]
 
 # Use a in-memory sqlite3 database when testing in CI systems
 if os.getenv("TRAMPOLINE_CI", None):
@@ -162,7 +160,6 @@ USE_I18N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-# [START staticurl]
 # [START gaeflex_py_django_static_config]
 # Define static storage via django-storages[google]
 GS_BUCKET_NAME = env("GS_BUCKET_NAME")
@@ -177,7 +174,6 @@ STORAGES = {
 }
 GS_DEFAULT_ACL = "publicRead"
 # [END gaeflex_py_django_static_config]
-# [END staticurl]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/stable/ref/settings/#default-auto-field

--- a/appengine/flexible_python37_and_earlier/django_cloudsql/app.yaml
+++ b/appengine/flexible_python37_and_earlier/django_cloudsql/app.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# [START runtime]
 # [START gaeflex_py_django_app_yaml]
 runtime: python
 env: flex
@@ -24,4 +23,3 @@ beta_settings:
 runtime_config:
   python_version: 3.7
 # [END gaeflex_py_django_app_yaml]
-# [END runtime]

--- a/appengine/flexible_python37_and_earlier/django_cloudsql/mysite/settings.py
+++ b/appengine/flexible_python37_and_earlier/django_cloudsql/mysite/settings.py
@@ -109,7 +109,6 @@ WSGI_APPLICATION = "mysite.wsgi.application"
 
 # Database
 
-# [START dbconfig]
 # [START gaeflex_py_django_database_config]
 # Use django-environ to parse the connection string
 DATABASES = {"default": env.db()}
@@ -120,7 +119,6 @@ if os.getenv("USE_CLOUD_SQL_AUTH_PROXY", None):
     DATABASES["default"]["PORT"] = 5432
 
 # [END gaeflex_py_django_database_config]
-# [END dbconfig]
 
 # Use a in-memory sqlite3 database when testing in CI systems
 if os.getenv("TRAMPOLINE_CI", None):
@@ -163,7 +161,6 @@ USE_L10N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-# [START staticurl]
 # [START gaeflex_py_django_static_config]
 # Define static storage via django-storages[google]
 GS_BUCKET_NAME = env("GS_BUCKET_NAME")
@@ -172,7 +169,6 @@ DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 STATICFILES_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 GS_DEFAULT_ACL = "publicRead"
 # [END gaeflex_py_django_static_config]
-# [END staticurl]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/stable/ref/settings/#default-auto-field


### PR DESCRIPTION
## Description

Fixes Internal:
b/347349906
b/347350693
b/347351000
b/347350159
b/347351033
b/347350809

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved