### PR TITLE
feat(translate): add region tag 'import_client_library' and refactor sample

### DIFF
--- a/translate/samples/AUTHORING_GUIDE.md
+++ b/translate/samples/AUTHORING_GUIDE.md
@@ -1,1 +1,0 @@
-See https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md

--- a/translate/samples/CONTRIBUTING.md
+++ b/translate/samples/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-See https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/CONTRIBUTING.md

--- a/translate/samples/snippets/noxfile_config.py
+++ b/translate/samples/snippets/noxfile_config.py
@@ -22,7 +22,6 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # Google-cloud-translate doesn't work with Python 3.12 for now.
     "ignored_versions": ["2.7", "3.7", "3.8"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them

--- a/translate/samples/snippets/noxfile_config.py
+++ b/translate/samples/snippets/noxfile_config.py
@@ -23,7 +23,7 @@
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # Google-cloud-translate doesn't work with Python 3.12 for now.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.12", "3.13"],
+    "ignored_versions": ["2.7", "3.7", "3.8"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/translate/samples/snippets/requirements.txt
+++ b/translate/samples/snippets/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-translate==3.18.0
-google-cloud-storage==2.9.0
-google-cloud-automl==2.14.1
+google-cloud-translate==3.20.2
+google-cloud-storage==3.1.0
+google-cloud-automl==2.16.3
 google-cloud-aiplatform[vertexai]

--- a/translate/samples/snippets/requirements.txt
+++ b/translate/samples/snippets/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-translate==3.20.2
-google-cloud-storage==3.1.0
-google-cloud-automl==2.16.3
+google-cloud-translate==3.18.0
+google-cloud-storage==2.9.0
+google-cloud-automl==2.14.1
 google-cloud-aiplatform[vertexai]

--- a/translate/samples/snippets/translate_v3_translate_text.py
+++ b/translate/samples/snippets/translate_v3_translate_text.py
@@ -17,7 +17,7 @@ import os
 
 # Import the Google Cloud Translation library.
 # [START translate_v3_import_client_library]
-from google.cloud import translate_v3beta1 as translate
+from google.cloud import translate_v3
 # [END translate_v3_import_client_library]
 
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT")
@@ -27,7 +27,7 @@ def translate_text(
     text: str = "YOUR_TEXT_TO_TRANSLATE",
     source_language_code: str = "en-US",
     target_language_code: str = "fr",
-) -> translate.TranslationServiceClient:
+) -> translate_v3.TranslationServiceClient:
     """Translate Text from a Source language to a Target language.
     Args:
         text: The content to translate.
@@ -39,7 +39,7 @@ def translate_text(
     """
 
     # Initialize Translation client.
-    client = translate.TranslationServiceClient()
+    client = translate_v3.TranslationServiceClient()
     parent = f"projects/{PROJECT_ID}/locations/global"
 
     # MIME type of the content to translate.

--- a/translate/samples/snippets/translate_v3_translate_text.py
+++ b/translate/samples/snippets/translate_v3_translate_text.py
@@ -25,14 +25,16 @@ PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT")
 
 def translate_text(
     text: str = "YOUR_TEXT_TO_TRANSLATE",
-    language_code: str = "fr",
+    source_language_code: str = "en-US",
+    target_language_code: str = "fr",
 ) -> translate_v3.TranslationServiceClient:
-    """Translating Text from English.
+    """Translate Text from a Source language to a Target language.
     Args:
         text: The content to translate.
-        language_code: The language code for the translation.
-            E.g. "fr" for French, "es" for Spanish, etc.
-            Available languages:
+        source_language_code: The code of the source language.
+        target_language_code: The code of the target language.
+            For example: "fr" for French, "es" for Spanish, etc.
+            Find available languages and codes here:
             https://cloud.google.com/translate/docs/languages#neural_machine_translation_model
     """
 
@@ -40,26 +42,18 @@ def translate_text(
     client = translate_v3.TranslationServiceClient()
     parent = f"projects/{PROJECT_ID}/locations/global"
 
-    # Translate text from English to chosen language.
-    # Supported MIME types:
-    # https://cloud.google.com/translate/docs/supported-formats
+    # Translate text from the source to the target language.
     response = client.translate_text(
         contents=[text],
-        target_language_code=language_code,
         parent=parent,
-        mime_type="text/plain",
-        source_language_code="en-US",
+        source_language_code=source_language_code,
+        target_language_code=target_language_code,
     )
 
-    # Display the translation for each input text provided.
-    for translation in response.translations:
-        print(f"Translated text: {translation.translated_text}")
-
-    # Example response:
+    # Display the translation for the text.
+    # For example, for "Hello! How are you doing today?":
     # Translated text: Bonjour comment vas-tu aujourd'hui?
+    print(f"Translated text: {response.translations[0].translated_text[0]}")
+
     return response
 # [END translate_v3_translate_text]
-
-
-if __name__ == "__main__":
-    translate_text(text="Hello! How are you doing today?", language_code="fr")

--- a/translate/samples/snippets/translate_v3_translate_text.py
+++ b/translate/samples/snippets/translate_v3_translate_text.py
@@ -17,7 +17,7 @@ import os
 
 # Import the Google Cloud Translation library.
 # [START translate_v3_import_client_library]
-from google.cloud import translate_v3
+from google.cloud import translate_v3beta1 as translate
 # [END translate_v3_import_client_library]
 
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT")
@@ -27,7 +27,7 @@ def translate_text(
     text: str = "YOUR_TEXT_TO_TRANSLATE",
     source_language_code: str = "en-US",
     target_language_code: str = "fr",
-) -> translate_v3.TranslationServiceClient:
+) -> translate.TranslationServiceClient:
     """Translate Text from a Source language to a Target language.
     Args:
         text: The content to translate.
@@ -39,11 +39,11 @@ def translate_text(
     """
 
     # Initialize Translation client.
-    client = translate_v3.TranslationServiceClient()
+    client = translate.TranslationServiceClient()
     parent = f"projects/{PROJECT_ID}/locations/global"
 
     # MIME type of the content to translate.
-    # Find supported types for `Text translation - Advanced (v3)` here:
+    # Supported MIME types:
     # https://cloud.google.com/translate/docs/supported-formats
     mime_type = "text/plain"
 

--- a/translate/samples/snippets/translate_v3_translate_text.py
+++ b/translate/samples/snippets/translate_v3_translate_text.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 # [START translate_v3_translate_text]
-# Imports the Google Cloud Translation library
 import os
 
+# Import the Google Cloud Translation library.
+# [START translate_v3_import_client_library]
 from google.cloud import translate_v3
+# [END translate_v3_import_client_library]
 
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT")
 
 
-# Initialize Translation client
 def translate_text(
     text: str = "YOUR_TEXT_TO_TRANSLATE",
     language_code: str = "fr",
@@ -31,13 +32,17 @@ def translate_text(
         text: The content to translate.
         language_code: The language code for the translation.
             E.g. "fr" for French, "es" for Spanish, etc.
-            Available languages: https://cloud.google.com/translate/docs/languages#neural_machine_translation_model
+            Available languages:
+            https://cloud.google.com/translate/docs/languages#neural_machine_translation_model
     """
 
+    # Initialize Translation client.
     client = translate_v3.TranslationServiceClient()
     parent = f"projects/{PROJECT_ID}/locations/global"
-    # Translate text from English to chosen language
-    # Supported mime types: # https://cloud.google.com/translate/docs/supported-formats
+
+    # Translate text from English to chosen language.
+    # Supported MIME types:
+    # https://cloud.google.com/translate/docs/supported-formats
     response = client.translate_text(
         contents=[text],
         target_language_code=language_code,
@@ -46,16 +51,15 @@ def translate_text(
         source_language_code="en-US",
     )
 
-    # Display the translation for each input text provided
+    # Display the translation for each input text provided.
     for translation in response.translations:
         print(f"Translated text: {translation.translated_text}")
+
     # Example response:
     # Translated text: Bonjour comment vas-tu aujourd'hui?
-
     return response
-
-
 # [END translate_v3_translate_text]
+
 
 if __name__ == "__main__":
     translate_text(text="Hello! How are you doing today?", language_code="fr")

--- a/translate/samples/snippets/translate_v3_translate_text.py
+++ b/translate/samples/snippets/translate_v3_translate_text.py
@@ -42,10 +42,16 @@ def translate_text(
     client = translate_v3.TranslationServiceClient()
     parent = f"projects/{PROJECT_ID}/locations/global"
 
+    # MIME type of the content to translate.
+    # Find supported types for `Text translation - Advanced (v3)` here:
+    # https://cloud.google.com/translate/docs/supported-formats
+    mime_type = "text/plain"
+
     # Translate text from the source to the target language.
     response = client.translate_text(
         contents=[text],
         parent=parent,
+        mime_type=mime_type,
         source_language_code=source_language_code,
         target_language_code=target_language_code,
     )
@@ -53,7 +59,16 @@ def translate_text(
     # Display the translation for the text.
     # For example, for "Hello! How are you doing today?":
     # Translated text: Bonjour comment vas-tu aujourd'hui?
-    print(f"Translated text: {response.translations[0].translated_text[0]}")
+    for translation in response.translations:
+        print(f"Translated text: {translation.translated_text}")
 
     return response
 # [END translate_v3_translate_text]
+
+
+if __name__ == "__main__":
+    translate_text(
+        text="Hello! How are you doing today?",
+        source_language_code="en-US",
+        target_language_code="fr"
+    )

--- a/translate/samples/snippets/translate_v3_translate_text_test.py
+++ b/translate/samples/snippets/translate_v3_translate_text_test.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
 import translate_v3_translate_text
 
 
-def test_translate_text(capsys: pytest.LogCaptureFixture) -> None:
-    response = translate_v3_translate_text.translate_text("Hello World!", "fr")
-    out, _ = capsys.readouterr()
+def test_translate_text() -> None:
+    response = translate_v3_translate_text.translate_text("Hello World!", "en-US", "fr")
     assert "Bonjour le monde" in response.translations[0].translated_text


### PR DESCRIPTION
## Description

Fixes Internal:
b/405384416

- Add region tag 'translate_v3_import_client_library'
- Remove remaining Markdown files from previous repos [1](https://github.com/googleapis/python-translate) and [2](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-translate/samples)
- Fix styling of the sample and removed unnecessary dependencies
- Refactor to improve sample objective of showing how to translate a simple text.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved