### PR TITLE
fix: update suggested video for summarization

### DIFF
--- a/generative_ai/video/gemini_youtube_video_summarization_example.py
+++ b/generative_ai/video/gemini_youtube_video_summarization_example.py
@@ -30,7 +30,7 @@ def generate_content() -> str:
         # Text prompt
         "Summarize this video.",
         # YouTube video of Google Pixel 9
-        Part.from_uri("https://youtu.be/sXrasaDZxw0", "video/mp4"),
+        Part.from_uri("https://youtu.be/MsAPm8TCFhU", "video/mp4"),
     ]
 
     response = model.generate_content(contents)


### PR DESCRIPTION
Fixes test failures for generative_ai/video (e.g. https://github.com/GoogleCloudPlatform/python-docs-samples/pull/13152)

Updates the sample video being used for summarization. The original video was marked private, this is another video of a similar type from the same channel (Made with Google). 

- [x] Please **merge** this PR for me once it is approved