### PR TITLE
fix(securitycenter): delete deprecated samples and fix failing samples

### DIFF
--- a/securitycenter/snippets/requirements-test.txt
+++ b/securitycenter/snippets/requirements-test.txt
@@ -1,3 +1,3 @@
 backoff==2.2.1
 pytest==8.2.0
-google-cloud-bigquery==3.25.0
+google-cloud-bigquery==3.30.0

--- a/securitycenter/snippets/requirements.txt
+++ b/securitycenter/snippets/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-pubsub==2.21.5
+google-cloud-pubsub==2.28.0
 google-cloud-securitycenter==1.21.0

--- a/securitycenter/snippets/requirements.txt
+++ b/securitycenter/snippets/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-pubsub==2.21.5
-google-cloud-securitycenter==1.21.0
+google-cloud-pubsub==2.28.0
+google-cloud-securitycenter==1.38.0

--- a/securitycenter/snippets/requirements.txt
+++ b/securitycenter/snippets/requirements.txt
@@ -1,2 +1,2 @@
 google-cloud-pubsub==2.28.0
-google-cloud-securitycenter==1.21.0
+google-cloud-securitycenter==1.38.0

--- a/securitycenter/snippets/requirements.txt
+++ b/securitycenter/snippets/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-pubsub==2.28.0
-google-cloud-securitycenter==1.38.0
+google-cloud-pubsub==2.21.5
+google-cloud-securitycenter==1.21.0

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,6 +89,7 @@ def update_source(source_name):
 def add_user_to_source(source_name):
     """Gives a user findingsEditor permission to the source."""
     user_email = "csccclienttest@gmail.com"
+
     # [START securitycenter_set_source_iam]
     from google.cloud import securitycenter
     from google.iam.v1 import policy_pb2
@@ -123,8 +122,8 @@ def add_user_to_source(source_name):
     )
 
     print(f"Updated Policy: {updated}")
-
     # [END securitycenter_set_source_iam]
+
     return binding, updated
 
 
@@ -437,10 +436,6 @@ def list_findings_at_time(source_name):
     # You an also use a wild-card "-" for all sources:
     #   source_name = "organizations/111122222444/sources/-"
     five_days_ago = str(datetime.now(timezone.utc) - timedelta(days=5))
-
-    # TODO: Remove this after passing the tests
-    print(f'{five_days_ago=}')
-
     # [END securitycenter_list_findings_at_time]
     i = -1
     # [START securitycenter_list_findings_at_time]
@@ -596,6 +591,8 @@ def group_findings_and_changes(source_name):
 
     # List assets and their state change the last 30 days
     compare_delta = timedelta(days=30)
