### PR TITLE
chore(gke): delete old region tag "gke_kubernetes_service_python"

### DIFF
--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -92,7 +92,6 @@ spec:
 ---
 
 # [START gke_kubernetes_service_yaml_python]
-# [START gke_container_poll_service_python]
 # The polls service provides a load-balancing proxy over the polls app
 # pods. By specifying the type as a 'LoadBalancer', Kubernetes Engine will
 # create an external HTTP load balancer.
@@ -113,5 +112,4 @@ spec:
     targetPort: 8080
   selector:
     app: polls
-# [END gke_container_poll_service_python]
 # [END gke_kubernetes_service_yaml_python]


### PR DESCRIPTION
## Description
Delete old region tag "gke_kubernetes_service_python" from kubernetes_engine/django_tutorial/polls.yaml

Fixes
b/393167940

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup)) <- Returns 403
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved