### PR TITLE
fix: update blur function to match other samples

### DIFF
--- a/functions/imagemagick/main.py
+++ b/functions/imagemagick/main.py
@@ -70,7 +70,7 @@ def __blur_image(current_blob):
 
     # Blur the image using ImageMagick.
     with Image(filename=temp_local_filename) as image:
-        image.resize(*image.size, blur=16, filter="hamming")
+        image.blur(radius=0, sigma=16)
         image.save(filename=temp_local_filename)
 
     print(f"Image {file_name} was blurred.")

--- a/functions/imagemagick/main_test.py
+++ b/functions/imagemagick/main_test.py
@@ -92,4 +92,4 @@ def test_blur_image(storage_client, image_mock, os_mock, capsys):
     assert f"Image {filename} was blurred." in out
     assert f"Blurred image uploaded to: gs://{blur_bucket}/{filename}" in out
     assert os_mock.remove.called
-    assert image_mock.resize.called
+    assert image_mock.blur.called

--- a/functions/v2/imagemagick/main.py
+++ b/functions/v2/imagemagick/main.py
@@ -73,7 +73,7 @@ def __blur_image(current_blob):
 
     # Blur the image using ImageMagick.
     with Image(filename=temp_local_filename) as image:
-        image.resize(*image.size, blur=16, filter="hamming")
+        image.blur(radius=0, sigma=16)
         image.save(filename=temp_local_filename)
 
     print(f"Image {file_name} was blurred.")

--- a/functions/v2/imagemagick/main_test.py
+++ b/functions/v2/imagemagick/main_test.py
@@ -96,4 +96,4 @@ def test_blur_image(storage_client, image_mock, os_mock, capsys):
     assert f"Image {filename} was blurred." in out
     assert f"Blurred image uploaded to: gs://{blur_bucket}/{filename}" in out
     assert os_mock.remove.called
-    assert image_mock.resize.called
+    assert image_mock.blur.called


### PR DESCRIPTION
## Description

Fixes #13292 

Updates sample to use the Wand equivalent to `-blur 0x8`, to match other samples. 

Potential root cause [comment in thread](https://github.com/GoogleCloudPlatform/python-docs-samples/pull/13279/files#r2025722122).

## Checklist

- [x] Please **merge** this PR for me once it is approved