### PR TITLE
chore(endpoints): migrate region tag step 3 - delete old region tag in openapi-appengine.yaml

### DIFF
--- a/endpoints/getting-started/openapi-appengine.yaml
+++ b/endpoints/getting-started/openapi-appengine.yaml
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 # [START endpoints_swagger_appengine_yaml_python]
-# [START endpoints_swagger_yaml_python]
 swagger: "2.0"
 info:
   description: "A simple Google Cloud Endpoints API example."
   title: "Endpoints Example"
   version: "1.0.0"
 host: "YOUR-PROJECT-ID.appspot.com"
-# [END endpoints_swagger_yaml_python]
 # [END endpoints_swagger_appengine_yaml_python]
 consumes:
 - "application/json"


### PR DESCRIPTION
## Description

Fixes Internal: b/393578122

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.13` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved