### PR TITLE
fix(template): update template to not test 3.13

### DIFF
--- a/generative_ai/template_folder/noxfile_config.py
+++ b/generative_ai/template_folder/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11"],
+    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,


### PR DESCRIPTION
## Description

Resolves CI issues with #12851, #12861, #12865, #12947, #12952, #12959, #12975, #13152

The `generative_ai/` template folder contains valid tests, and is currently failing the above PRs due to requiring `pandas`, which as of pandas 2.2.3 does not support Python 3.13. 

All other samples within the folder don't test for Python 3.13, so update the template to match. 

cc @msampathkumar 

- [x] Please **merge** this PR for me once it is approved