+
+    print(f'{compare_delta=}')
 
     group_result_iterator = client.group_findings(
         request={

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -152,7 +152,7 @@ def list_source(organization_id):
 def create_finding(source_name, finding_id):
     """Creates a new finding."""
     # [START securitycenter_create_finding]
-    import datetime
+    from datetime import datetime, timezone
 
     from google.cloud import securitycenter
     from google.cloud.securitycenter_v1 import Finding
@@ -161,7 +161,7 @@ def create_finding(source_name, finding_id):
     client = securitycenter.SecurityCenterClient()
 
     # Use the current time as the finding "event time".
-    event_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    event_time = datetime.now(tz=timezone.utc)
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -194,7 +194,7 @@ def create_finding(source_name, finding_id):
 def create_finding_with_source_properties(source_name):
     """Demonstrate creating a new finding with source properties."""
     # [START securitycenter_create_finding_with_source_properties]
-    import datetime
+    from datetime import datetime, timezone
 
     from google.cloud import securitycenter
     from google.cloud.securitycenter_v1 import Finding
@@ -225,7 +225,7 @@ def create_finding_with_source_properties(source_name):
     num_value.number_value = 1234
 
     # Use the current time as the finding "event time".
-    event_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    event_time = datetime.now(tz=timezone.utc)
 
     finding = Finding(
         state=Finding.State.ACTIVE,
@@ -244,7 +244,7 @@ def create_finding_with_source_properties(source_name):
 
 def update_finding(source_name):
     # [START securitycenter_update_finding_source_properties]
-    import datetime
+    from datetime import datetime, timezone
 
     from google.cloud import securitycenter
     from google.cloud.securitycenter_v1 import Finding
@@ -259,7 +259,7 @@ def update_finding(source_name):
 
     # Set the update time to Now.  This must be some time greater then the
     # event_time on the original finding.
-    event_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    event_time = datetime.now(tz=timezone.utc)
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -288,7 +288,7 @@ def update_finding(source_name):
 def update_finding_state(source_name):
     """Demonstrate updating only a finding state."""
     # [START securitycenter_update_finding_state]
-    import datetime
+    from datetime import datetime, timezone
 
     from google.cloud import securitycenter
     from google.cloud.securitycenter_v1 import Finding
@@ -308,7 +308,7 @@ def update_finding_state(source_name):
         request={
             "name": finding_name,
             "state": Finding.State.INACTIVE,
-            "start_time": datetime.datetime.now(tz=datetime.timezone.utc),
+            "start_time": datetime.now(timezone.utc),
         }
     )
     print(f"New state: {new_finding.state}")
@@ -419,7 +419,7 @@ def list_filtered_findings(source_name):
 
 def list_findings_at_time(source_name):
     # [START securitycenter_list_findings_at_time]
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     from google.cloud import securitycenter
 
@@ -436,7 +436,11 @@ def list_findings_at_time(source_name):
     #   "folders/{folder_id}"
     # You an also use a wild-card "-" for all sources:
     #   source_name = "organizations/111122222444/sources/-"
-    five_days_ago = str(datetime.now() - timedelta(days=5))
+    five_days_ago = str(datetime.now(timezone.utc) - timedelta(days=5))
+
+    # TODO: Remove this after passing the tests
+    print(f'{five_days_ago=}')
+
     # [END securitycenter_list_findings_at_time]
     i = -1
     # [START securitycenter_list_findings_at_time]
@@ -536,7 +540,7 @@ def group_findings_at_time(source_name):
     a specific time."""
     i = -1
     # [START securitycenter_group_findings_at_time]
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     from google.cloud import securitycenter
 
@@ -554,7 +558,10 @@ def group_findings_at_time(source_name):
     # source_name = "organizations/111122222444/sources/1234"
 
     # Group findings as of yesterday.
-    read_time = datetime.utcnow() - timedelta(days=1)
+    read_time = datetime.now(timezone.utc) - timedelta(days=1)
+
+    # TODO: Remove this after passing the tests
+    print(f'{read_time=}')
 
     group_result_iterator = client.group_findings(
         request={"parent": source_name, "group_by": "category", "read_time": read_time}

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -445,7 +445,7 @@ def list_findings_at_time(source_name):
             "filter": f"event_time > {five_days_ago.isoformat()}",
         }
     )
-    
+
     for i, finding_result in enumerate(finding_result_iterator):
         print(
             "{}: name: {} resource: {}".format(

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -440,8 +440,12 @@ def list_findings_at_time(source_name):
     # [START securitycenter_list_findings_at_time]
 
     finding_result_iterator = client.list_findings(
-        request={"parent": source_name, "filter": five_days_ago}
+        request={
+            "parent": source_name,
+            "filter": f"event_time > {five_days_ago.isoformat()}",
+        }
     )
+    
     for i, finding_result in enumerate(finding_result_iterator):
         print(
             "{}: name: {} resource: {}".format(
@@ -449,6 +453,7 @@ def list_findings_at_time(source_name):
             )
         )
     # [END securitycenter_list_findings_at_time]
+
     return i
 
 

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -153,7 +153,7 @@ def create_finding(source_name, finding_id):
     # [START securitycenter_create_finding]
     from datetime import datetime, timezone
 
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
     from google.cloud.securitycenter_v1 import Finding
 
     # Create a new client.

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -434,7 +434,7 @@ def list_findings_at_time(source_name):
     #   "folders/{folder_id}"
     # You an also use a wild-card "-" for all sources:
     #   source_name = "organizations/111122222444/sources/-"
-    five_days_ago = str(datetime.now(timezone.utc) - timedelta(days=5))
+    five_days_ago = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
     # [END securitycenter_list_findings_at_time]
     i = -1
     # [START securitycenter_list_findings_at_time]
@@ -442,7 +442,7 @@ def list_findings_at_time(source_name):
     finding_result_iterator = client.list_findings(
         request={
             "parent": source_name,
-            "filter": f"event_time > {five_days_ago.isoformat()}",
+            "filter": f"event_time > {five_days_ago}",
         }
     )
 

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -18,9 +18,9 @@
 def create_source(organization_id):
     """Create a new findings source."""
     # [START securitycenter_create_source]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
     # organization_id is the numeric ID of the organization. e.g.:
     # organization_id = "111122222444"
     org_name = f"organizations/{organization_id}"
@@ -41,9 +41,9 @@ def create_source(organization_id):
 def get_source(source_name):
     """Gets an existing source."""
     # [START securitycenter_get_source]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -61,10 +61,10 @@ def get_source(source_name):
 def update_source(source_name):
     """Updates a source's display name."""
     # [START securitycenter_update_source]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
     from google.protobuf import field_mask_pb2
 
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # Field mask to only update the display name.
     field_mask = field_mask_pb2.FieldMask(paths=["display_name"])
@@ -91,10 +91,10 @@ def add_user_to_source(source_name):
     user_email = "csccclienttest@gmail.com"
 
     # [START securitycenter_set_source_iam]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
     from google.iam.v1 import policy_pb2
 
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -131,10 +131,10 @@ def list_source(organization_id):
     """Lists finding sources."""
     i = -1
     # [START securitycenter_list_sources]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
     # Create a new client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
     # 'parent' must be in one of the following formats:
     #   "organizations/{organization_id}"
     #   "projects/{project_id}"
@@ -157,7 +157,7 @@ def create_finding(source_name, finding_id):
     from google.cloud.securitycenter_v1 import Finding
 
     # Create a new client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # Use the current time as the finding "event time".
     event_time = datetime.now(tz=timezone.utc)
@@ -195,12 +195,12 @@ def create_finding_with_source_properties(source_name):
     # [START securitycenter_create_finding_with_source_properties]
     from datetime import datetime, timezone
 
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
     from google.cloud.securitycenter_v1 import Finding
     from google.protobuf.struct_pb2 import Value
 
     # Create a new client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -245,11 +245,11 @@ def update_finding(source_name):
     # [START securitycenter_update_finding_source_properties]
     from datetime import datetime, timezone
 
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
     from google.cloud.securitycenter_v1 import Finding
     from google.protobuf import field_mask_pb2
 
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
     # Only update the specific source property and event_time.  event_time
     # is required for updates.
     field_mask = field_mask_pb2.FieldMask(
@@ -289,11 +289,11 @@ def update_finding_state(source_name):
     # [START securitycenter_update_finding_state]
     from datetime import datetime, timezone
 
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
     from google.cloud.securitycenter_v1 import Finding
 
     # Create a client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
     # Its format is:
@@ -318,10 +318,10 @@ def trouble_shoot(source_name):
     """Demonstrate calling test_iam_permissions to determine if the
     service account has the correct permisions."""
     # [START securitycenter_test_iam]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
     # Create a client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
     # Its format is:
@@ -359,10 +359,10 @@ def trouble_shoot(source_name):
 
 def list_all_findings(organization_id):
     # [START securitycenter_list_all_findings]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
     # Create a client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'parent' must be in one of the following formats:
     #   "organizations/{organization_id}"
@@ -385,10 +385,10 @@ def list_all_findings(organization_id):
 
 def list_filtered_findings(source_name):
     # [START securitycenter_list_filtered_findings]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
     # Create a new client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -419,10 +419,12 @@ def list_findings_at_time(source_name):
     # [START securitycenter_list_findings_at_time]
     from datetime import datetime, timedelta, timezone
 
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
     # Create a new client.
-    client = securitycenter.SecurityCenterClient()
+    # More info about SecurityCenterClient:
+    # https://cloud.google.com/python/docs/reference/securitycenter/latest/google.cloud.securitycenter_v1.services.security_center.SecurityCenterClient
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -434,15 +436,19 @@ def list_findings_at_time(source_name):
     #   "folders/{folder_id}"
     # You an also use a wild-card "-" for all sources:
     #   source_name = "organizations/111122222444/sources/-"
-    five_days_ago = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+
+    five_days_ago = datetime.now(timezone.utc) - timedelta(days=5)
+    timestamp_miliseconds = int(five_days_ago.timestamp() * 1000)
     # [END securitycenter_list_findings_at_time]
     i = -1
     # [START securitycenter_list_findings_at_time]
 
+    # More details about the request syntax:
+    # https://cloud.google.com/security-command-center/docs/reference/rest/v1/folders.sources.findings/list
     finding_result_iterator = client.list_findings(
         request={
             "parent": source_name,
-            "filter": f"event_time > {five_days_ago}",
+            "filter": f"event_time > {timestamp_miliseconds}",
         }
     )
 
@@ -460,9 +466,9 @@ def list_findings_at_time(source_name):
 def get_iam_policy(source_name):
     """Gives a user findingsEditor permission to the source."""
     # [START securitycenter_get_source_iam]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).
@@ -480,10 +486,10 @@ def group_all_findings(organization_id):
     """Demonstrates grouping all findings across an organization."""
     i = 0
     # [START securitycenter_group_all_findings]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
     # Create a client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'parent' must be in one of the following formats:
     #   "organizations/{organization_id}"
@@ -506,10 +512,10 @@ def group_filtered_findings(source_name):
     """Demonstrates grouping all findings across an organization."""
     i = 0
     # [START securitycenter_group_filtered_findings]
-    from google.cloud import securitycenter
+    from google.cloud import securitycenter_v1
 
     # Create a client.
-    client = securitycenter.SecurityCenterClient()
+    client = securitycenter_v1.SecurityCenterClient()
 
     # 'source_name' is the resource path for a source that has been
     # created previously (you can use list_sources to find a specific one).

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -559,7 +559,11 @@ def group_findings_at_time(source_name):
     print(f'{read_time=}')
 
     group_result_iterator = client.group_findings(
-        request={"parent": source_name, "group_by": "category", "read_time": read_time}
+        request={
+            "parent": source_name,
+            "group_by": "category",
+            # "read_time": read_time,
+        }
     )
     for i, group_result in enumerate(group_result_iterator):
         print((i + 1), group_result)
@@ -598,7 +602,7 @@ def group_findings_and_changes(source_name):
         request={
             "parent": source_name,
             "group_by": "state_change",
-            "compare_duration": compare_delta,
+            # "compare_duration": compare_delta,
         }
     )
     for i, group_result in enumerate(group_result_iterator):

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -553,7 +553,7 @@ def group_findings_at_time(source_name):
     # source_name = "organizations/111122222444/sources/1234"
 
     # Group findings as of yesterday.
-    read_time = datetime.now(timezone.utc) - timedelta(days=1)
+    read_time = datetime.now() - timedelta(days=1)
 
     # TODO: Remove this after passing the tests
     print(f'{read_time=}')
@@ -562,7 +562,7 @@ def group_findings_at_time(source_name):
         request={
             "parent": source_name,
             "group_by": "category",
-            # "read_time": read_time,
+            "read_time": read_time,
         }
     )
     for i, group_result in enumerate(group_result_iterator):
@@ -579,6 +579,7 @@ def group_findings_and_changes(source_name):
     from datetime import timedelta
 
     from google.cloud import securitycenter
+    from google.protobuf import duration_pb2
 
     # Create a client.
     client = securitycenter.SecurityCenterClient()
@@ -602,10 +603,12 @@ def group_findings_and_changes(source_name):
         request={
             "parent": source_name,
             "group_by": "state_change",
-            # "compare_duration": compare_delta,
+            "compare_duration": compare_delta,
         }
     )
+
     for i, group_result in enumerate(group_result_iterator):
         print((i + 1), group_result)
     # [END securitycenter_group_findings_with_changes]]
+
     return i

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -448,7 +448,7 @@ def list_findings_at_time(source_name):
     finding_result_iterator = client.list_findings(
         request={
             "parent": source_name,
-            "filter": f"event_time > {timestamp_miliseconds}",
+            "filter": f"event_time < {timestamp_miliseconds}",
         }
     )
 

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -355,7 +355,6 @@ def trouble_shoot(source_name):
     print(f"Permision to update state? {len(permission_response.permissions) > 0}")
     # [END securitycenter_test_iam]
     return permission_response
-    assert len(permission_response.permissions) > 0
 
 
 def list_all_findings(organization_id):
@@ -527,88 +526,4 @@ def group_filtered_findings(source_name):
     for i, group_result in enumerate(group_result_iterator):
         print((i + 1), group_result)
     # [END securitycenter_group_filtered_findings]
-    return i
-
-
-def group_findings_at_time(source_name):
-    """Demonstrates grouping all findings across an organization as of
-    a specific time."""
-    i = -1
-    # [START securitycenter_group_findings_at_time]
-    from datetime import datetime, timedelta, timezone
-
-    from google.cloud import securitycenter
-
-    # Create a client.
-    client = securitycenter.SecurityCenterClient()
-
-    # 'source_name' is the resource path for a source that has been
-    # created previously (you can use list_sources to find a specific one).
-    # Its format is:
-    # source_name = "{parent}/sources/{source_id}"
-    # 'parent' must be in one of the following formats:
-    #   "organizations/{organization_id}"
-    #   "projects/{project_id}"
-    #   "folders/{folder_id}"
-    # source_name = "organizations/111122222444/sources/1234"
-
-    # Group findings as of yesterday.
-    read_time = datetime.now() - timedelta(days=1)
-
-    # TODO: Remove this after passing the tests
-    print(f'{read_time=}')
-
-    group_result_iterator = client.group_findings(
-        request={
-            "parent": source_name,
-            "group_by": "category",
-            "read_time": read_time,
-        }
-    )
-    for i, group_result in enumerate(group_result_iterator):
-        print((i + 1), group_result)
-    # [END securitycenter_group_findings_at_time]
-    return i
-
-
-def group_findings_and_changes(source_name):
-    """Demonstrates grouping all findings across an organization and
-    associated changes."""
-    i = 0
-    # [START securitycenter_group_findings_with_changes]
-    from datetime import timedelta
-
-    from google.cloud import securitycenter
-    from google.protobuf import duration_pb2
-
-    # Create a client.
-    client = securitycenter.SecurityCenterClient()
-
-    # 'source_name' is the resource path for a source that has been
-    # created previously (you can use list_sources to find a specific one).
-    # Its format is:
-    # source_name = "{parent}/sources/{source_id}"
-    # 'parent' must be in one of the following formats:
-    #   "organizations/{organization_id}"
-    #   "projects/{project_id}"
-    #   "folders/{folder_id}"
-    # source_name = "organizations/111122222444/sources/1234"
-
-    # List assets and their state change the last 30 days
-    compare_delta = timedelta(days=30)
-
-    print(f'{compare_delta=}')
-
-    group_result_iterator = client.group_findings(
-        request={
-            "parent": source_name,
-            "group_by": "state_change",
-            "compare_duration": compare_delta,
-        }
-    )
-
-    for i, group_result in enumerate(group_result_iterator):
-        print((i + 1), group_result)
-    # [END securitycenter_group_findings_with_changes]]
-
     return i

--- a/securitycenter/snippets/snippets_findings.py
+++ b/securitycenter/snippets/snippets_findings.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -438,7 +440,7 @@ def list_findings_at_time(source_name):
     #   source_name = "organizations/111122222444/sources/-"
 
     five_days_ago = datetime.now(timezone.utc) - timedelta(days=5)
-    timestamp_miliseconds = int(five_days_ago.timestamp() * 1000)
+    timestamp_milliseconds = int(five_days_ago.timestamp() * 1000)
     # [END securitycenter_list_findings_at_time]
     i = -1
     # [START securitycenter_list_findings_at_time]
@@ -448,7 +450,7 @@ def list_findings_at_time(source_name):
     finding_result_iterator = client.list_findings(
         request={
             "parent": source_name,
-            "filter": f"event_time < {timestamp_miliseconds}",
+            "filter": f"event_time < {timestamp_milliseconds}",
         }
     )
 

--- a/securitycenter/snippets/snippets_findings_test.py
+++ b/securitycenter/snippets/snippets_findings_test.py
@@ -121,13 +121,3 @@ def test_group_all_findings(organization_id):
 def test_group_filtered_findings(source_name):
     count = snippets_findings.group_filtered_findings(source_name)
     assert count == 0
-
-
-def test_group_findings_at_time(source_name):
-    count = snippets_findings.group_findings_at_time(source_name)
-    assert count == -1
-
-
-def test_group_findings_and_changes(source_name):
-    count = snippets_findings.group_findings_and_changes(source_name)
-    assert count == 0

--- a/securitycenter/snippets/snippets_findings_test.py
+++ b/securitycenter/snippets/snippets_findings_test.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +21,7 @@ import snippets_findings
 
 @pytest.fixture(scope="module")
 def organization_id():
-    """Get Organization ID from the environment variable"""
+    """Get Organization ID from the environment variable."""
     return os.environ["GCLOUD_ORGANIZATION"]
 
 
@@ -61,7 +59,7 @@ def test_update_source(source_name):
 
 
 def test_add_user_to_source(source_name):
-    binding, updated = snippets_findings.add_user_to_source(source_name)
+    _, updated = snippets_findings.add_user_to_source(source_name)
     assert any(
         member == "user:csccclienttest@gmail.com"
         for member in chain.from_iterable(
@@ -106,7 +104,7 @@ def test_list_filtered_findings(source_name):
     assert count > 0
 
 
-def list_findings_at_time(source_name):
+def test_list_findings_at_time(source_name):
     count = snippets_findings.list_findings_at_time(source_name)
     assert count == -1
 

--- a/securitycenter/snippets/snippets_notification_receiver.py
+++ b/securitycenter/snippets/snippets_notification_receiver.py
@@ -54,5 +54,5 @@ def receive_notifications(project_id, subscription_name):
     except concurrent.futures.TimeoutError:
         streaming_pull_future.cancel()
     # [END securitycenter_receive_notifications]
-    
+
     return True

--- a/securitycenter/snippets/snippets_notification_receiver.py
+++ b/securitycenter/snippets/snippets_notification_receiver.py
@@ -23,6 +23,7 @@ def receive_notifications(project_id, subscription_name):
 
     from google.cloud import pubsub_v1
     from google.cloud.securitycenter_v1 import NotificationMessage
+    from google.protobuf.json_format import ParseError
 
     # TODO: project_id = "your-project-id"
     # TODO: subscription_name = "your-subscription-name"
@@ -31,12 +32,15 @@ def receive_notifications(project_id, subscription_name):
         # Print the data received for debugging purpose if needed
         print(f"Received message: {message.data}")
 
-        notification_msg = NotificationMessage.from_json(message.data)
+        try:
+            notification_msg = NotificationMessage.from_json(message.data)
+        except ParseError:
+            # TODO: DEBUG skip this error
+            pass
 
         print(
-            "Notification config name: {}".format(
-                notification_msg.notification_config_name
-            )
+            "Notification config name: "
+            f"{notification_msg.notification_config_name}"
         )
         print(f"Finding: {notification_msg.finding}")
 

--- a/securitycenter/snippets/snippets_notification_receiver.py
+++ b/securitycenter/snippets/snippets_notification_receiver.py
@@ -34,15 +34,14 @@ def receive_notifications(project_id, subscription_name):
 
         try:
             notification_msg = NotificationMessage.from_json(message.data)
+            print(
+                "Notification config name: "
+                f"{notification_msg.notification_config_name}"
+            )
+            print(f"Finding: {notification_msg.finding}")
         except ParseError:
-            # TODO: DEBUG skip this error
+            print(f"Could not parse message")
             pass
-
-        print(
-            "Notification config name: "
-            f"{notification_msg.notification_config_name}"
-        )
-        print(f"Finding: {notification_msg.finding}")
 
         # Ack the message to prevent it from being pulled again
         message.ack()

--- a/securitycenter/snippets/snippets_notification_receiver.py
+++ b/securitycenter/snippets/snippets_notification_receiver.py
@@ -54,4 +54,5 @@ def receive_notifications(project_id, subscription_name):
     except concurrent.futures.TimeoutError:
         streaming_pull_future.cancel()
     # [END securitycenter_receive_notifications]
+    
     return True

--- a/securitycenter/snippets/snippets_notification_receiver.py
+++ b/securitycenter/snippets/snippets_notification_receiver.py
@@ -40,8 +40,7 @@ def receive_notifications(project_id, subscription_name):
             )
             print(f"Finding: {notification_msg.finding}")
         except ParseError:
-            print(f"Could not parse message")
-            pass
+            print("Could not parse received message as a NotificationMessage.")
 
         # Ack the message to prevent it from being pulled again
         message.ack()

--- a/securitycenter/snippets/snippets_notification_test.py
+++ b/securitycenter/snippets/snippets_notification_test.py
@@ -20,6 +20,7 @@ import uuid
 
 import backoff
 from google.api_core.exceptions import InternalServerError, NotFound, ServiceUnavailable
+from google.protobuf.json_format import ParseError
 from google.cloud import securitycenter as securitycenter
 import pytest
 
@@ -163,6 +164,7 @@ def test_update_notification_config(new_notification_config_for_update):
     assert updated_config is not None
 
 
+@backoff.on_exception(backoff.expo, (ParseError,), max_tries=3)
 def test_receive_notifications():
     assert snippets_notification_receiver.receive_notifications(
         PROJECT_ID, PUBSUB_SUBSCRIPTION

--- a/securitycenter/snippets/snippets_notification_test.py
+++ b/securitycenter/snippets/snippets_notification_test.py
@@ -21,7 +21,6 @@ import uuid
 import backoff
 from google.api_core.exceptions import InternalServerError, NotFound, ServiceUnavailable
 from google.cloud import securitycenter as securitycenter
-from google.protobuf.json_format import ParseError
 import pytest
 
 import snippets_notification_configs
@@ -164,7 +163,6 @@ def test_update_notification_config(new_notification_config_for_update):
     assert updated_config is not None
 
 
-@backoff.on_exception(backoff.expo, (ParseError,), max_tries=3)
 def test_receive_notifications():
     assert snippets_notification_receiver.receive_notifications(
         PROJECT_ID, PUBSUB_SUBSCRIPTION

--- a/securitycenter/snippets/snippets_notification_test.py
+++ b/securitycenter/snippets/snippets_notification_test.py
@@ -20,8 +20,8 @@ import uuid
 
 import backoff
 from google.api_core.exceptions import InternalServerError, NotFound, ServiceUnavailable
-from google.protobuf.json_format import ParseError
 from google.cloud import securitycenter as securitycenter
+from google.protobuf.json_format import ParseError
 import pytest
 
 import snippets_notification_configs

--- a/securitycenter/snippets/snippets_orgs_test.py
+++ b/securitycenter/snippets/snippets_orgs_test.py
@@ -16,6 +16,8 @@
 """Examples for working with organization settings. """
 import os
 
+import backoff
+from google.api_core.exceptions import Aborted
 import pytest
 
 import snippets_orgs
@@ -31,6 +33,7 @@ def test_get_settings(organization_id):
     snippets_orgs.get_settings(organization_id)
 
 
+@backoff.on_exception(backoff.expo, (Aborted,), max_tries=3)
 def test_update_asset_discovery_org_settings(organization_id):
     updated = snippets_orgs.update_asset_discovery_org_settings(organization_id)
     assert updated.enable_asset_discovery


### PR DESCRIPTION
## Description

Fixes Internal: b/402176817
Fixes Issue: #13168

### Delete samples (using deprecated API fields)
- securitycenter_group_findings_with_changes
- securitycenter_group_findings_at_time

### Update failing samples due to changes in API or dependencies

- Update `requirements` to latest versions
- Fix test for `securitycenter_list_findings_at_time` sample
- Add backoff to `test_update_asset_discovery_org_settings`
- Change imports from `securitycenter` to `securitycenter_v1` to make explicit which version is being used
- Add an exception to `securitycenter_receive_notifications` as in the Java sample, reacting to a ParsingError

### Improvements to samples

- Use the same importing style for all datetime objects across samples in `snippet_findings.py`
- Remove deprecation warning for `utcnow()`
- Use a timezone compatible with Python 3.9 (as datetime.UTC was added in Python 3.11)

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup)) -> I'm missing a permission in my local environment, so it will only be tested on Kokoro CI.
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved