### PR TITLE
docs(genai): Add `audio_timestamp` parameter for Audio Understanding

### DIFF
--- a/genai/text_generation/textgen_transcript_with_gcs_audio.py
+++ b/genai/text_generation/textgen_transcript_with_gcs_audio.py
@@ -16,7 +16,7 @@
 def generate_content() -> str:
     # [START googlegenaisdk_textgen_transcript_with_gcs_audio]
     from google import genai
-    from google.genai.types import HttpOptions, Part
+    from google.genai.types import GenerateContentConfig, HttpOptions, Part
 
     client = genai.Client(http_options=HttpOptions(api_version="v1"))
     prompt = """
@@ -32,6 +32,8 @@ def generate_content() -> str:
                 mime_type="audio/mpeg",
             ),
         ],
+        # Required to enable timestamp understanding for audio-only files
+        config=GenerateContentConfig(audio_timestamp=True),
     )
     print(response.text)
     # Example response:

--- a/genai/text_generation/textgen_with_gcs_audio.py
+++ b/genai/text_generation/textgen_with_gcs_audio.py
@@ -16,7 +16,7 @@
 def generate_content() -> str:
     # [START googlegenaisdk_textgen_with_gcs_audio]
     from google import genai
-    from google.genai.types import GenerateContentConfig, HttpOptions, Part
+    from google.genai.types import HttpOptions, Part
 
     client = genai.Client(http_options=HttpOptions(api_version="v1"))
     prompt = """

--- a/genai/text_generation/textgen_with_gcs_audio.py
+++ b/genai/text_generation/textgen_with_gcs_audio.py
@@ -16,7 +16,7 @@
 def generate_content() -> str:
     # [START googlegenaisdk_textgen_with_gcs_audio]
     from google import genai
-    from google.genai.types import HttpOptions, Part
+    from google.genai.types import GenerateContentConfig, HttpOptions, Part
 
     client = genai.Client(http_options=HttpOptions(api_version="v1"))
     prompt = """
@@ -33,6 +33,8 @@ def generate_content() -> str:
                 mime_type="audio/mpeg",
             ),
         ],
+        # Required to enable timestamp understanding for audio-only files
+        config=GenerateContentConfig(audio_timestamp=True),
     )
     print(response.text)
     # Example response:
@@ -40,8 +42,8 @@ def generate_content() -> str:
     #
     # **Chapter Breakdown:**
     #
-    # * **[0:00-1:14] Introduction:** Host Rasheed Finch introduces Aisha and DeCarlos and ...
-    # * **[1:15-2:44] Transformative Features:** Aisha and DeCarlos discuss their ...
+    # *   **0:00-0:13:** Introduction to the podcast and the topic of Pixel Feature Drops
+    # *   **0:14-0:27:** Introduces the guest speaker, Aisha Sheriff and DeCarlos Love
     # ...
     # [END googlegenaisdk_textgen_with_gcs_audio]
     return response.text

--- a/genai/text_generation/textgen_with_gcs_audio.py
+++ b/genai/text_generation/textgen_with_gcs_audio.py
@@ -20,9 +20,7 @@ def generate_content() -> str:
 
     client = genai.Client(http_options=HttpOptions(api_version="v1"))
     prompt = """
-    Provide the summary of the audio file.
-    Summarize the main points of the audio concisely.
-    Create a chapter breakdown with timestamps for key sections or topics discussed.
+    Provide a concise summary of the main points in the audio file.
     """
     response = client.models.generate_content(
         model="gemini-2.0-flash-001",
@@ -33,18 +31,12 @@ def generate_content() -> str:
                 mime_type="audio/mpeg",
             ),
         ],
-        # Required to enable timestamp understanding for audio-only files
-        config=GenerateContentConfig(audio_timestamp=True),
     )
     print(response.text)
     # Example response:
-    # This episode of the Made by Google podcast features product managers ...
-    #
-    # **Chapter Breakdown:**
-    #
-    # *   **0:00-0:13:** Introduction to the podcast and the topic of Pixel Feature Drops
-    # *   **0:14-0:27:** Introduces the guest speaker, Aisha Sheriff and DeCarlos Love
-    # ...
+    # Here's a summary of the main points from the audio file:
+
+    # The Made by Google podcast discusses the Pixel feature drops with product managers Aisha Sheriff and De Carlos Love.  The key idea is that devices should improve over time, with a connected experience across phones, watches, earbuds, and tablets.
     # [END googlegenaisdk_textgen_with_gcs_audio]
     return response.text
 


### PR DESCRIPTION
## Description

Required according to documentation: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding#audio_transcription

Audio timestamps are inaccurate without this parameter. I also removed references to timestamps from the audio summary sample to simplify it.