### PR TITLE
feat(cloud-sql): enable lazy refresh for postgres, mysql and sql server connectors

### DIFF
--- a/cloud-sql/mysql/sqlalchemy/connect_connector.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector.py
@@ -42,7 +42,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
     refresh_strategy = RefreshStrategy.LAZY
 
-    connector = Connector(ip_type = ip_type, refresh_strategy = refresh_strategy)
+    connector = Connector(ip_type=ip_type, refresh_strategy=refresh_strategy)
 
     def getconn() -> pymysql.connections.Connection:
         conn: pymysql.connections.Connection = connector.connect(

--- a/cloud-sql/mysql/sqlalchemy/connect_connector.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector.py
@@ -41,11 +41,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
 
-    # setting the refresh strategy to LAZY
-    # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to
-    # avoid background refreshes from throttling CPU.
-
+    # initialize Cloud SQL Python Connector object
     connector = Connector(ip_type=ip_type, refresh_strategy="LAZY")
 
     def getconn() -> pymysql.connections.Connection:

--- a/cloud-sql/mysql/sqlalchemy/connect_connector.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_mysql_sqlalchemy_connect_connector]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes
+from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
 import pymysql
 
 import sqlalchemy
@@ -40,8 +40,9 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
+    refresh_strategy = RefreshStrategy.LAZY
 
-    connector = Connector(ip_type)
+    connector = Connector(ip_type = ip_type, refresh_strategy = refresh_strategy)
 
     def getconn() -> pymysql.connections.Connection:
         conn: pymysql.connections.Connection = connector.connect(

--- a/cloud-sql/mysql/sqlalchemy/connect_connector.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector.py
@@ -43,7 +43,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
 
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to 
+    # this is recommended for serverless environments to
     # avoid background refreshes from throttling CPU.
 
     connector = Connector(ip_type=ip_type, refresh_strategy="LAZY")

--- a/cloud-sql/mysql/sqlalchemy/connect_connector.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_mysql_sqlalchemy_connect_connector]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
+from google.cloud.sql.connector import Connector, IPTypes
 import pymysql
 
 import sqlalchemy
@@ -40,9 +40,13 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    refresh_strategy = RefreshStrategy.LAZY
 
-    connector = Connector(ip_type=ip_type, refresh_strategy=refresh_strategy)
+    # setting the refresh strategy to LAZY
+    # to refresh the tokens when they are needed, rather than on a regular interval
+    # this is recommended for serverless environments to 
+    # avoid background refreshes from throttling CPU.
+
+    connector = Connector(ip_type=ip_type, refresh_strategy="LAZY")
 
     def getconn() -> pymysql.connections.Connection:
         conn: pymysql.connections.Connection = connector.connect(

--- a/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -41,7 +41,7 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     refresh_strategy = RefreshStrategy.LAZY
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector(refresh_strategy = refresh_strategy)
+    connector = Connector(refresh_strategy=refresh_strategy)
 
     def getconn() -> pymysql.connections.Connection:
         conn: pymysql.connections.Connection = connector.connect(

--- a/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_mysql_sqlalchemy_auto_iam_authn]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes
+from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
 import pymysql
 
 import sqlalchemy
@@ -38,9 +38,10 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
+    refresh_strategy = RefreshStrategy.LAZY
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector()
+    connector = Connector(refresh_strategy = refresh_strategy)
 
     def getconn() -> pymysql.connections.Connection:
         conn: pymysql.connections.Connection = connector.connect(

--- a/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_mysql_sqlalchemy_auto_iam_authn]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
+from google.cloud.sql.connector import Connector, IPTypes
 import pymysql
 
 import sqlalchemy
@@ -38,10 +38,14 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    refresh_strategy = RefreshStrategy.LAZY
+    
+    # setting the refresh strategy to LAZY
+    # to refresh the tokens when they are needed, rather than on a regular interval
+    # this is recommended for serverless environments to 
+    # avoid background refreshes from throttling CPU.
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector(refresh_strategy=refresh_strategy)
+    connector = Connector(refresh_strategy="LAZY")
 
     def getconn() -> pymysql.connections.Connection:
         conn: pymysql.connections.Connection = connector.connect(

--- a/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -41,7 +41,7 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to 
+    # this is recommended for serverless environments to
     # avoid background refreshes from throttling CPU.
 
     # initialize Cloud SQL Python Connector object

--- a/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -39,11 +39,6 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
 
-    # setting the refresh strategy to LAZY
-    # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to
-    # avoid background refreshes from throttling CPU.
-
     # initialize Cloud SQL Python Connector object
     connector = Connector(refresh_strategy="LAZY")
 

--- a/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/mysql/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -38,7 +38,7 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    
+
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
     # this is recommended for serverless environments to

--- a/cloud-sql/postgres/sqlalchemy/connect_connector.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_postgres_sqlalchemy_connect_connector]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes
+from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
 import pg8000
 
 import sqlalchemy
@@ -40,9 +40,10 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
+    refresh_strategy = RefreshStrategy.LAZY
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector()
+    connector = Connector(refresh_strategy = refresh_strategy)
 
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(

--- a/cloud-sql/postgres/sqlalchemy/connect_connector.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector.py
@@ -43,7 +43,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to 
+    # this is recommended for serverless environments to
     # avoid background refreshes from throttling CPU.
 
     # initialize Cloud SQL Python Connector object

--- a/cloud-sql/postgres/sqlalchemy/connect_connector.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector.py
@@ -41,11 +41,6 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
 
-    # setting the refresh strategy to LAZY
-    # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to
-    # avoid background refreshes from throttling CPU.
-
     # initialize Cloud SQL Python Connector object
     connector = Connector(refresh_strategy="LAZY")
 

--- a/cloud-sql/postgres/sqlalchemy/connect_connector.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_postgres_sqlalchemy_connect_connector]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
+from google.cloud.sql.connector import Connector, IPTypes
 import pg8000
 
 import sqlalchemy
@@ -40,10 +40,14 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    refresh_strategy = RefreshStrategy.LAZY
+    
+    # setting the refresh strategy to LAZY
+    # to refresh the tokens when they are needed, rather than on a regular interval
+    # this is recommended for serverless environments to 
+    # avoid background refreshes from throttling CPU.
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector(refresh_strategy=refresh_strategy)
+    connector = Connector(refresh_strategy="LAZY")
 
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(

--- a/cloud-sql/postgres/sqlalchemy/connect_connector.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector.py
@@ -43,7 +43,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     refresh_strategy = RefreshStrategy.LAZY
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector(refresh_strategy = refresh_strategy)
+    connector = Connector(refresh_strategy=refresh_strategy)
 
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(

--- a/cloud-sql/postgres/sqlalchemy/connect_connector.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector.py
@@ -40,7 +40,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    
+
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
     # this is recommended for serverless environments to

--- a/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_postgres_sqlalchemy_auto_iam_authn]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
+from google.cloud.sql.connector import Connector, IPTypes
 import pg8000
 
 import sqlalchemy
@@ -38,10 +38,13 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    refresh_strategy = RefreshStrategy.LAZY
 
+    # setting the refresh strategy to LAZY
+    # to refresh the tokens when they are needed, rather than on a regular interval
+    # this is recommended for serverless environments to 
+    # avoid background refreshes from throttling CPU.
     # initialize Cloud SQL Python Connector object
-    connector = Connector(refresh_strategy=refresh_strategy)
+    connector = Connector(refresh_strategy="LAZY")
 
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(

--- a/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_postgres_sqlalchemy_auto_iam_authn]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes
+from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
 import pg8000
 
 import sqlalchemy
@@ -38,9 +38,10 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
+    refresh_strategy = RefreshStrategy.LAZY
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector()
+    connector = Connector(refresh_strategy = refresh_strategy)
 
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(

--- a/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -41,7 +41,7 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
 
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to 
+    # this is recommended for serverless environments to
     # avoid background refreshes from throttling CPU.
     # initialize Cloud SQL Python Connector object
     connector = Connector(refresh_strategy="LAZY")

--- a/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -41,7 +41,7 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
     refresh_strategy = RefreshStrategy.LAZY
 
     # initialize Cloud SQL Python Connector object
-    connector = Connector(refresh_strategy = refresh_strategy)
+    connector = Connector(refresh_strategy=refresh_strategy)
 
     def getconn() -> pg8000.dbapi.Connection:
         conn: pg8000.dbapi.Connection = connector.connect(

--- a/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
+++ b/cloud-sql/postgres/sqlalchemy/connect_connector_auto_iam_authn.py
@@ -39,10 +39,6 @@ def connect_with_connector_auto_iam_authn() -> sqlalchemy.engine.base.Engine:
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
 
-    # setting the refresh strategy to LAZY
-    # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to
-    # avoid background refreshes from throttling CPU.
     # initialize Cloud SQL Python Connector object
     connector = Connector(refresh_strategy="LAZY")
 

--- a/cloud-sql/sql-server/sqlalchemy/connect_connector.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_connector.py
@@ -41,11 +41,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
 
-    # setting the refresh strategy to LAZY
-    # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to
-    # avoid background refreshes from throttling CPU.
-
+    # initialize Cloud SQL Python Connector object
     connector = Connector(ip_type=ip_type, refresh_strategy="LAZY")
 
     connect_args = {}

--- a/cloud-sql/sql-server/sqlalchemy/connect_connector.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_connector.py
@@ -42,7 +42,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
     refresh_strategy = RefreshStrategy.LAZY
 
-    connector = Connector(ip_type = ip_type, refresh_strategy = refresh_strategy)
+    connector = Connector(ip_type=ip_type, refresh_strategy=refresh_strategy)
 
     connect_args = {}
     # If your SQL Server instance requires SSL, you need to download the CA

--- a/cloud-sql/sql-server/sqlalchemy/connect_connector.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_connector.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_sqlserver_sqlalchemy_connect_connector]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes
+from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
 import pytds
 
 import sqlalchemy
@@ -40,8 +40,9 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
+    refresh_strategy = RefreshStrategy.LAZY
 
-    connector = Connector(ip_type)
+    connector = Connector(ip_type = ip_type, refresh_strategy = refresh_strategy)
 
     connect_args = {}
     # If your SQL Server instance requires SSL, you need to download the CA

--- a/cloud-sql/sql-server/sqlalchemy/connect_connector.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_connector.py
@@ -15,7 +15,7 @@
 # [START cloud_sql_sqlserver_sqlalchemy_connect_connector]
 import os
 
-from google.cloud.sql.connector import Connector, IPTypes, RefreshStrategy
+from google.cloud.sql.connector import Connector, IPTypes
 import pytds
 
 import sqlalchemy
@@ -40,9 +40,13 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    refresh_strategy = RefreshStrategy.LAZY
+    
+    # setting the refresh strategy to LAZY
+    # to refresh the tokens when they are needed, rather than on a regular interval
+    # this is recommended for serverless environments to 
+    # avoid background refreshes from throttling CPU.
 
-    connector = Connector(ip_type=ip_type, refresh_strategy=refresh_strategy)
+    connector = Connector(ip_type=ip_type, refresh_strategy="LAZY")
 
     connect_args = {}
     # If your SQL Server instance requires SSL, you need to download the CA

--- a/cloud-sql/sql-server/sqlalchemy/connect_connector.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_connector.py
@@ -40,7 +40,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     db_name = os.environ["DB_NAME"]  # e.g. 'my-database'
 
     ip_type = IPTypes.PRIVATE if os.environ.get("PRIVATE_IP") else IPTypes.PUBLIC
-    
+
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
     # this is recommended for serverless environments to

--- a/cloud-sql/sql-server/sqlalchemy/connect_connector.py
+++ b/cloud-sql/sql-server/sqlalchemy/connect_connector.py
@@ -43,7 +43,7 @@ def connect_with_connector() -> sqlalchemy.engine.base.Engine:
     
     # setting the refresh strategy to LAZY
     # to refresh the tokens when they are needed, rather than on a regular interval
-    # this is recommended for serverless environments to 
+    # this is recommended for serverless environments to
     # avoid background refreshes from throttling CPU.
 
     connector = Connector(ip_type=ip_type, refresh_strategy="LAZY")


### PR DESCRIPTION
Enabled lazy refresh for the Python Cloud SQL connector (Postgres, MySQL, and SQL Server). 