### PR TITLE
Pytorch upgrade in `gemma-flex-template` docker image

### DIFF
--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -12,7 +12,7 @@
 
 # This uses Ubuntu with Python 3.11 and comes with CUDA drivers for
 # GPU use.
-ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.6.0-cuda11.8-cudnn9-devel
+ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.6.0-cuda11.8-cudnn9-runtime
 
 FROM ${SERVING_BUILD_IMAGE}
 

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -12,7 +12,7 @@
 
 # This uses Ubuntu with Python 3.10 and comes with CUDA drivers for
 # GPU use.
-ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.3.1-cuda11.8-cudnn8-runtime
+ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.6.0-cuda11.8-cudnn9-devel
 
 FROM ${SERVING_BUILD_IMAGE}
 

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This uses Ubuntu with Python 3.10 and comes with CUDA drivers for
+# This uses Ubuntu with Python 3.11 and comes with CUDA drivers for
 # GPU use.
 ARG SERVING_BUILD_IMAGE=pytorch/pytorch:2.6.0-cuda11.8-cudnn9-devel
 


### PR DESCRIPTION
Without this change (failing build):

<img width="1416" alt="Screenshot 2025-03-30 at 1 28 43 PM" src="https://github.com/user-attachments/assets/8a753e48-391d-47a0-8d44-6b71ae9cd82a" />


With this change (successful build):

<img width="1420" alt="Screenshot 2025-03-30 at 1 29 07 PM" src="https://github.com/user-attachments/assets/2778ec4f-4bc6-467b-b26f-ca9fc5dbaaa9" />


Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved