### PR TITLE
Update main.py - MIME Type & Metadata

### DIFF
--- a/functions/imagemagick/main.py
+++ b/functions/imagemagick/main.py
@@ -86,9 +86,12 @@ def __blur_image(current_blob):
     new_blob.content_type = current_blob.content_type
 
     # Add custom metadata.
+# Add custom metadata.
+    import datetime
     new_blob.metadata = {
         "blurred": "true",
         "original_file": file_name,
+        "blurred_at": datetime.datetime.utcnow().isoformat(),
     }
 
     new_blob.upload_from_filename(temp_local_filename)

--- a/functions/imagemagick/main.py
+++ b/functions/imagemagick/main.py
@@ -70,7 +70,7 @@ def __blur_image(current_blob):
 
     # Blur the image using ImageMagick.
     with Image(filename=temp_local_filename) as image:
-        image.resize(*image.size, blur=16, filter="hamming")
+        image.resize(*image.size, blur=160, filter="hamming")
         image.save(filename=temp_local_filename)
 
     print(f"Image {file_name} was blurred.")
@@ -81,6 +81,16 @@ def __blur_image(current_blob):
     blur_bucket_name = os.getenv("BLURRED_BUCKET_NAME")
     blur_bucket = storage_client.bucket(blur_bucket_name)
     new_blob = blur_bucket.blob(file_name)
+
+    # Copy mimetype from the source blob.
+    new_blob.content_type = current_blob.content_type
+
+    # Add custom metadata.
+    new_blob.metadata = {
+        "blurred": "true",
+        "original_file": file_name,
+    }
+
     new_blob.upload_from_filename(temp_local_filename)
     print(f"Blurred image uploaded to: gs://{blur_bucket_name}/{file_name}")
 


### PR DESCRIPTION
Function has been re-written to:
- Preserve Source MIMEtype
- Add Metadata to indicate source and wether blurred or not
- Blur radius increaed to 160 (16 did nothing to hide image)

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved