### PR TITLE
chore(gke): delete old region tags from django_tutorial

### DIFF
--- a/kubernetes_engine/django_tutorial/Dockerfile
+++ b/kubernetes_engine/django_tutorial/Dockerfile
@@ -11,8 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START docker]
-
 # The Google App Engine python runtime is Debian Jessie with Python installed
 # and various os-level packages to allow installation of popular Python
 # libraries. The source is on github at:
@@ -29,4 +27,3 @@ RUN /env/bin/pip install --upgrade pip && /env/bin/pip install -r /app/requireme
 ADD . /app
 
 CMD gunicorn -b :$PORT mysite.wsgi
-# [END docker]

--- a/kubernetes_engine/django_tutorial/mysite/settings.py
+++ b/kubernetes_engine/django_tutorial/mysite/settings.py
@@ -76,7 +76,6 @@ WSGI_APPLICATION = "mysite.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/stable/ref/settings/#databases
 
-# [START dbconfig]
 # [START gke_django_database_config]
 DATABASES = {
     "default": {
@@ -91,7 +90,6 @@ DATABASES = {
     }
 }
 # [END gke_django_database_config]
-# [END dbconfig]
 
 # Internationalization
 # https://docs.djangoproject.com/en/stable/topics/i18n/


### PR DESCRIPTION
## Description

Fixes Internal:
b/347350154
b/347350144

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved