### PR TITLE
chore(language): remove markdown files from migration

### DIFF
--- a/language/AUTHORING_GUIDE.md
+++ b/language/AUTHORING_GUIDE.md
@@ -1,1 +1,0 @@
-See https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md

--- a/language/CONTRIBUTING.md
+++ b/language/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-See https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/CONTRIBUTING.md

--- a/language/README.md
+++ b/language/README.md
@@ -1,3 +1,0 @@
-These samples have been moved.
-
-https://github.com/googleapis/python-language/tree/main/samples


### PR DESCRIPTION
## Description

- Delete Markdown files pointing to an archived repo which returned a "Not found 404".

- Delete files not required in this repo, as they already are in the root directory:
language/AUTHORING_GUIDE.md
language/CONTRIBUTING.md

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] Please **merge** this PR for me once it is approved