### PR TITLE
fix(gke): delete unused region tags and start migrating "service" region tag

### DIFF
--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -48,7 +48,6 @@ spec:
         # off in production.
         imagePullPolicy: Always
         env:
-            # [START gke_cloudsql_secrets_python]
             - name: DATABASE_NAME
               valueFrom:
                 secretKeyRef:
@@ -64,11 +63,9 @@ spec:
                 secretKeyRef:
                   name: cloudsql
                   key: password
-            # [END gke_cloudsql_secrets_python]
         ports:
         - containerPort: 8080
       
-      # [START gke_proxy_container_python]
       - image: gcr.io/cloudsql-docker/gce-proxy:1.16
         name: cloudsql-proxy
         command: ["/cloud_sql_proxy", "--dir=/cloudsql",
@@ -82,8 +79,6 @@ spec:
             mountPath: /etc/ssl/certs
           - name: cloudsql
             mountPath: /cloudsql
-      # [END gke_proxy_container_python]
-      # [START gke_volumes_python]
       volumes:
         - name: cloudsql-oauth-credentials
           secret:
@@ -93,10 +88,10 @@ spec:
             path: /etc/ssl/certs
         - name: cloudsql
           emptyDir: {}
-      # [END gke_volumes_python]
 # [END gke_kubernetes_deployment_yaml_python]
 ---
 
+# [START gke_kubernetes_service_yaml_python]
 # [START gke_container_poll_service_python]
 # The polls service provides a load-balancing proxy over the polls app
 # pods. By specifying the type as a 'LoadBalancer', Kubernetes Engine will
@@ -119,3 +114,4 @@ spec:
   selector:
     app: polls
 # [END gke_container_poll_service_python]
+# [END gke_kubernetes_service_yaml_python]


### PR DESCRIPTION
## Description
- Delete unused region tags 
- Start migrating region tag "service" 

Fixes
[b/347350469](https://b.corp.google.com/issues/347350469)
[b/347350500](https://b.corp.google.com/issues/347350500)
[b/347350953](https://b.corp.google.com/issues/347350953)
[b/393167940](https://b.corp.google.com/issues/393167940)

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup)) <- Returns 403
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved