### PR TITLE
chore(secretmanager): Add global samples for delayed destory

### DIFF
--- a/secretmanager/snippets/create_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/create_secret_with_delayed_destroy.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for creating a new secret with
+delayed_destroy.
+"""
+
+import argparse
+
+from google.cloud import secretmanager
+
+# [START secretmanager_create_secret_with_delayed_destroy]
+
+
+def create_secret_with_delayed_destroy(
+    project_id: str,
+    secret_id: str,
+    version_destroy_ttl: int,
+) -> secretmanager.Secret:
+    """
+    Create a new secret with the given name and version destroy ttl. A
+    secret is a logical wrapper around a collection of secret versions.
+    Secret versions hold the actual secret material.
+    """
+
+    # Import the Secret Manager client library.
+    from google.cloud import secretmanager
+
+    # Import the Duration protobuf library.
+    from google.protobuf.duration_pb2 import Duration
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    # Build the resource name of the parent project.
+    parent = f"projects/{project_id}"
+
+    # Create the secret.
+    response = client.create_secret(
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {
+                "replication": {"automatic": {}},
+                "version_destroy_ttl": Duration(seconds=version_destroy_ttl),
+            },
+        }
+    )
+
+    # Print the new secret name.
+    print(f"Created secret: {response.name}")
+
+    return response
+
+
+# [END secretmanager_create_secret_with_delayed_destroy]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("secret_id", help="id of the secret to create")
+    parser.add_argument("version_destroy_ttl", help="version_destroy_ttl you want to add")
+    args = parser.parse_args()
+
+    create_secret_with_delayed_destroy(args.project_id, args.secret_id, args.version_destroy_ttl)

--- a/secretmanager/snippets/create_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/create_secret_with_delayed_destroy.py
@@ -13,17 +13,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 """
-command line application and sample code for creating a new secret with
+Command line application and sample code for creating a new secret with
 delayed_destroy.
 """
 
-# [START secretmanager_create_secret_with_delayed_destroy]
 import argparse
+
+# [START secretmanager_create_secret_with_delayed_destroy]
 
 # Import the Secret Manager client library.
 from google.cloud import secretmanager
-
-# from datetime import timedelta
 from google.protobuf.duration_pb2 import Duration
 
 
@@ -61,8 +60,8 @@ def create_secret_with_delayed_destroy(
 
     return response
 
-
 # [END secretmanager_create_secret_with_delayed_destroy]
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/secretmanager/snippets/create_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/create_secret_with_delayed_destroy.py
@@ -17,11 +17,14 @@ command line application and sample code for creating a new secret with
 delayed_destroy.
 """
 
+# [START secretmanager_create_secret_with_delayed_destroy]
 import argparse
 
+# Import the Secret Manager client library.
 from google.cloud import secretmanager
 
