### PR TITLE
chore(datastore): delete and migrate invalid region tags in the whole folder - step 1

### DIFF
--- a/datastore/cloud-ndb/flask_app.py
+++ b/datastore/cloud-ndb/flask_app.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START ndb_flask]
+# [START datastore_ndb_flask]
 from flask import Flask
 
 from google.cloud import ndb
@@ -41,6 +41,4 @@ class Book(ndb.Model):
 def list_books():
     books = Book.query()
     return str([book.to_dict() for book in books])
-
-
-# [END ndb_flask]
+# [END datastore_ndb_flask]

--- a/datastore/cloud-ndb/flask_app.py
+++ b/datastore/cloud-ndb/flask_app.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # [START datastore_ndb_flask]
+# [START ndb_flask]
 from flask import Flask
 
 from google.cloud import ndb
@@ -41,4 +42,5 @@ class Book(ndb.Model):
 def list_books():
     books = Book.query()
     return str([book.to_dict() for book in books])
+# [END ndb_flask]
 # [END datastore_ndb_flask]

--- a/datastore/cloud-ndb/quickstart.py
+++ b/datastore/cloud-ndb/quickstart.py
@@ -13,28 +13,23 @@
 # limitations under the License.
 
 # [START datastore_quickstart_python]
-# [START ndb_import]
 from google.cloud import ndb
 
 
-# [END ndb_import]
 class Book(ndb.Model):
     title = ndb.StringProperty()
 
 
-# [START ndb_client]
 client = ndb.Client()
 
 
-# [END ndb_client]
 def list_books():
     with client.context():
         books = Book.query()
         for book in books:
             print(book.to_dict())
-
-
 # [END datastore_quickstart_python]
+
 
 if __name__ == "__main__":
     list_books()

--- a/datastore/cloud-ndb/requirements.txt
+++ b/datastore/cloud-ndb/requirements.txt
@@ -1,5 +1,3 @@
-# [START ndb_version]
 google-cloud-ndb==2.3.2
-# [END ndb_version]
 Flask==3.0.3
 Werkzeug==3.0.6


### PR DESCRIPTION
## Description

Fixes Internal:
b/347350603
b/347825351
b/347350340

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved