### PR TITLE
fix(bigquery): fix typos and comments in cloud-client samples

### DIFF
--- a/bigquery/cloud-client/conftest.py
+++ b/bigquery/cloud-client/conftest.py
@@ -23,9 +23,9 @@ prefixer = test_utils.prefixer.Prefixer("python-docs-samples", "bigquery/cloud-c
 
 PREFIX = prefixer.create_prefix()
 ENTITY_ID = "cloud-developer-relations@google.com"  # Group account
-DATASET_ID = f"{PREFIX}_cloud_client"
-TABLE_NAME = f"{PREFIX}_view_access_policies_table"
-VIEW_NAME = f"{PREFIX}_view_access_policies_view"
+DATASET_ID = f"{PREFIX}_access_policies_dataset"
+TABLE_NAME = f"{PREFIX}_access_policies_table"
+VIEW_NAME = f"{PREFIX}_access_policies_view"
 
 
 @pytest.fixture(scope="module")
@@ -70,8 +70,7 @@ def view(client: bigquery.Client, project_id: str, table: str) -> str:
     view = bigquery.Table(FULL_VIEW_NAME)
 
     # f"{table}" will inject the full table name,
-    # with project_id and dataset_id, as required by
-    # .create_table()
+    # with project_id and dataset_id, as required by create_table()
     view.view_query = f"SELECT * FROM `{table}`"
     view = client.create_table(view)
     return view

--- a/bigquery/cloud-client/grant_access_to_dataset.py
+++ b/bigquery/cloud-client/grant_access_to_dataset.py
@@ -27,12 +27,12 @@ def grant_access_to_dataset(
 
     # TODO(developer): Update and uncomment the lines below.
 
-    # ID of the dataset to revoke access to.
+    # ID of the dataset to grant access to.
     # dataset_id = "my_project_id.my_dataset"
 
-    # ID of the user or group from whom you are adding access.
+    # ID of the user or group receiving access to the dataset.
     # Alternatively, the JSON REST API representation of the entity,
-    # such as a view's table reference.
+    # such as the view's table reference.
     # entity_id = "user-or-group-to-add@example.com"
 
     # One of the "Basic roles for datasets" described here:

--- a/bigquery/cloud-client/grant_access_to_table_or_view.py
+++ b/bigquery/cloud-client/grant_access_to_table_or_view.py
@@ -37,7 +37,7 @@ def grant_access_to_table_or_view(
     # Table or view name to get the access policy.
     # resource_name = "my_table"
 
-    # Principal to whom to grant access.
+    # Principal to grant access to a table or view.
     # For more information about principal identifiers see:
     # https://cloud.google.com/iam/docs/principal-identifiers
     # principal_id = "user:bob@example.com"

--- a/bigquery/cloud-client/grant_access_to_table_or_view.py
+++ b/bigquery/cloud-client/grant_access_to_table_or_view.py
@@ -37,12 +37,14 @@ def grant_access_to_table_or_view(
     # Table or view name to get the access policy.
     # resource_name = "my_table"
 
-    # The principal requesting access to the table or view.
-    # Find more details about principal identifiers here:
+    # Principal to whom to grant access.
+    # For more information about principal identifiers see:
     # https://cloud.google.com/iam/docs/principal-identifiers
     # principal_id = "user:bob@example.com"
 
-    # Role to assign to the member.
+    # Role to grant to the principal.
+    # For more information about BigQuery roles see:
+    # https://cloud.google.com/bigquery/docs/access-control
     # role = "roles/bigquery.dataViewer"
 
     # Instantiate a client.
@@ -54,8 +56,7 @@ def grant_access_to_table_or_view(
     # Get the IAM access policy for the table or view.
     policy = client.get_iam_policy(full_resource_name)
 
-    # To grant access to a table or view,
-    # add bindings to the Table or View policy.
+    # To grant access to a table or view, add bindings to the IAM policy.
     #
     # Find more details about Policy and Binding objects here:
     # https://cloud.google.com/security-command-center/docs/reference/rest/Shared.Types/Policy
@@ -66,7 +67,7 @@ def grant_access_to_table_or_view(
     }
     policy.bindings.append(binding)
 
-    # Set the IAM access spolicy with updated bindings.
+    # Set the IAM access policy with updated bindings.
     updated_policy = client.set_iam_policy(full_resource_name, policy)
 
     # Show a success message.

--- a/bigquery/cloud-client/revoke_access_to_table_or_view.py
+++ b/bigquery/cloud-client/revoke_access_to_table_or_view.py
@@ -25,7 +25,6 @@ def revoke_access_to_table_or_view(
     principal_to_remove: str | None = None,
 ) -> Policy:
     # [START bigquery_revoke_access_to_table_or_view]
-    # Imports the Google Cloud client library.
     from google.cloud import bigquery
 
     # TODO(developer): Update and uncomment the lines below.
@@ -48,7 +47,7 @@ def revoke_access_to_table_or_view(
     # Find more information about roles and principals (referred to as members) here:
     # https://cloud.google.com/security-command-center/docs/reference/rest/Shared.Types/Binding
 
-    # Instantiates a client.
+    # Instantiate a client.
     client = bigquery.Client()
 
     # Get the full table name.
@@ -58,7 +57,7 @@ def revoke_access_to_table_or_view(
     policy = client.get_iam_policy(full_resource_name)
 
     # To revoke access to a table or view,
-    # remove bindings from the Table or View policy.
+    # remove bindings from the Table or View IAM policy.
     #
     # Find more details about the Policy object here:
     # https://cloud.google.com/security-command-center/docs/reference/rest/Shared.Types/Policy

--- a/bigquery/cloud-client/revoke_dataset_access.py
+++ b/bigquery/cloud-client/revoke_dataset_access.py
@@ -60,7 +60,7 @@ def revoke_dataset_access(dataset_id: str, entity_id: str) -> list[AccessEntry]:
             ["access_entries"],
         )
 
-        # Show a success message.
+        # Notify user that the API call was successful.
         full_dataset_id = f"{dataset.project}.{dataset.dataset_id}"
         print(f"Revoked dataset access for '{entity_id}' to ' dataset '{full_dataset_id}.'")
     except PreconditionFailed:  # A read-modify-write error.

--- a/bigquery/cloud-client/revoke_dataset_access.py
+++ b/bigquery/cloud-client/revoke_dataset_access.py
@@ -17,14 +17,13 @@ from google.cloud.bigquery.dataset import AccessEntry
 
 def revoke_dataset_access(dataset_id: str, entity_id: str) -> list[AccessEntry]:
     # [START bigquery_revoke_dataset_access]
-    # Import the Google Cloud client library.
     from google.cloud import bigquery
     from google.api_core.exceptions import PreconditionFailed
 
     # TODO(developer): Update and uncomment the lines below.
 
     # ID of the dataset to revoke access to.
-    # dataset_id = "your-project.your_dataset"
+    # dataset_id = "my-project.my_dataset"
 
     # ID of the user or group from whom you are revoking access.
     # Alternatively, the JSON REST API representation of the entity,
@@ -61,6 +60,7 @@ def revoke_dataset_access(dataset_id: str, entity_id: str) -> list[AccessEntry]:
             ["access_entries"],
         )
 
+        # Show a success message.
         full_dataset_id = f"{dataset.project}.{dataset.dataset_id}"
         print(f"Revoked dataset access for '{entity_id}' to ' dataset '{full_dataset_id}.'")
     except PreconditionFailed:  # A read-modify-write error.

--- a/bigquery/cloud-client/view_dataset_access_policy.py
+++ b/bigquery/cloud-client/view_dataset_access_policy.py
@@ -17,7 +17,6 @@ from google.cloud.bigquery.dataset import AccessEntry
 
 def view_dataset_access_policy(dataset_id: str) -> list[AccessEntry]:
     # [START bigquery_view_dataset_access_policy]
-    # Import the Google Cloud client library.
     from google.cloud import bigquery
 
     # Instantiate a client.
@@ -38,6 +37,7 @@ def view_dataset_access_policy(dataset_id: str) -> list[AccessEntry]:
         f"{len(dataset.access_entries)} Access entries found "
         f"in dataset '{dataset_id}':"
     )
+
     for access_entry in dataset.access_entries:
         print()
         print(f"Role: {access_entry.role}")

--- a/bigquery/cloud-client/view_table_or_view_access_policy.py
+++ b/bigquery/cloud-client/view_table_or_view_access_policy.py
@@ -17,7 +17,6 @@ from google.api_core.iam import Policy
 
 def view_table_or_view_access_policy(project_id: str, dataset_id: str, resource_id: str) -> Policy:
     # [START bigquery_view_table_or_view_access_policy]
-    # Imports the Google Cloud client library.
     from google.cloud import bigquery
 
     # TODO(developer): Update and uncomment the lines below.


### PR DESCRIPTION
## Description

Fixes b/403272595

- Fix comments (for example 'grant' instead of 'revoke', and found typos)
- Remove unnecessary comments (for example in imports at the start of the sample)
- Unify comments style

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved