### PR TITLE
feat: update all v1 Cloud SQL Proxy usages to v2

### DIFF
--- a/.kokoro/tests/run_tests.sh
+++ b/.kokoro/tests/run_tests.sh
@@ -132,16 +132,16 @@ export GOOGLE_CLIENT_SECRETS=$(pwd)/testing/client-secrets.json
 export DATALABELING_ENDPOINT="test-datalabeling.sandbox.googleapis.com:443"
 
 # Run Cloud SQL proxy (background process exit when script does)
-wget --quiet https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
-     -O ${HOME}/cloud_sql_proxy && chmod +x ${HOME}/cloud_sql_proxy
-${HOME}/cloud_sql_proxy -instances="${MYSQL_INSTANCE}"=tcp:3306,"${MYSQL_INSTANCE}" -dir "${HOME}" &>> \
-       ${HOME}/cloud_sql_proxy.log &
+wget --quiet https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.15.1/cloud-sql-proxy.linux.amd64 \
+     -O ${HOME}/cloud-sql-proxy && chmod +x ${HOME}/cloud-sql-proxy
+${HOME}/cloud-sql-proxy --port 3306 ${MYSQL_INSTANCE} &>> \
+       ${HOME}/cloud-sql-proxy.log &
 echo -e "\Cloud SQL proxy started for MySQL."
-${HOME}/cloud_sql_proxy -instances="${POSTGRES_INSTANCE}"=tcp:5432,"${POSTGRES_INSTANCE}" -dir "${HOME}" &>> \
-       ${HOME}/cloud_sql_proxy-postgres.log &
+${HOME}/cloud-sql-proxy --port 5432 ${POSTGRES_INSTANCE} &>> \
+       ${HOME}/cloud-sql-proxy-postgres.log &
 echo -e "\Cloud SQL proxy started for Postgres."
-${HOME}/cloud_sql_proxy -instances="${SQLSERVER_INSTANCE}"=tcp:1433 &>> \
-       ${HOME}/cloud_sql_proxy-sqlserver.log &
+${HOME}/cloud-sql-proxy --port 1433 ${SQLSERVER_INSTANCE} &>> \
+       ${HOME}/cloud-sql-proxy-sqlserver.log &
 echo -e "\Cloud SQL proxy started for SQL Server."
 
 echo -e "\n******************** TESTING PROJECTS ********************"

--- a/.kokoro/tests/run_tests_orig.sh
+++ b/.kokoro/tests/run_tests_orig.sh
@@ -92,12 +92,12 @@ export GOOGLE_CLIENT_SECRETS=$(pwd)/testing/client-secrets.json
 export DATALABELING_ENDPOINT="test-datalabeling.sandbox.googleapis.com:443"
 
 # Run Cloud SQL proxy (background process exit when script does)
-wget --quiet https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 \
-     -O ${HOME}/cloud_sql_proxy && chmod +x ${HOME}/cloud_sql_proxy
-${HOME}/cloud_sql_proxy -instances="${MYSQL_INSTANCE}"=tcp:3306 &>> \
-       ${HOME}/cloud_sql_proxy.log &
-${HOME}/cloud_sql_proxy -instances="${POSTGRES_INSTANCE}"=tcp:5432 &>> \
-       ${HOME}/cloud_sql_proxy-postgres.log &
+wget --quiet https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.15.1/cloud-sql-proxy.linux.amd64 \
+     -O ${HOME}/cloud-sql-proxy && chmod +x ${HOME}/cloud-sql-proxy
+${HOME}/cloud-sql-proxy --port 3306 ${MYSQL_INSTANCE} &>> \
+       ${HOME}/cloud-sql-proxy.log &
+${HOME}/cloud-sql-proxy --port 5432 ${POSTGRES_INSTANCE} &>> \
+       ${HOME}/cloud-sql-proxy-postgres.log &
 echo -e "\nCloud SQL proxy started."
 
 echo -e "\n******************** TESTING PROJECTS ********************"

--- a/appengine/standard/cloudsql/main.py
+++ b/appengine/standard/cloudsql/main.py
@@ -50,7 +50,7 @@ def connect_to_cloudsql():
     # will work if you're running a local MySQL server or using the Cloud SQL
     # proxy, for example:
     #
-    #   $ cloud_sql_proxy -instances=your-connection-name=tcp:3306
+    #   $ cloud-sql-proxy --port 3306 <your-connection-name>
     #
     else:
         db = MySQLdb.connect(

--- a/cloud-sql/mysql/client-side-encryption/README.md
+++ b/cloud-sql/mysql/client-side-encryption/README.md
@@ -2,14 +2,14 @@
 
 ## Before you begin
 
-1. If you haven't already, set up a Python Development Environment by following the [python setup guide](https://cloud.google.com/python/setup) and 
+1. If you haven't already, set up a Python Development Environment by following the [python setup guide](https://cloud.google.com/python/setup) and
 [create a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
 
-1. Create a 2nd Gen Cloud SQL Instance by following these 
+1. Create a Cloud SQL Instance by following these
 [instructions](https://cloud.google.com/sql/docs/mysql/create-instance). Note the connection string,
 database user, and database password that you create.
 
-1. Create a database for your application by following these 
+1. Create a database for your application by following these
 [instructions](https://cloud.google.com/sql/docs/mysql/create-manage-databases). Note the database
 name.
 
@@ -17,9 +17,8 @@ name.
 [instructions](https://cloud.google.com/kms/docs/creating-keys). Copy the resource name of your
 created key.
 
-1. Create a service account with the 'Cloud SQL Client' permissions by following these 
-[instructions](https://cloud.google.com/sql/docs/mysql/connect-external-app#4_if_required_by_your_authentication_method_create_a_service_account).
-Download a JSON key to use to authenticate your connection.
+1. Grant an IAM user or service account the 'Cloud SQL Client' permissions by following these
+[instructions](https://cloud.google.com/sql/docs/mysql/roles-and-permissions#introduction).
 
 1. **macOS / Windows only**: Configure gRPC Root Certificates: On some platforms you may need to
 accept the Google server certificates, see instructions for setting up
@@ -27,13 +26,15 @@ accept the Google server certificates, see instructions for setting up
 
 ## Running locally
 
-To run this application locally, download and install the `cloud_sql_proxy` by
+Set up Application Default Credentials (ADC) for local development (using the
+IAM user or service account who was granted the `Cloud SQL Client` role) by
+following these [instructions](https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment).
+
+To run this application locally, download and install the `cloud-sql-proxy` by
 following the instructions
 [here](https://cloud.google.com/sql/docs/mysql/sql-proxy#install).
 
 Instructions are provided below for using the proxy with a TCP connection or a Unix Domain Socket.
-On Linux or Mac OS you can use either option, but on Windows the proxy currently requires a TCP
-connection.
 
 ### Launch proxy with TCP
 
@@ -41,46 +42,61 @@ To run the sample locally with a TCP connection, set environment variables and l
 shown below.
 
 #### Linux / Mac OS
+
 Use these terminal commands to initialize environment variables:
+
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export DB_HOST='127.0.0.1:3306'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 export GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
+
 ```bash
-./cloud_sql_proxy -instances=<project-id>:<region>:<instance-name>=tcp:3306 -credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --port 3306 <project-id>:<region>:<instance-name> &
 ```
 
 #### Windows/PowerShell
+
 Use these PowerShell commands to initialize environment variables:
+
 ```powershell
-$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
 $env:DB_HOST="127.0.0.1:3306"
 $env:DB_USER="<DB_USER_NAME>"
 $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
 $env:GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
+
 ```powershell
-Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:3306 -credential_file=<CREDENTIALS_JSON_FILE>"
+Start-Process -filepath "C:\<path to cloud-sql-proxy.exe>" -ArgumentList "--port 3306 <project-id>:<region>:<instance-name>"
 ```
 
 ### Launch proxy with Unix Domain Socket
-NOTE: this option is currently only supported on Linux and Mac OS. Windows users should use the
-[Launch proxy with TCP](#launch-proxy-with-tcp) option.
+
+> [!NOTE]
+>
+> The Proxy supports Unix domain sockets on recent versions of Windows, but
+> replaces colons with periods:
+>
+> ```shell
+> # Starts a Unix domain socket at the path:
+> #    C:\cloudsql\my-project.my-region.my-instance
+> ./cloud-sql-proxy.exe --unix-socket C:\cloudsql my-project:my-region:my-instance
+> ```
 
 To use a Unix socket, you'll need to create a directory and give write access to the user running
 the proxy. For example:
@@ -91,31 +107,35 @@ sudo chown -R $USER /cloudsql
 ```
 
 You'll also need to initialize an environment variable containing the directory you just created:
+
 ```bash
 export DB_SOCKET_DIR=/path/to/the/new/directory
 ```
 
 Use these terminal commands to initialize other environment variables as well:
+
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_CONNECTION_NAME='<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 export GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/overview) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
+
 ```bash
-./cloud_sql_proxy -dir=$DB_SOCKET_DIR --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --unix-socket $DB_SOCKET_DIR $INSTANCE_CONNECTION_NAME &
 ```
 
 ### Install requirements
 
 Next, setup install the requirements into a virtual environment:
+
 ```bash
 virtualenv --python python3 env
 source env/bin/activate
@@ -125,6 +145,7 @@ pip install -r requirements.txt
 ### Run the demo
 
 Add new votes and the collected votes:
+
 ```bash
 python snippets/query_and_decrypt_data.py 
 ```

--- a/cloud-sql/postgres/client-side-encryption/README.md
+++ b/cloud-sql/postgres/client-side-encryption/README.md
@@ -2,14 +2,14 @@
 
 ## Before you begin
 
-1. If you haven't already, set up a Python Development Environment by following the [python setup guide](https://cloud.google.com/python/setup) and 
+1. If you haven't already, set up a Python Development Environment by following the [python setup guide](https://cloud.google.com/python/setup) and
 [create a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
 
-1. Create a 2nd Gen Cloud SQL Instance by following these 
+1. Create a 2nd Gen Cloud SQL Instance by following these
 [instructions](https://cloud.google.com/sql/docs/postgres/create-instance). Note the connection string,
 database user, and database password that you create.
 
-1. Create a database for your application by following these 
+1. Create a database for your application by following these
 [instructions](https://cloud.google.com/sql/docs/postgres/create-manage-databases). Note the database
 name.
 
@@ -17,23 +17,23 @@ name.
 [instructions](https://cloud.google.com/kms/docs/creating-keys). Copy the resource name of your
 created key.
 
-1. Create a service account with the 'Cloud SQL Client' permissions by following these 
-[instructions](https://cloud.google.com/sql/docs/postgres/connect-admin-proxy#create-service-account).
-Download a JSON key to use to authenticate your connection.
+1. Grant an IAM user or service account the 'Cloud SQL Client' permissions by following these
+[instructions](https://cloud.google.com/sql/docs/postgres/roles-and-permissions#introduction).
 
 1. **macOS / Windows only**: Configure gRPC Root Certificates: On some platforms you may need to
 accept the Google server certificates, see instructions for setting up
 [root certs](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigtable/examples/README.md#configure-grpc-root-certificates).
- 
 
 ## Running locally
 
-To run this application locally, download and install the `cloud_sql_proxy` by
+Set up Application Default Credentials (ADC) for local development (using the
+IAM user or service account who was granted the `Cloud SQL Client` role) by
+following these [instructions](https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment).
+
+To run this application locally, download and install the `cloud-sql-proxy` by
 following the instructions [here](https://cloud.google.com/sql/docs/postgres/connect-admin-proxy#install).
 
 Instructions are provided below for using the proxy with a TCP connection or a Unix Domain Socket.
-On Linux or Mac OS you can use either option, but on Windows the proxy currently requires a TCP
-connection.
 
 ### Launch proxy with TCP
 
@@ -41,50 +41,65 @@ To run the sample locally with a TCP connection, set environment variables and l
 shown below.
 
 #### Linux / Mac OS
+
 Use these terminal commands to initialize environment variables:
+
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export DB_HOST='127.0.0.1:5432'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 export GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/quickstart) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
+
 ```bash
-./cloud_sql_proxy -instances=<project-id>:<region>:<instance-name>=tcp:5432 -credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --port 5432 <project-id>:<region>:<instance-name> &
 ```
 
 Note: if you are running a local Postgres server, you will need to turn it off before running the command above or use a different port.
 
 #### Windows/PowerShell
+
 Use these PowerShell commands to initialize environment variables:
+
 ```powershell
-$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
 $env:DB_HOST="127.0.0.1:5432"
 $env:DB_USER="<DB_USER_NAME>"
 $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
 $env:GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/quickstart) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
+
 ```powershell
-Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:5432 -credential_file=<CREDENTIALS_JSON_FILE>"
+Start-Process -filepath "C:\<path to cloud-sql-proxy.exe>" -ArgumentList "--port 5432 <project-id>:<region>:<instance-name>"
 ```
 
 Note: if you are running a local Postgres server, you will need to turn it off before running the command above or use a different port.
 
 ### Launch proxy with Unix Domain Socket
-NOTE: this option is currently only supported on Linux and Mac OS. Windows users should use the
-[Launch proxy with TCP](#launch-proxy-with-tcp) option.
+
+> [!NOTE]
+>
+> The Proxy supports Unix domain sockets on recent versions of Windows, but
+> replaces colons with periods:
+>
+> ```shell
+> # Starts a Unix domain socket at the path:
+> #    C:\cloudsql\my-project.my-region.my-instance
+> ./cloud-sql-proxy.exe --unix-socket C:\cloudsql my-project:my-region:my-instance
+> ```
 
 To use a Unix socket, you'll need to create a directory for the sockets and
 initialize an environment variable containing the directory you just created.
@@ -95,26 +110,29 @@ export DB_SOCKET_DIR=$(mktemp -d cloudsql)
 ```
 
 Use these terminal commands to initialize other environment variables as well:
+
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export INSTANCE_CONNECTION_NAME='<MY-PROJECT>:<INSTANCE-REGION>:<INSTANCE-NAME>'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 export GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/quickstart) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
+
 ```bash
-./cloud_sql_proxy -dir=$DB_SOCKET_DIR --instances=$INSTANCE_CONNECTION_NAME --credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --unix-socket $DB_SOCKET_DIR $INSTANCE_CONNECTION_NAME &
 ```
 
 ### Install requirements
 
 Next, setup install the requirements into a virtual environment:
+
 ```bash
 virtualenv --python python3 env
 source env/bin/activate
@@ -124,11 +142,13 @@ pip install -r requirements.txt
 ### Run the demo
 
 Add new votes:
+
 ```bash
 python snippets/encrypt_and_insert_data.py 
 ```
 
 View the collected votes:
+
 ```bash
 python snippets/query_and_decrypt_data.py 
 ```

--- a/cloud-sql/sql-server/client-side-encryption/README.md
+++ b/cloud-sql/sql-server/client-side-encryption/README.md
@@ -2,14 +2,14 @@
 
 ## Before you begin
 
-1. If you haven't already, set up a Python Development Environment by following the [python setup guide](https://cloud.google.com/python/setup) and 
+1. If you haven't already, set up a Python Development Environment by following the [python setup guide](https://cloud.google.com/python/setup) and
 [create a project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#creating_a_project).
 
-1. Create a 2nd Gen Cloud SQL Instance by following these 
+1. Create a 2nd Gen Cloud SQL Instance by following these
 [instructions](https://cloud.google.com/sql/docs/sqlserver/create-instance). Note the connection string,
 database user, and database password that you create.
 
-1. Create a database for your application by following these 
+1. Create a database for your application by following these
 [instructions](https://cloud.google.com/sql/docs/sqlserver/create-manage-databases). Note the database
 name.
 
@@ -17,9 +17,8 @@ name.
 [instructions](https://cloud.google.com/kms/docs/creating-keys). Copy the resource name of your
 created key.
 
-1. Create a service account with the 'Cloud SQL Client' permissions by following these 
-[instructions](https://cloud.google.com/sql/docs/sqlserver/connect-admin-proxy#create-service-account).
-Download a JSON key to use to authenticate your connection.
+1. Grant an IAM user or service account the 'Cloud SQL Client' permissions by following these
+[instructions](https://cloud.google.com/sql/docs/sqlserver/roles-and-permissions#introduction).
 
 1. **macOS / Windows only**: Configure gRPC Root Certificates: On some platforms you may need to
 accept the Google server certificates, see instructions for setting up
@@ -27,13 +26,13 @@ accept the Google server certificates, see instructions for setting up
 
 ## Running locally
 
-To run this application locally, download and install the `cloud_sql_proxy` by
+Set up Application Default Credentials (ADC) for local development (using the
+IAM user or service account who was granted the `Cloud SQL Client` role) by
+following these [instructions](https://cloud.google.com/docs/authentication/set-up-adc-local-dev-environment).
+
+To run this application locally, download and install the `cloud-sql-proxy` by
 following the instructions
 [here](https://cloud.google.com/sql/docs/sqlserver/connect-admin-proxy#install).
-
-Instructions are provided below for using the proxy with a TCP connection or a Unix Domain Socket.
-On Linux or Mac OS you can use either option, but on Windows the proxy currently requires a TCP
-connection.
 
 ### Launch proxy with TCP
 
@@ -41,46 +40,53 @@ To run the sample locally with a TCP connection, set environment variables and l
 shown below.
 
 #### Linux / Mac OS
+
 Use these terminal commands to initialize environment variables:
+
 ```bash
-export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/key.json
 export DB_HOST='127.0.0.1:1433'
 export DB_USER='<DB_USER_NAME>'
 export DB_PASS='<DB_PASSWORD>'
 export DB_NAME='<DB_NAME>'
 export GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/quickstart) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in the background:
+
 ```bash
-./cloud_sql_proxy -instances=<project-id>:<region>:<instance-name>=tcp:1433 -credential_file=$GOOGLE_APPLICATION_CREDENTIALS &
+./cloud-sql-proxy --port 1433 <project-id>:<region>:<instance-name> &
 ```
 
 #### Windows/PowerShell
+
 Use these PowerShell commands to initialize environment variables:
+
 ```powershell
-$env:GOOGLE_APPLICATION_CREDENTIALS="<CREDENTIALS_JSON_FILE>"
 $env:DB_HOST="127.0.0.1:1433"
 $env:DB_USER="<DB_USER_NAME>"
 $env:DB_PASS="<DB_PASSWORD>"
 $env:DB_NAME="<DB_NAME>"
 $env:GCP_KMS_URI='<GCP_KMS_URI>'
 ```
+
 Note: Saving credentials in environment variables is convenient, but not secure - consider a more
 secure solution such as [Secret Manager](https://cloud.google.com/secret-manager/docs/quickstart) to
 help keep secrets safe.
 
 Then use this command to launch the proxy in a separate PowerShell session:
+
 ```powershell
-Start-Process -filepath "C:\<path to proxy exe>" -ArgumentList "-instances=<project-id>:<region>:<instance-name>=tcp:1433 -credential_file=<CREDENTIALS_JSON_FILE>"
+Start-Process -filepath "C:\<path to cloud-sql-proxy.exe>" -ArgumentList "--port 1433 <project-id>:<region>:<instance-name>"
 ```
 
 ### Install requirements
 
 Next, setup install the requirements into a virtual environment:
+
 ```bash
 virtualenv --python python3 env
 source env/bin/activate
@@ -90,6 +96,7 @@ pip install -r requirements.txt
 ### Run the demo
 
 Add new votes and view the collected votes:
+
 ```bash
 python snippets/query_and_decrypt_data.py 
 ```

--- a/kubernetes_engine/django_tutorial/polls.yaml
+++ b/kubernetes_engine/django_tutorial/polls.yaml
@@ -40,14 +40,14 @@ spec:
         app: polls
     spec:
       containers:
-      - name: polls-app
-        # Replace  with your project ID or use `make template`
-        image: gcr.io/<your-project-id>/polls
-        # This setting makes nodes pull the docker image every time before
-        # starting the pod. This is useful when debugging, but should be turned
-        # off in production.
-        imagePullPolicy: Always
-        env:
+        - name: polls-app
+          # Replace  with your project ID or use `make template`
+          image: gcr.io/<your-project-id>/polls
+          # This setting makes nodes pull the docker image every time before
+          # starting the pod. This is useful when debugging, but should be turned
+          # off in production.
+          imagePullPolicy: Always
+          env:
             - name: DATABASE_NAME
               valueFrom:
                 secretKeyRef:
@@ -63,22 +63,23 @@ spec:
                 secretKeyRef:
                   name: cloudsql
                   key: password
-        ports:
-        - containerPort: 8080
-      
-      - image: gcr.io/cloudsql-docker/gce-proxy:1.16
-        name: cloudsql-proxy
-        command: ["/cloud_sql_proxy", "--dir=/cloudsql",
-                  "-instances=<your-cloudsql-connection-string>=tcp:5432",
-                  "-credential_file=/secrets/cloudsql/credentials.json"]
-        volumeMounts:
-          - name: cloudsql-oauth-credentials
-            mountPath: /secrets/cloudsql
-            readOnly: true
-          - name: ssl-certs
-            mountPath: /etc/ssl/certs
-          - name: cloudsql
-            mountPath: /cloudsql
+          ports:
+            - containerPort: 8080
+
+        - image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:latest
+          name: cloud-sql-proxy
+          args:
+            - "--port=5432"
+            - "--credentials-file=/secrets/cloudsql/credentials.json"
+            - "<your-cloudsql-connection-string>"
+          volumeMounts:
+            - name: cloudsql-oauth-credentials
+              mountPath: /secrets/cloudsql
+              readOnly: true
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs
+            - name: cloudsql
+              mountPath: /cloudsql
       volumes:
         - name: cloudsql-oauth-credentials
           secret:
@@ -90,7 +91,6 @@ spec:
           emptyDir: {}
 # [END gke_kubernetes_deployment_yaml_python]
 ---
-
 # [START gke_kubernetes_service_yaml_python]
 # The polls service provides a load-balancing proxy over the polls app
 # pods. By specifying the type as a 'LoadBalancer', Kubernetes Engine will
@@ -108,8 +108,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-  - port: 80
-    targetPort: 8080
+    - port: 80
+      targetPort: 8080
   selector:
     app: polls
 # [END gke_kubernetes_service_yaml_python]

--- a/run/idp-sql/README.md
+++ b/run/idp-sql/README.md
@@ -52,7 +52,7 @@ Other environment variables:
 
 1. Set [environment variables](#environment-variables).
 
-1. To run this application locally, download and install the `cloud_sql_proxy` by
+1. To run this application locally, download and install the `cloud-sql-proxy` by
 [following the instructions](https://cloud.google.com/sql/docs/postgres/sql-proxy#install).
 
 The proxy can be used with a TCP connection or a Unix Domain Socket. On Linux or


### PR DESCRIPTION
## Description
The Cloud SQL Proxy v2 was released in 2022, moving test infra and usage of v1 Proxy over to v2 syntax.

Fixes #13123 