### PR TITLE
chore(deps): bump deps for generative_ai/embeddings

### DIFF
--- a/generative_ai/embeddings/requirements.txt
+++ b/generative_ai/embeddings/requirements.txt
@@ -1,14 +1,12 @@
 pandas==1.3.5; python_version == '3.7'
 pandas==2.0.3; python_version == '3.8'
-pandas==2.1.4; python_version > '3.8'
+pandas==2.2.3; python_version > '3.8'
 pillow==10.3.0; python_version < '3.8'
 pillow==10.3.0; python_version >= '3.8'
-google-cloud-aiplatform[all]==1.69.0
+google-cloud-aiplatform[all]==1.84.0
 sentencepiece==0.2.0
 google-auth==2.29.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
 numpy<2
 openai==1.30.5
 immutabledict==4.2.0


### PR DESCRIPTION
## Description

Resolves CI issues with #12851, #12861, #12865, #12947, #12952, #12959, #12975, #13152

Fixes #12995

Based on local testing, updating the pandas (#13152) and google-cloud-aiplatform (#12865) version to latest resolves the NoneType issue. 

- [x] Please **merge** this PR for me once it is approved
- [x] Please rebase linked PRs after merging