-# [START secretmanager_create_secret_with_delayed_destroy]
+# from datetime import timedelta
+from google.protobuf.duration_pb2 import Duration
 
 
 def create_secret_with_delayed_destroy(
@@ -34,12 +37,6 @@ def create_secret_with_delayed_destroy(
     secret is a logical wrapper around a collection of secret versions.
     Secret versions hold the actual secret material.
     """
-
-    # Import the Secret Manager client library.
-    from google.cloud import secretmanager
-
-    # Import the Duration protobuf library.
-    from google.protobuf.duration_pb2 import Duration
 
     # Create the Secret Manager client.
     client = secretmanager.SecretManagerServiceClient()

--- a/secretmanager/snippets/disable_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/disable_secret_with_delayed_destroy.py
@@ -15,19 +15,18 @@
 
 import argparse
 
+# [START secretmanager_disable_secret_with_delayed_destroy]
+
+# Import the Secret Manager client library.
 from google.cloud import secretmanager
 
 
-# [START secretmanager_disable_secret_with_delayed_destroy]
 def disable_secret_with_delayed_destroy(
     project_id: str, secret_id: str
 ) -> secretmanager.Secret:
     """
     Disable the version destroy ttl on the given secret version.
     """
-
-    # Import the Secret Manager client library.
-    from google.cloud import secretmanager
 
     # Create the Secret Manager client.
     client = secretmanager.SecretManagerServiceClient()
@@ -42,9 +41,10 @@ def disable_secret_with_delayed_destroy(
 
     # Print the new secret name.
     print(f"Disabled delayed destroy on secret: {response.name}")
-    # [END secretmanager_disable_secret_with_delayed_destroy]
 
     return response
+
+# [END secretmanager_disable_secret_with_delayed_destroy]
 
 
 if __name__ == "__main__":

--- a/secretmanager/snippets/disable_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/disable_secret_with_delayed_destroy.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import argparse
+
+from google.cloud import secretmanager
+
+# [START secretmanager_disable_secret_with_delayed_destroy]
+
+
+def disable_secret_with_delayed_destroy(
+    project_id: str, secret_id: str
+) -> secretmanager.Secret:
+    """
+    Disable the version destroy ttl on the given secret version.
+    """
+
+    # Import the Secret Manager client library.
+    from google.cloud import secretmanager
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    # Build the resource name of the secret.
+    name = client.secret_path(project_id, secret_id)
+
+    # Disable delayed destroy of the secret.
+    secret = {"name": name}
+    update_mask = {"paths": ["version_destroy_ttl"]}
+    response = client.update_secret(request={"secret": secret, "update_mask": update_mask})
+
+    # Print the new secret name.
+    print(f"Disabled delayed destroy on secret: {response.name}")
+    # [END secretmanager_disable_secret_with_delayed_destroy]
+
+    return response
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("secret_id", help="id of the secret from which to act")
+    args = parser.parse_args()
+
+    disable_secret_with_delayed_destroy(
+        args.project_id, args.secret_id
+    )

--- a/secretmanager/snippets/disable_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/disable_secret_with_delayed_destroy.py
@@ -17,9 +17,8 @@ import argparse
 
 from google.cloud import secretmanager
 
+
 # [START secretmanager_disable_secret_with_delayed_destroy]
-
-
 def disable_secret_with_delayed_destroy(
     project_id: str, secret_id: str
 ) -> secretmanager.Secret:
@@ -36,7 +35,7 @@ def disable_secret_with_delayed_destroy(
     # Build the resource name of the secret.
     name = client.secret_path(project_id, secret_id)
 
-    # Disable delayed destroy of the secret.
+    # Delayed destroy of the secret version.
     secret = {"name": name}
     update_mask = {"paths": ["version_destroy_ttl"]}
     response = client.update_secret(request={"secret": secret, "update_mask": update_mask})

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -170,7 +170,7 @@ def secret(
     annotation_value: str,
     ttl: Optional[str],
 ) -> Iterator[Tuple[str, str, str, str]]:
-    print(f"creating secret {secret_id}")
+    print(f"creating secret with given secret id.")
 
     parent = f"projects/{project_id}"
     time.sleep(5)
@@ -596,4 +596,4 @@ def test_update_secret_with_delayed_destroy(secret_with_delayed_destroy: Tuple[s
     project_id, secret_id = secret_with_delayed_destroy
     updated_version_destroy_ttl_value = 118400
     updated_secret = update_secret_with_delayed_destroy(project_id, secret_id, updated_version_destroy_ttl_value)
-    assert updated_secret.version_destroy_ttl == timedelta(seconds=version_destroy_ttl)
+    assert updated_secret.version_destroy_ttl == timedelta(seconds=updated_version_destroy_ttl_value)

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -170,7 +170,7 @@ def secret(
     annotation_value: str,
     ttl: Optional[str],
 ) -> Iterator[Tuple[str, str, str, str]]:
-    print(f"creating secret with given secret id.")
+    print(f"creating secret {secret_id}")
 
     parent = f"projects/{project_id}"
     time.sleep(5)
@@ -199,7 +199,7 @@ def secret_with_delayed_destroy(
     version_destroy_ttl: int,
     ttl: Optional[str],
 ) -> Iterator[Tuple[str, str]]:
-    print(f"creating secret {secret_id}")
+    print("creating secret with given secret id.")
 
     parent = f"projects/{project_id}"
     time.sleep(5)
@@ -328,9 +328,7 @@ def test_create_secret_with_annotations(
 
 def test_create_secret_with_delayed_destroy(
     client: secretmanager.SecretManagerServiceClient,
-    project_id: str,
-    secret_id: str,
-    version_destroy_ttl: int,
+    project_id: str, secret_id: str, version_destroy_ttl: int
 ) -> None:
     secret = create_secret_with_delayed_destroy(project_id, secret_id, version_destroy_ttl)
     assert secret_id in secret.name

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 
 import base64
+from datetime import timedelta
 import os
 import time
 from typing import Iterator, Optional, Tuple, Union
@@ -19,6 +20,8 @@ import uuid
 
 from google.api_core import exceptions, retry
 from google.cloud import secretmanager
+from google.protobuf.duration_pb2 import Duration
+
 import pytest
 
 from access_secret_version import access_secret_version
@@ -26,6 +29,7 @@ from add_secret_version import add_secret_version
 from consume_event_notification import consume_event_notification
 from create_secret import create_secret
 from create_secret_with_annotations import create_secret_with_annotations
+from create_secret_with_delayed_destroy import create_secret_with_delayed_destroy
 from create_secret_with_labels import create_secret_with_labels
 from create_secret_with_user_managed_replication import create_ummr_secret
 from create_update_secret_label import create_update_secret_label
@@ -36,6 +40,7 @@ from destroy_secret_version import destroy_secret_version
 from destroy_secret_version_with_etag import destroy_secret_version_with_etag
 from disable_secret_version import disable_secret_version
 from disable_secret_version_with_etag import disable_secret_version_with_etag
+from disable_secret_with_delayed_destroy import disable_secret_with_delayed_destroy
 from edit_secret_annotations import edit_secret_annotations
 from enable_secret_version import enable_secret_version
 from enable_secret_version_with_etag import enable_secret_version_with_etag
@@ -50,6 +55,7 @@ from list_secrets_with_filter import list_secrets_with_filter
 from quickstart import quickstart
 from update_secret import update_secret
 from update_secret_with_alias import update_secret_with_alias
+from update_secret_with_delayed_destroy import update_secret_with_delayed_destroy
 from update_secret_with_etag import update_secret_with_etag
 from view_secret_annotations import view_secret_annotations
 from view_secret_labels import view_secret_labels
@@ -93,6 +99,11 @@ def annotation_key() -> str:
 @pytest.fixture()
 def annotation_value() -> str:
     return "annotationvalue"
+
+
+@pytest.fixture()
+def version_destroy_ttl() -> str:
+    return 604800  # 7 days in seconds
 
 
 @retry.Retry()
@@ -178,6 +189,33 @@ def secret(
     )
 
     yield project_id, secret_id, secret.etag
+
+
+@pytest.fixture()
+def secret_with_delayed_destroy(
+    client: secretmanager.SecretManagerServiceClient,
+    project_id: str,
+    secret_id: str,
+    version_destroy_ttl: int,
+    ttl: Optional[str],
+) -> Iterator[Tuple[str, str]]:
+    print(f"creating secret {secret_id}")
+
+    parent = f"projects/{project_id}"
+    time.sleep(5)
+    retry_client_create_secret(
+        client,
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {
+                "replication": {"automatic": {}},
+                "version_destroy_ttl": Duration(seconds=version_destroy_ttl),
+            },
+        },
+    )
+
+    yield project_id, secret_id
 
 
 @pytest.fixture()
@@ -288,6 +326,17 @@ def test_create_secret_with_annotations(
     assert secret_id in secret.name
 
 
+def test_create_secret_with_delayed_destroy(
+    client: secretmanager.SecretManagerServiceClient,
+    project_id: str,
+    secret_id: str,
+    version_destroy_ttl: int,
+) -> None:
+    secret = create_secret_with_delayed_destroy(project_id, secret_id, version_destroy_ttl)
+    assert secret_id in secret.name
+    assert timedelta(seconds=version_destroy_ttl) == secret.version_destroy_ttl
+
+
 def test_delete_secret(
     client: secretmanager.SecretManagerServiceClient, secret: Tuple[str, str, str]
 ) -> None:
@@ -339,6 +388,15 @@ def test_destroy_secret_version_with_etag(
     project_id, secret_id, version_id, etag = secret_version
     version = destroy_secret_version_with_etag(project_id, secret_id, version_id, etag)
     assert version.destroy_time
+
+
+def test_disable_secret_with_delayed_destroy(
+    client: secretmanager.SecretManagerServiceClient,
+    secret_with_delayed_destroy: Tuple[str, str],
+) -> None:
+    project_id, secret_id = secret_with_delayed_destroy
+    updated_secret = disable_secret_with_delayed_destroy(project_id, secret_id)
+    assert updated_secret.version_destroy_ttl == timedelta(0)
 
 
 def test_enable_disable_secret_version(
@@ -532,3 +590,10 @@ def test_update_secret_with_alias(secret_version: Tuple[str, str, str, str]) -> 
     project_id, secret_id, version_id, _ = secret_version
     secret = update_secret_with_alias(project_id, secret_id)
     assert secret.version_aliases["test"] == 1
+
+
+def test_update_secret_with_delayed_destroy(secret_with_delayed_destroy: Tuple[str, str], version_destroy_ttl: str) -> None:
+    project_id, secret_id = secret_with_delayed_destroy
+    updated_version_destroy_ttl_value = 118400
+    updated_secret = update_secret_with_delayed_destroy(project_id, secret_id, updated_version_destroy_ttl_value)
+    assert updated_secret.version_destroy_ttl == timedelta(seconds=version_destroy_ttl)

--- a/secretmanager/snippets/update_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/update_secret_with_delayed_destroy.py
@@ -17,21 +17,17 @@ import argparse
 
 from google.cloud import secretmanager
 
+# from datetime import timedelta
+from google.protobuf.duration_pb2 import Duration
+
+
 # [START secretmanager_update_secret_with_delayed_destroy]
-
-
 def update_secret_with_delayed_destroy(
     project_id: str, secret_id: str, new_version_destroy_ttl: int
 ) -> secretmanager.UpdateSecretRequest:
     """
     Update the version destroy ttl value on an existing secret.
     """
-
-    # Import the Secret Manager client library.
-    from google.cloud import secretmanager
-
-    # from datetime import timedelta
-    from google.protobuf.duration_pb2 import Duration
 
     # Create the Secret Manager client.
     client = secretmanager.SecretManagerServiceClient()

--- a/secretmanager/snippets/update_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/update_secret_with_delayed_destroy.py
@@ -15,13 +15,13 @@
 
 import argparse
 
-from google.cloud import secretmanager
+# [START secretmanager_update_secret_with_delayed_destroy]
 
-# from datetime import timedelta
+# Import the Secret Manager client library.
+from google.cloud import secretmanager
 from google.protobuf.duration_pb2 import Duration
 
 
-# [START secretmanager_update_secret_with_delayed_destroy]
 def update_secret_with_delayed_destroy(
     project_id: str, secret_id: str, new_version_destroy_ttl: int
 ) -> secretmanager.UpdateSecretRequest:
@@ -47,7 +47,7 @@ def update_secret_with_delayed_destroy(
 
     return response
 
-    # [END secretmanager_update_secret_with_delayed_destroy]
+# [END secretmanager_update_secret_with_delayed_destroy]
 
 
 if __name__ == "__main__":

--- a/secretmanager/snippets/update_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/update_secret_with_delayed_destroy.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import argparse
+
+from google.cloud import secretmanager
+
+# [START secretmanager_update_secret_with_delayed_destroy]
+
+
+def update_secret_with_delayed_destroy(
+    project_id: str, secret_id: str, new_version_destroy_ttl: int
+) -> secretmanager.UpdateSecretRequest:
+    """
+    Update the version destroy ttl value on an existing secret.
+    """
+
+    # Import the Secret Manager client library.
+    from google.cloud import secretmanager
+
+    # from datetime import timedelta
+    from google.protobuf.duration_pb2 import Duration
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    # Build the resource name of the secret.
+    name = client.secret_path(project_id, secret_id)
+
+    # Update the version_destroy_ttl.
+    secret = {"name": name, "version_destroy_ttl": Duration(seconds=new_version_destroy_ttl)}
+    update_mask = {"paths": ["version_destroy_ttl"]}
+    response = client.update_secret(
+        request={"secret": secret, "update_mask": update_mask}
+    )
+
+    # Print the new secret name.
+    print(f"Updated secret: {response.name}")
+
+    return response
+
+    # [END secretmanager_update_secret_with_delayed_destroy]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("secret-id", help="id of the secret to act on")
+    parser.add_argument("version_destroy_ttl", "new version destroy ttl to be added")
+    args = parser.parse_args()
+
+    update_secret_with_delayed_destroy(args.project_id, args.secret_id, args.version_destroy_ttl)


### PR DESCRIPTION
## Description

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [x] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved