### PR TITLE
chore(datacatalog): skip tests for deprecated Data Catalog

### DIFF
--- a/datacatalog/quickstart/quickstart_test.py
+++ b/datacatalog/quickstart/quickstart_test.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 
 import quickstart
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_quickstart(
     capsys, client, project_id, dataset_id, table_id, random_tag_template_id
 ):

--- a/datacatalog/snippets/create_custom_entry_test.py
+++ b/datacatalog/snippets/create_custom_entry_test.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
 
 import create_custom_entry
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_create_custom_entry(
     capsys,
     client,

--- a/datacatalog/snippets/create_fileset_test.py
+++ b/datacatalog/snippets/create_fileset_test.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import create_fileset
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_create_fileset(
     capsys,
     client,

--- a/datacatalog/snippets/data_catalog_ptm_create_taxonomy_test.py
+++ b/datacatalog/snippets/data_catalog_ptm_create_taxonomy_test.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import data_catalog_ptm_create_taxonomy
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_create_taxonomy(capsys, project_id: str, random_taxonomy_display_name: str):
     data_catalog_ptm_create_taxonomy.create_taxonomy(
         project_id=project_id,

--- a/datacatalog/snippets/grant_tag_template_user_role_test.py
+++ b/datacatalog/snippets/grant_tag_template_user_role_test.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import grant_tag_template_user_role
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_grant_tag_template_user_role(
     capsys, project_id, random_existing_tag_template_id, valid_member_id
 ):

--- a/datacatalog/snippets/lookup_entry_test.py
+++ b/datacatalog/snippets/lookup_entry_test.py
@@ -16,6 +16,8 @@
 
 import re
 
+import pytest
+
 import lookup_entry
 
 BIGQUERY_PROJECT = "bigquery-public-data"
@@ -26,6 +28,7 @@ PUBSUB_PROJECT = "pubsub-public-data"
 PUBSUB_TOPIC = "taxirides-realtime"
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_lookup_entry(capsys):
     override_values = {
         "bigquery_project_id": BIGQUERY_PROJECT,

--- a/datacatalog/snippets/search_assets_test.py
+++ b/datacatalog/snippets/search_assets_test.py
@@ -17,7 +17,7 @@ import pytest
 import search_assets
 
 
-@pytest.mark.skip(reason="Needs fixing by CODEOWNER - issue #8541")
+@pytest.mark.skip(reason="deprecated service")
 def test_search_assets(capsys, project_id, random_existing_tag_template_id):
     override_values = {
         "project_id": project_id,

--- a/datacatalog/v1beta1/test_create_entry_group.py
+++ b/datacatalog/v1beta1/test_create_entry_group.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import create_entry_group
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_create_entry_group(capsys, client, project_id, random_entry_group_id):
     create_entry_group.create_entry_group(project_id, random_entry_group_id)
     out, err = capsys.readouterr()

--- a/datacatalog/v1beta1/test_create_fileset_entry.py
+++ b/datacatalog/v1beta1/test_create_fileset_entry.py
@@ -15,9 +15,12 @@
 
 import re
 
+import pytest
+
 import create_fileset_entry
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_create_fileset_entry(capsys, client, random_entry_name):
     entry_name_pattern = "(?P<entry_group_name>.+?)/entries/(?P<entry_id>.+?$)"
     entry_name_matches = re.match(entry_name_pattern, random_entry_name)

--- a/datacatalog/v1beta1/test_get_entry.py
+++ b/datacatalog/v1beta1/test_get_entry.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import get_entry
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_get_entry(client, entry):
     # break entry name into parts
     name = client.parse_entry_path(entry)

--- a/datacatalog/v1beta1/test_lookup_entry.py
+++ b/datacatalog/v1beta1/test_lookup_entry.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import lookup_entry
 
@@ -19,6 +19,7 @@ BIGQUERY_PROJECT = "bigquery-public-data"
 BIGQUERY_DATASET = "new_york_taxi_trips"
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_lookup_entry(client, entry, project_id):
     bigquery_dataset = f"projects/{BIGQUERY_PROJECT}/datasets/{BIGQUERY_DATASET}"
     resource_name = f"//bigquery.googleapis.com/{bigquery_dataset}"

--- a/datacatalog/v1beta1/test_lookup_entry_sql_resource.py
+++ b/datacatalog/v1beta1/test_lookup_entry_sql_resource.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import lookup_entry_sql_resource
 
@@ -19,6 +19,7 @@ BIGQUERY_PROJECT = "bigquery-public-data"
 BIGQUERY_DATASET = "new_york_taxi_trips"
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_lookup_entry():
     sql_name = f"bigquery.dataset.`{BIGQUERY_PROJECT}`.`{BIGQUERY_DATASET}`"
     resource_name = f"//bigquery.googleapis.com/projects/{BIGQUERY_PROJECT}/datasets/{BIGQUERY_DATASET}"

--- a/datacatalog/v1beta1/test_search.py
+++ b/datacatalog/v1beta1/test_search.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import pytest
 
 import search
 
 
+@pytest.mark.skip(reason="deprecated service")
 def test_search_catalog(client, project_id, entry_group_name):
     results = search.sample_search_catalog(
         project_id, False, f"name:{entry_group_name}"


### PR DESCRIPTION
## Description

Fixes b/394006908

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved