### PR TITLE
Bump up runtime version to python 3.13

### DIFF
--- a/appengine/standard_python3/building-an-app/building-an-app-1/app.yaml
+++ b/appengine/standard_python3/building-an-app/building-an-app-1/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: python39
+runtime: python313
 
 handlers:
   # This configures Google App Engine to serve the files in the app's static

--- a/appengine/standard_python3/building-an-app/building-an-app-1/main.py
+++ b/appengine/standard_python3/building-an-app/building-an-app-1/main.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gae_python38_render_template]
 # [START gae_python3_render_template]
 import datetime
 
@@ -43,3 +44,4 @@ if __name__ == "__main__":
     # App Engine itself will serve those files as configured in app.yaml.
     app.run(host="127.0.0.1", port=8080, debug=True)
 # [END gae_python3_render_template]
+# [END gae_python38_render_template]

--- a/appengine/standard_python3/building-an-app/building-an-app-1/main.py
+++ b/appengine/standard_python3/building-an-app/building-an-app-1/main.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gae_python313_render_template]
 # [START gae_python3_render_template]
 import datetime
 
@@ -44,4 +43,3 @@ if __name__ == "__main__":
     # App Engine itself will serve those files as configured in app.yaml.
     app.run(host="127.0.0.1", port=8080, debug=True)
 # [END gae_python3_render_template]
-# [END gae_python313_render_template]

--- a/appengine/standard_python3/building-an-app/building-an-app-1/main.py
+++ b/appengine/standard_python3/building-an-app/building-an-app-1/main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gae_python38_render_template]
+# [START gae_python313_render_template]
 # [START gae_python3_render_template]
 import datetime
 
@@ -44,4 +44,4 @@ if __name__ == "__main__":
     # App Engine itself will serve those files as configured in app.yaml.
     app.run(host="127.0.0.1", port=8080, debug=True)
 # [END gae_python3_render_template]
-# [END gae_python38_render_template]
+# [END gae_python313_render_template]


### PR DESCRIPTION
## Description
Bump up python runtime version to latest python 3.13 
## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved