### PR TITLE
feat(Dataflow): Update Kafka snippet to use Managed I/O

### DIFF
--- a/dataflow/snippets/Dockerfile
+++ b/dataflow/snippets/Dockerfile
@@ -18,24 +18,32 @@
 # on the host machine. This Dockerfile is derived from the
 # dataflow/custom-containers/ubuntu sample.
 
-FROM ubuntu:focal
+FROM python:3.12-slim
+
+# Install JRE
+COPY --from=openjdk:8-jre-slim /usr/local/openjdk-8 /usr/local/openjdk-8
+ENV JAVA_HOME /usr/local/openjdk-8
+RUN update-alternatives --install /usr/bin/java java /usr/local/openjdk-8/bin/java 10 
 
 WORKDIR /pipeline
 
-COPY --from=apache/beam_python3.11_sdk:2.62.0 /opt/apache/beam /opt/apache/beam
+# Copy files from official SDK image.
+COPY --from=apache/beam_python3.11_sdk:2.63.0 /opt/apache/beam /opt/apache/beam
+# Set the entrypoint to Apache Beam SDK launcher.
 ENTRYPOINT [ "/opt/apache/beam/boot" ]
 
-COPY requirements.txt .
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        curl python3-distutils default-jre docker.io \
-    && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
-    && curl https://bootstrap.pypa.io/get-pip.py | python \
-    # Install the requirements.
-    && pip install --no-cache-dir -r requirements.txt \
-    && pip check
+# Install Docker.
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends docker.io
 
+# Install dependencies.
+RUN pip3 install --no-cache-dir apache-beam[gcp]==2.63.0
+RUN pip install --no-cache-dir kafka-python==2.0.6
 
+# Verify that the image does not have conflicting dependencies.
+RUN pip check
+
+# Copy the snippets to test.
 COPY read_kafka.py ./
 COPY read_kafka_multi_topic.py ./
+

--- a/dataflow/snippets/noxfile_config.py
+++ b/dataflow/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.9", "3.10", "3.12", "3.13"],
+    "ignored_versions": ["2.7", "3.7", "3.8", "3.9", "3.10", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/snippets/noxfile_config.py
+++ b/dataflow/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.12", "3.13"],
+    "ignored_versions": ["2.7", "3.7", "3.8", "3.9", "3.10", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/snippets/read_kafka.py
+++ b/dataflow/snippets/read_kafka.py
@@ -48,7 +48,9 @@ def read_from_kafka() -> None:
                   "topic": options.topic,
                   "data_format": "RAW",
                   "auto_offset_reset_config": "earliest",
-                  "max_read_time_seconds": 5  # For testing, avoid in production.
+                  # The max_read_time_seconds parameter is intended for testing.
+                  # Avoiding using this parameter in production.
+                  "max_read_time_seconds": 5
                 }
             )
             # Subdivide the output into fixed 5-second windows.

--- a/dataflow/snippets/read_kafka.py
+++ b/dataflow/snippets/read_kafka.py
@@ -19,7 +19,6 @@ import argparse
 import apache_beam as beam
 
 from apache_beam import window
-from apache_beam.io.kafka import ReadFromKafka
 from apache_beam.io.textio import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 

--- a/dataflow/snippets/read_kafka.py
+++ b/dataflow/snippets/read_kafka.py
@@ -49,7 +49,7 @@ def read_from_kafka() -> None:
                   "data_format": "RAW",
                   "auto_offset_reset_config": "earliest",
                   # The max_read_time_seconds parameter is intended for testing.
-                  # Avoiding using this parameter in production.
+                  # Avoid using this parameter in production.
                   "max_read_time_seconds": 5
                 }
             )

--- a/dataflow/snippets/read_kafka.py
+++ b/dataflow/snippets/read_kafka.py
@@ -42,16 +42,16 @@ def read_from_kafka() -> None:
         (
             pipeline
             # Read messages from an Apache Kafka topic.
-            | ReadFromKafka(
-                consumer_config={"bootstrap.servers": options.bootstrap_server},
-                topics=[options.topic],
-                with_metadata=False,
-                max_num_records=5,
-                start_read_time=0,
+            | beam.managed.Read(
+                beam.managed.KAFKA,
+                config={
+                  "bootstrap_servers": options.bootstrap_server,
+                  "topic": options.topic,
+                  "data_format": "RAW",
+                  "auto_offset_reset_config": "earliest",
+                  "max_read_time_seconds": 5 # For testing, avoid in production.
+                }
             )
-            # The previous step creates a key-value collection, keyed by message ID.
-            # The values are the message payloads.
-            | beam.Values()
             # Subdivide the output into fixed 5-second windows.
             | beam.WindowInto(window.FixedWindows(5))
             | WriteToText(

--- a/dataflow/snippets/read_kafka.py
+++ b/dataflow/snippets/read_kafka.py
@@ -49,7 +49,7 @@ def read_from_kafka() -> None:
                   "topic": options.topic,
                   "data_format": "RAW",
                   "auto_offset_reset_config": "earliest",
-                  "max_read_time_seconds": 5 # For testing, avoid in production.
+                  "max_read_time_seconds": 5  # For testing, avoid in production.
                 }
             )
             # Subdivide the output into fixed 5-second windows.

--- a/dataflow/snippets/requirements.txt
+++ b/dataflow/snippets/requirements.txt
@@ -1,2 +1,2 @@
-apache-beam[gcp]==2.58.0
-kafka-python==2.0.2
+apache-beam[gcp]==2.63.0
+kafka-python==2.0.6


### PR DESCRIPTION
## Description

- Update the `dataflow_kafka_read` snippet to use [Managed I/O](https://cloud.google.com/dataflow/docs/guides/managed-io-kafka)
- Bump the Apache Beam version to 2.63 (required for Managed I/O)
- Update the Dockerfile to be compatible with Beam 2.63.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved