### PR TITLE
fix(documentai): refactor 'quickstart' sample

### DIFF
--- a/documentai/snippets/quickstart_sample.py
+++ b/documentai/snippets/quickstart_sample.py
@@ -13,21 +13,26 @@
 # limitations under the License.
 
 from google.cloud.documentai_v1.types.document import Document
-from google.cloud.documentai_v1.types.processor import Processor
 
 
 def quickstart(
     project_id: str,
+    processor_id: str,
     location: str,
     file_path: str,
-    processor_display_name: str,
-) -> tuple[Processor, Document]:
+) -> Document:
     # [START documentai_quickstart]
     from google.api_core.client_options import ClientOptions
-    from google.cloud import documentai_v1  # type: ignore
+    from google.cloud import documentai_v1
+
+    # TODO(developer): Create a processor of type "OCR_PROCESSOR".
 
     # TODO(developer): Update and uncomment these variables before running the sample.
     # project_id = "MY_PROJECT_ID"
+
+    # Processor ID as hexadecimal characters.
+    # Not to be confused with the Processor Display Name.
+    # processor_id = "MY_PROCESSOR_ID"
 
     # Processor location. For example: "us" or "eu".
     # location = "MY_PROCESSOR_LOCATION"
@@ -35,30 +40,21 @@ def quickstart(
     # Path for file to process.
     # file_path = "/path/to/local/pdf"
 
-    # Processor display name must be unique per project.
-    # processor_display_name = "MY_PROCESSOR_DISPLAY_NAME"
-
     # Set `api_endpoint` if you use a location other than "us".
     opts = ClientOptions(api_endpoint=f"{location}-documentai.googleapis.com")
 
     # Initialize Document AI client.
     client = documentai_v1.DocumentProcessorServiceClient(client_options=opts)
 
-    # Get the full resource name of the location.
-    # For example: `projects/{project_id}/locations/{location}`
-    parent = client.common_location_path(project_id, location)
+    # Get the Fully-qualified Processor path.
+    full_processor_name = client.processor_path(project_id, location, processor_id)
 
-    # Create a Processor.
-    # For available types, refer to https://cloud.google.com/document-ai/docs/create-processor
-    processor = client.create_processor(
-        parent=parent,
-        processor=documentai_v1.Processor(
-            type_="OCR_PROCESSOR",
-            display_name=processor_display_name,
-        ),
-    )
+    # Get a Processor reference.
+    request = documentai_v1.GetProcessorRequest(name=full_processor_name)
+    processor = client.get_processor(request=request)
 
-    # Print the processor information.
+    # `processor.name` is the full resource name of the processor.
+    # For example: `projects/{project_id}/locations/{location}/processors/{processor_id}`
     print(f"Processor Name: {processor.name}")
 
     # Read the file into memory.
@@ -72,11 +68,8 @@ def quickstart(
         mime_type="application/pdf",
     )
 
-    # Configure the process request.
-    # `processor.name` is the full resource name of the processor,
-    # For example: `projects/{project_id}/locations/{location}/processors/{processor_id}`
+    # Send a request and get the processed document.
     request = documentai_v1.ProcessRequest(name=processor.name, raw_document=raw_document)
-
     result = client.process_document(request=request)
     document = result.document
 
@@ -87,4 +80,4 @@ def quickstart(
     print(document.text)
     # [END documentai_quickstart]
 
-    return processor, document
+    return document


### PR DESCRIPTION
## Description

Fixes Internal: b/393632125

- Refactor sample to make it consistent with other languages in https://cloud.google.com/document-ai/docs/process-documents-client-libraries#using_the_client_library
- Move the creation and deletion of the Processor from the sample to a Test fixture as the Quickstart shows how to create the processor in the Web console, not by Python code
- Cleanup test workflow based on Cavazos' advice

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved