### PR TITLE
Enforce 25Kb limit for infinite transcription

### DIFF
--- a/speech/microphone/transcribe_streaming_infinite_v2.py
+++ b/speech/microphone/transcribe_streaming_infinite_v2.py
@@ -40,6 +40,8 @@ import pyaudio
 STREAMING_LIMIT = 240000  # 4 minutes
 SAMPLE_RATE = 16000
 CHUNK_SIZE = int(SAMPLE_RATE / 10)  # 100ms
+# 25KB API limit. Increasing this will throw error
+MAX_STREAMING_CHUNK = 25 * 1024 
 
 RED = "\033[0;31m"
 GREEN = "\033[0;32m"
@@ -213,7 +215,23 @@ class ResumableMicrophoneStream:
                 except queue.Empty:
                     break
 
-            yield b"".join(data)
+            # Enforce max streaming chunk size supported by the API
+            combined_size = sum(len(chunk) for chunk in data)
+            if combined_size <= MAX_STREAMING_CHUNK:
+                yield b"".join(data)
+            else:
+                run_chunks = []
+                run_size = 0
+                for chunk in data:
+                    if len(chunk) + run_size > MAX_STREAMING_CHUNK:
+                        yield b"".join(run_chunks)
+                        run_chunks = [chunk]
+                        run_size = len(chunk)
+                    else:
+                        run_chunks.append(chunk)
+                        run_size += len(chunk)
+                if run_chunks:
+                    yield b"".join(run_chunks)
 
 
 def listen_print_loop(responses: object, stream: object) -> None:


### PR DESCRIPTION
## Description 
Current implementation breaks when a new stream is created, even under 5 min limit. This is due to the missing logic to handle 25KB stream size limit [1]

Updated the 'generator' function to yield data as soon as API limit is reached.

[1] - https://github.com/GoogleCloudPlatform/python-docs-samples/issues/12053

Fixes #12053

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved