### PR TITLE
feat(parametermanager): added samples for handling cmek in parameter for global and regional

### DIFF
--- a/parametermanager/snippets/create_param_with_kms_key.py
+++ b/parametermanager/snippets/create_param_with_kms_key.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for
+creating a new default format parameter with kms key.
+"""
+
+from google.cloud import parametermanager_v1
+
+
+# [START parametermanager_create_param_with_kms_key]
+def create_param_with_kms_key(
+    project_id: str, parameter_id: str, kms_key: str
+) -> parametermanager_v1.Parameter:
+    """
+    Creates a parameter with default format (Unformatted)
+    in the global location of the specified
+    project and kms key using the Google Cloud Parameter Manager SDK.
+
+    Args:
+        project_id (str): The ID of the project where
+        the parameter is to be created.
+        parameter_id (str): The ID to assign to the new parameter.
+        This ID must be unique within the project.
+        kms_key (str): The KMS key used to encrypt the parameter.
+
+    Returns:
+        parametermanager_v1.Parameter: An object representing
+        the newly created parameter.
+
+    Example:
+        create_param_with_kms_key(
+            "my-project",
+            "my-global-parameter",
+            "projects/my-project/locations/global/keyRings/test/cryptoKeys/test-key"
+        )
+    """
+    # Import the necessary library for Google Cloud Parameter Manager.
+    from google.cloud import parametermanager_v1
+
+    # Create the Parameter Manager client.
+    client = parametermanager_v1.ParameterManagerClient()
+
+    # Build the resource name of the parent project in the global location.
+    parent = client.common_location_path(project_id, "global")
+
+    # Define the parameter creation request.
+    request = parametermanager_v1.CreateParameterRequest(
+        parent=parent,
+        parameter_id=parameter_id,
+        parameter=parametermanager_v1.Parameter(kms_key=kms_key),
+    )
+
+    # Create the parameter.
+    response = client.create_parameter(request=request)
+
+    # Print the newly created parameter name.
+    print(f"Created parameter {response.name} with kms key {kms_key}")
+    # [END parametermanager_create_param_with_kms_key]
+
+    return response

--- a/parametermanager/snippets/regional_samples/create_regional_param_with_kms_key.py
+++ b/parametermanager/snippets/regional_samples/create_regional_param_with_kms_key.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for
+creating a new default format regional parameter with kms key.
+"""
+
+from google.cloud import parametermanager_v1
+
+
+# [START parametermanager_create_regional_param_with_kms_key]
+def create_regional_param_with_kms_key(
+    project_id: str, location_id: str, parameter_id: str, kms_key: str
+) -> parametermanager_v1.Parameter:
+    """
+    Creates a regional parameter with default format (Unformatted)
+    in the specified location, project and with kms key
+    using the Google Cloud Parameter Manager SDK.
+
+    Args:
+        project_id (str): The ID of the project where
+        the regional parameter is to be created.
+        location_id (str): The region where the parameter is to be created.
+        parameter_id (str): The ID to assign to the new parameter.
+        This ID must be unique within the project.
+        kms_key (str): The KMS key used to encrypt the parameter.
+
+    Returns:
+        parametermanager_v1.Parameter: An object representing
+        the newly created regional parameter.
+
+    Example:
+        create_regional_param_with_kms_key(
+            "my-project",
+            "us-central1",
+            "my-regional-parameter",
+            "projects/my-project/locations/us-central1/keyRings/test/cryptoKeys/test-key"
+        )
+    """
+
+    # Import the Parameter Manager client library.
+    from google.cloud import parametermanager_v1
+
+    api_endpoint = f"parametermanager.{location_id}.rep.googleapis.com"
+    # Create the Parameter Manager client for the specified region.
+    client = parametermanager_v1.ParameterManagerClient(
+        client_options={"api_endpoint": api_endpoint}
+    )
+
+    # Build the resource name of the parent project for the specified region.
+    parent = client.common_location_path(project_id, location_id)
+
+    # Define the parameter creation request.
+    request = parametermanager_v1.CreateParameterRequest(
+        parent=parent,
+        parameter_id=parameter_id,
+        parameter=parametermanager_v1.Parameter(kms_key=kms_key),
+    )
+
+    # Create the parameter.
+    response = client.create_parameter(request=request)
+
+    # Print the newly created parameter name.
+    print(f"Created regional parameter {response.name} with kms key {kms_key}")
+    # [END parametermanager_create_regional_param_with_kms_key]
+
+    return response

--- a/parametermanager/snippets/regional_samples/remove_regional_param_kms_key.py
+++ b/parametermanager/snippets/regional_samples/remove_regional_param_kms_key.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for removing the kms key from the regional parameter.
+"""
+
+from google.cloud import parametermanager_v1
+
+
+# [START parametermanager_remove_regional_param_kms_key]
+def remove_regional_param_kms_key(
+    project_id: str, location_id: str, parameter_id: str
+) -> parametermanager_v1.Parameter:
+    """
+    Remove the kms key of a specified regional parameter
+    in the specified project using the Google Cloud Parameter Manager SDK.
+
+    Args:
+        project_id (str): The ID of the project where the parameter is to be created.
+        location_id (str): The region where the parameter is to be created.
+        parameter_id (str): The ID of the regional parameter for
+        which kms key is to be updated.
+
+    Returns:
+        parametermanager_v1.Parameter: An object representing the
+        updated regional parameter.
+
+    Example:
+        remove_regional_param_kms_key(
+            "my-project",
+            "us-central1",
+            "my-global-parameter"
+        )
+    """
+    # Import the necessary library for Google Cloud Parameter Manager.
+    from google.cloud import parametermanager_v1
+    from google.protobuf import field_mask_pb2
+
+    # Create the Parameter Manager client.
+    api_endpoint = f"parametermanager.{location_id}.rep.googleapis.com"
+    # Create the Parameter Manager client for the specified region.
+    client = parametermanager_v1.ParameterManagerClient(
+        client_options={"api_endpoint": api_endpoint}
+    )
+
+    # Build the resource name of the regional parameter.
+    name = client.parameter_path(project_id, location_id, parameter_id)
+
+    # Get the current regional parameter details.
+    parameter = client.get_parameter(name=name)
+
+    # Set the kms key field of the regional parameter.
+    parameter.kms_key = None
+
+    # Define the update mask for the kms_key field.
+    update_mask = field_mask_pb2.FieldMask(paths=["kms_key"])
+
+    # Define the request to update the parameter.
+    request = parametermanager_v1.UpdateParameterRequest(
+        parameter=parameter, update_mask=update_mask
+    )
+
+    # Call the API to update (kms_key) the parameter.
+    response = client.update_parameter(request=request)
+
+    # Print the parameter ID that was updated.
+    print(f"Removed kms key for regional parameter {parameter_id}")
+    # [END parametermanager_remove_regional_param_kms_key]
+
+    return response

--- a/parametermanager/snippets/regional_samples/update_regional_param_kms_key.py
+++ b/parametermanager/snippets/regional_samples/update_regional_param_kms_key.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for updating the kms key of the regional parameter.
+"""
+
+from google.cloud import parametermanager_v1
+
+
+# [START parametermanager_update_regional_param_kms_key]
+def update_regional_param_kms_key(
+    project_id: str, location_id: str, parameter_id: str, kms_key: str
+) -> parametermanager_v1.Parameter:
+    """
+    Update the kms key of a specified regional parameter
+    in the specified project using the Google Cloud Parameter Manager SDK.
+
+    Args:
+        project_id (str): The ID of the project where the parameter is to be created.
+        location_id (str): The region where the parameter is to be created.
+        parameter_id (str): The ID of the regional parameter for
+        which kms key is to be updated.
+        kms_key (str): The kms_key to be updated for the parameter.
+
+    Returns:
+        parametermanager_v1.Parameter: An object representing the
+        updated regional parameter.
+
+    Example:
+        update_regional_param_kms_key(
+            "my-project",
+            "us-central1",
+            "my-global-parameter",
+            "projects/my-project/locations/us-central1/keyRings/test/cryptoKeys/updated-test-key"
+        )
+    """
+    # Import the necessary library for Google Cloud Parameter Manager.
+    from google.cloud import parametermanager_v1
+    from google.protobuf import field_mask_pb2
+
+    # Create the Parameter Manager client.
+    api_endpoint = f"parametermanager.{location_id}.rep.googleapis.com"
+    # Create the Parameter Manager client for the specified region.
+    client = parametermanager_v1.ParameterManagerClient(
+        client_options={"api_endpoint": api_endpoint}
+    )
+
+    # Build the resource name of the regional parameter.
+    name = client.parameter_path(project_id, location_id, parameter_id)
+
+    # Get the current regional parameter details.
+    parameter = client.get_parameter(name=name)
+
+    # Set the kms key field of the regional parameter.
+    parameter.kms_key = kms_key
+
+    # Define the update mask for the kms_key field.
+    update_mask = field_mask_pb2.FieldMask(paths=["kms_key"])
+
+    # Define the request to update the parameter.
+    request = parametermanager_v1.UpdateParameterRequest(
+        parameter=parameter, update_mask=update_mask
+    )
+
+    # Call the API to update (kms_key) the parameter.
+    response = client.update_parameter(request=request)
+
+    # Print the parameter ID that was updated.
+    print(f"Updated regional parameter {parameter_id} with kms key {response.kms_key}")
+    # [END parametermanager_update_regional_param_kms_key]
+
+    return response

--- a/parametermanager/snippets/remove_param_kms_key.py
+++ b/parametermanager/snippets/remove_param_kms_key.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for removing the kms key of the parameter.
+"""
+from google.cloud import parametermanager_v1
+
+
+# [START parametermanager_remove_param_kms_key]
+def remove_param_kms_key(
+    project_id: str, parameter_id: str
+) -> parametermanager_v1.Parameter:
+    """
+    Remove a kms key of a specified global parameter
+    in the specified project using the Google Cloud Parameter Manager SDK.
+
+    Args:
+        project_id (str): The ID of the project where the parameter is located.
+        parameter_id (str): The ID of the parameter for
+        which kms key is to be removed.
+
+    Returns:
+        parametermanager_v1.Parameter: An object representing the
+        updated parameter.
+
+    Example:
+        remove_param_kms_key(
+            "my-project",
+            "my-global-parameter"
+        )
+    """
+    # Import the necessary library for Google Cloud Parameter Manager.
+    from google.cloud import parametermanager_v1
+    from google.protobuf import field_mask_pb2
+
+    # Create the Parameter Manager client.
+    client = parametermanager_v1.ParameterManagerClient()
+
+    # Build the resource name of the parameter.
+    name = client.parameter_path(project_id, "global", parameter_id)
+
+    # Get the current parameter details.
+    parameter = client.get_parameter(name=name)
+
+    parameter.kms_key = None
+
+    # Define the update mask for the kms_key field.
+    update_mask = field_mask_pb2.FieldMask(paths=["kms_key"])
+
+    # Define the request to update the parameter.
+    request = parametermanager_v1.UpdateParameterRequest(
+        parameter=parameter, update_mask=update_mask
+    )
+
+    # Call the API to update (kms_key) the parameter.
+    response = client.update_parameter(request=request)
+
+    # Print the parameter ID that it was disabled.
+    print(f"Removed kms key for parameter {parameter_id}")
+    # [END parametermanager_remove_param_kms_key]
+
+    return response

--- a/parametermanager/snippets/requirements-test.txt
+++ b/parametermanager/snippets/requirements-test.txt
@@ -1,2 +1,3 @@
 pytest==8.2.0
 google-cloud-secret-manager==2.21.1
+google-cloud-kms==3.2.1

--- a/parametermanager/snippets/requirements.txt
+++ b/parametermanager/snippets/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-parametermanager==0.1.0
+google-cloud-parametermanager==0.1.3

--- a/parametermanager/snippets/update_param_kms_key.py
+++ b/parametermanager/snippets/update_param_kms_key.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for updating the kms key of the parameter.
+"""
+
+from google.cloud import parametermanager_v1
+
+
+# [START parametermanager_update_param_kms_key]
+def update_param_kms_key(
+    project_id: str, parameter_id: str, kms_key: str
+) -> parametermanager_v1.Parameter:
+    """
+    Update the kms key of a specified global parameter
+    in the specified project using the Google Cloud Parameter Manager SDK.
+
+    Args:
+        project_id (str): The ID of the project where the parameter is located.
+        parameter_id (str): The ID of the parameter for
+        which kms key is to be updated.
+        kms_key (str): The kms_key to be updated for the parameter.
+
+    Returns:
+        parametermanager_v1.Parameter: An object representing the
+        updated parameter.
+
+    Example:
+        update_param_kms_key(
+            "my-project",
+            "my-global-parameter",
+            "projects/my-project/locations/global/keyRings/test/cryptoKeys/updated-test-key"
+        )
+    """
+    # Import the necessary library for Google Cloud Parameter Manager.
+    from google.cloud import parametermanager_v1
+    from google.protobuf import field_mask_pb2
+
+    # Create the Parameter Manager client.
+    client = parametermanager_v1.ParameterManagerClient()
+
+    # Build the resource name of the parameter.
+    name = client.parameter_path(project_id, "global", parameter_id)
+
+    # Get the current parameter details.
+    parameter = client.get_parameter(name=name)
+
+    # Set the kms key field of the parameter.
+    parameter.kms_key = kms_key
+
+    # Define the update mask for the kms_key field.
+    update_mask = field_mask_pb2.FieldMask(paths=["kms_key"])
+
+    # Define the request to update the parameter.
+    request = parametermanager_v1.UpdateParameterRequest(
+        parameter=parameter, update_mask=update_mask
+    )
+
+    # Call the API to update (kms_key) the parameter.
+    response = client.update_parameter(request=request)
+
+    # Print the parameter ID that was updated.
+    print(f"Updated parameter {parameter_id} with kms key {response.kms_key}")
+    # [END parametermanager_update_param_kms_key]
+
+    return response


### PR DESCRIPTION
## Description
Added samples for Global and Regional Parameter Manager API with CMEK key
- create_param_with_kms_key
- update_param_kms_key
- remove_param_kms_key
- create_regional_param_with_kms_key
- update_regional_param_kms_key
- remove_regional_param_kms_key

Added test cases for both global and regional parameter.
**Note: The KMS service needs to be enabled in the testing project to pass the integration tests.**


## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved