### PR TITLE
feat(genai): add python samples for text generation

### DIFF
--- a/genai/text_generation/noxfile_config.py
+++ b/genai/text_generation/noxfile_config.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default TEST_CONFIG_OVERRIDE for python repos.
+
+# You can copy this file into your directory, then it will be imported from
+# the noxfile.py.
+
+# The source of truth:
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/noxfile_config.py
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    # Old samples are opted out of enforcing Python type hints
+    # All new samples should feature them
+    "enforce_type_hints": True,
+    # An envvar key for determining the project id to use. Change it
+    # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
+    # build specific Cloud project. You can also use your own string
+    # to use your own Cloud project.
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    # If you need to use a specific version of pip,
+    # change pip_version_override to the string representation
+    # of the version number, for example, "20.2.4"
+    "pip_version_override": None,
+    # A dictionary you want to inject into your test. Don't put any
+    # secrets here. These values will override predefined values.
+    "envs": {},
+}

--- a/genai/text_generation/requirements-test.txt
+++ b/genai/text_generation/requirements-test.txt
@@ -1,0 +1,2 @@
+google-api-core==2.24.0
+pytest==8.2.0

--- a/genai/text_generation/requirements.txt
+++ b/genai/text_generation/requirements.txt
@@ -1,0 +1,1 @@
+google-genai==0.6.0

--- a/genai/text_generation/requirements.txt
+++ b/genai/text_generation/requirements.txt
@@ -1,1 +1,1 @@
-google-genai==0.6.0
+google-genai==0.7.0

--- a/genai/text_generation/test_text_generation.py
+++ b/genai/text_generation/test_text_generation.py
@@ -14,12 +14,6 @@
 
 import os
 
-from typing import Generator
-
-from google import genai
-
-import pytest
-
 import textgen_chat_with_txt
 import textgen_chat_with_txt_stream
 import textgen_with_txt
@@ -27,26 +21,10 @@ import textgen_with_txt_img
 import textgen_with_txt_stream
 
 
-PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-
-
-@pytest.fixture(autouse=True)
-def setup_client() -> Generator[None, None, None]:
-    original_Client = genai.Client
-
-    class AutoInitClient(original_Client):
-        def __new__(cls, *args, **kwargs) -> genai.Client:  # noqa: ANN002 ANN003
-            return original_Client(
-                vertexai=True,
-                project=PROJECT_ID,
-                location="us-central1"
-            )
-
-    genai.Client = AutoInitClient
-
-    yield
-
-    genai.Client = original_Client
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+os.environ["GOOGLE_CLOUD_LOCATION"] = "us-central1"
+# The project name is included in the CICD pipeline
+# os.environ['GOOGLE_CLOUD_PROJECT'] = "add-your-project-name"
 
 
 def test_textgen_with_txt() -> None:

--- a/genai/text_generation/test_text_generation.py
+++ b/genai/text_generation/test_text_generation.py
@@ -12,11 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from google import genai
+
+import pytest
+
 import textgen_chat_with_txt
 import textgen_chat_with_txt_stream
 import textgen_with_txt
 import textgen_with_txt_img
 import textgen_with_txt_stream
+
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+@pytest.fixture(autouse=True)
+def setup_client():
+    original_Client = genai.Client
+
+    class AutoInitClient(original_Client):
+        def __new__(cls, *args, **kwargs):
+            return original_Client(
+                vertexai=True,
+                project=PROJECT_ID,
+                location="us-central1"
+            )
+
+    genai.Client = AutoInitClient
+
+    yield
+
+    genai.Client = original_Client
 
 
 def test_textgen_with_txt() -> None:

--- a/genai/text_generation/test_text_generation.py
+++ b/genai/text_generation/test_text_generation.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import textgen_chat_with_txt
+import textgen_chat_with_txt_stream
 import textgen_with_txt
 import textgen_with_txt_img
 import textgen_with_txt_stream
-import textgen_chat_with_txt
-import textgen_chat_with_txt_stream
 
 
 def test_textgen_with_txt() -> None:

--- a/genai/text_generation/test_text_generation.py
+++ b/genai/text_generation/test_text_generation.py
@@ -14,6 +14,8 @@
 
 import os
 
+from typing import Any, Generator
+
 from google import genai
 
 import pytest
@@ -29,11 +31,11 @@ PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
 
 
 @pytest.fixture(autouse=True)
-def setup_client():
+def setup_client() -> Generator[None, None, None]:
     original_Client = genai.Client
 
     class AutoInitClient(original_Client):
-        def __new__(cls, *args, **kwargs):
+        def __new__(cls, *args: Any, **kwargs: Any) -> genai.Client:
             return original_Client(
                 vertexai=True,
                 project=PROJECT_ID,

--- a/genai/text_generation/test_text_generation.py
+++ b/genai/text_generation/test_text_generation.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textgen_with_txt
+import textgen_with_txt_img
+import textgen_with_txt_stream
+import textgen_chat_with_txt
+import textgen_chat_with_txt_stream
+
+
+def test_textgen_with_txt() -> None:
+    response = textgen_with_txt.generate_content()
+    assert response
+
+
+def test_textgen_with_txt_img() -> None:
+    response = textgen_with_txt_img.generate_content()
+    assert response
+
+
+def test_textgen_with_txt_stream() -> None:
+    response = textgen_with_txt_stream.generate_content()
+    assert response
+
+
+def test_textgen_chat_with_txt() -> None:
+    response = textgen_chat_with_txt.generate_content()
+    assert response
+
+
+def test_textgen_chat_with_txt_stream() -> None:
+    response = textgen_chat_with_txt_stream.generate_content()
+    assert response

--- a/genai/text_generation/test_text_generation.py
+++ b/genai/text_generation/test_text_generation.py
@@ -16,6 +16,8 @@ import os
 
 import textgen_chat_with_txt
 import textgen_chat_with_txt_stream
+import textgen_config_with_txt
+import textgen_sys_instr_with_txt
 import textgen_with_txt
 import textgen_with_txt_img
 import textgen_with_txt_stream
@@ -49,4 +51,14 @@ def test_textgen_chat_with_txt() -> None:
 
 def test_textgen_chat_with_txt_stream() -> None:
     response = textgen_chat_with_txt_stream.generate_content()
+    assert response
+
+
+def test_textgen_config_with_txt() -> None:
+    response = textgen_config_with_txt.generate_content()
+    assert response
+
+
+def test_textgen_sys_instr_with_txt() -> None:
+    response = textgen_sys_instr_with_txt.generate_content()
     assert response

--- a/genai/text_generation/test_text_generation.py
+++ b/genai/text_generation/test_text_generation.py
@@ -14,7 +14,7 @@
 
 import os
 
-from typing import Any, Generator
+from typing import Generator
 
 from google import genai
 
@@ -35,7 +35,7 @@ def setup_client() -> Generator[None, None, None]:
     original_Client = genai.Client
 
     class AutoInitClient(original_Client):
-        def __new__(cls, *args: Any, **kwargs: Any) -> genai.Client:
+        def __new__(cls, *args, **kwargs) -> genai.Client:  # noqa: ANN002 ANN003
             return original_Client(
                 vertexai=True,
                 project=PROJECT_ID,

--- a/genai/text_generation/textgen_chat_with_txt.py
+++ b/genai/text_generation/textgen_chat_with_txt.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content() -> str:
+    # [START googlegenaisdk_textgen_chat_with_txt]
+    from google import genai
+    from google.genai.types import Content, Part
+
+    client = genai.Client()
+    chat = client.chats.create(
+        model="gemini-2.0-flash-001",
+        history=[
+            Content(
+                parts=[Part(text="Hello")],
+                role="user"
+            ),
+            Content(
+                parts=[Part(text="Great to meet you. What would you like to know?")],
+                role="model"
+            )
+        ]
+    )
+    response = chat.send_message("tell me a story")
+    print(response.text)
+    # Example response:
+    # Okay, here's a story for you:
+    # ...
+    # [END googlegenaisdk_textgen_chat_with_txt]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/genai/text_generation/textgen_chat_with_txt_stream.py
+++ b/genai/text_generation/textgen_chat_with_txt_stream.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content() -> str:
+    # [START googlegenaisdk_textgen_chat_with_txt_stream]
+    from google import genai
+
+    client = genai.Client()
+    chat = client.chats.create(model="gemini-2.0-flash-001")
+    response_text = ""
+
+    for chunk in chat.send_message_stream("Why is the sky blue?"):
+        print(chunk.text)
+        response_text += chunk.text
+    # Example response:
+    # The
+    #  sky appears blue due to a phenomenon called **Rayleigh scattering**. Here's
+    #  a breakdown of why:
+    # ...
+    # [END googlegenaisdk_textgen_chat_with_txt_stream]
+    return response_text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/genai/text_generation/textgen_config_with_txt.py
+++ b/genai/text_generation/textgen_config_with_txt.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content() -> str:
+    # [START googlegenaisdk_textgen_config_with_txt]
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client()
+    response = client.models.generate_content(
+        model="gemini-2.0-flash-001",
+        contents="Why is the sky blue?",
+        # See the documentation: https://googleapis.github.io/python-genai/genai.html#genai.types.GenerateContentConfig
+        config=types.GenerateContentConfig(
+            temperature=0,
+            candidate_count=1,
+            response_mime_type="application/json"
+        )
+    )
+    print(response.text)
+    # Example response:
+    # {
+    #   "explanation": "The sky appears blue due to a phenomenon called Rayleigh scattering. When ...
+    # }
+    # [END googlegenaisdk_textgen_config_with_txt]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/genai/text_generation/textgen_sys_instr_with_txt.py
+++ b/genai/text_generation/textgen_sys_instr_with_txt.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content() -> str:
+    # [START googlegenaisdk_textgen_sys_instr_with_txt]
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client()
+    response = client.models.generate_content(
+        model="gemini-2.0-flash-001",
+        contents="Why is the sky blue?",
+        config=types.GenerateContentConfig(
+            system_instruction=[
+                "You're a language translator.",
+                "Your mission is to translate text in English to French."
+            ]
+        )
+    )
+    print(response.text)
+    # Example response:
+    # Pourquoi le ciel est-il bleu ?
+    # [END googlegenaisdk_textgen_sys_instr_with_txt]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/genai/text_generation/textgen_with_txt.py
+++ b/genai/text_generation/textgen_with_txt.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content() -> str:
+    # [START googlegenaisdk_textgen_with_txt]
+    from google import genai
+
+    client = genai.Client()
+    response = client.models.generate_content(
+        model="gemini-2.0-flash-001",
+        contents="How does AI work?"
+    )
+    print(response.text)
+    # Example response:
+    # Okay, let's break down how AI works. It's a broad field, so I'll focus on the ...
+    #
+    # Here's a simplified overview:
+    # ...
+    # [END googlegenaisdk_textgen_with_txt]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/genai/text_generation/textgen_with_txt_img.py
+++ b/genai/text_generation/textgen_with_txt_img.py
@@ -1,0 +1,40 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content() -> str:
+    # [START googlegenaisdk_textgen_with_txt_img]
+    from google import genai
+    from google.genai.types import Part
+
+    client = genai.Client()
+    response = client.models.generate_content(
+        model="gemini-2.0-flash-001",
+        contents=[
+            "What is shown in this image?",
+            Part.from_uri(
+                file_uri="gs://cloud-samples-data/generative-ai/image/scones.jpg",
+                mime_type="image/jpeg"
+            )
+        ]
+    )
+    print(response.text)
+    # Example response:
+    # The image shows a flat lay of blueberry scones arranged on parchment paper. There are ...
+    # [END googlegenaisdk_textgen_with_txt_img]
+    return response.text
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/genai/text_generation/textgen_with_txt_stream.py
+++ b/genai/text_generation/textgen_with_txt_stream.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def generate_content() -> str:
+    # [START googlegenaisdk_textgen_with_txt_stream]
+    from google import genai
+
+    client = genai.Client()
+    response_text = ""
+
+    for chunk in client.models.generate_content_stream(
+        model="gemini-2.0-flash-001",
+        contents="Why is the sky blue?"
+    ):
+        print(chunk.text)
+        response_text += chunk.text
+    # Example response:
+    # The
+    #  sky appears blue due to a phenomenon called **Rayleigh scattering**. Here's
+    #  a breakdown of why:
+    # ...
+    # [END googlegenaisdk_textgen_with_txt_stream]
+    return response_text
+
+
+if __name__ == "__main__":
+    generate_content()


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.12` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
