### PR TITLE
fix: make mock span expected format

### DIFF
--- a/functions/v2/http_logging/main_test.py
+++ b/functions/v2/http_logging/main_test.py
@@ -34,7 +34,7 @@ def test_functions_log_http_should_print_message(app, capsys):
     os.environ["K_CONFIGURATION"] = "test-config-name"
     project_id = os.environ["GOOGLE_CLOUD_PROJECT"]
     mock_trace = "abcdef"
-    mock_span = "2"
+    mock_span = "0000000000000002"
     expected = {
         "message": "Hello, world!",
         "severity": "INFO",


### PR DESCRIPTION
## Description

Resolves testing errors on #12895

Updates the mockdata in this test to match the expected data format: 

https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.span_id

> The span ID is expected to be a 16-character, hexadecimal encoding of an 8-byte array and should not be zero.

The original mock value was being formatted, and thus failing the assert. 

- [x] Please **merge** this PR for me once it is approved