### PR TITLE
chore(secretmanager): Add regional samples for delayed destory

### DIFF
--- a/secretmanager/snippets/regional_samples/create_regional_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/regional_samples/create_regional_secret_with_delayed_destroy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,16 @@ def create_regional_secret_with_delayed_destroy(
     Create a new secret with the given name and version_destroy_ttl. A secret is a logical wrapper
     around a collection of secret versions. Secret versions hold the actual
     secret material.
-    """
+
+    Args:
+      project_id: Parent project id
+      location_id: Location of the secret
+      secret_id: ID of the secret or fully qualified identifier for the secret
+      version_destroy_ttl: Secret Version TTL after destruction request
+
+    Returns:
+      Regional secret with delayed destroy
+      """
 
     # Endpoint to call the regional secret manager sever
     api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
@@ -76,10 +85,10 @@ if __name__ == "__main__":
     )
     parser.add_argument("secret_id", help="id of the secret to create")
     parser.add_argument(
-        "version_destroy_ttl", help="version_destroy_ttl you want to add"
+        "version_destroy_ttl", help="version_destroy_ttl you want to add (in seconds)"
     )
     args = parser.parse_args()
 
     create_regional_secret_with_delayed_destroy(
-        args.project_id, args.location_id, args.secret_id, args.version_destroy_ttl
+        args.project_id, args.location_id, args.secret_id, int(args.version_destroy_ttl)
     )

--- a/secretmanager/snippets/regional_samples/create_regional_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/regional_samples/create_regional_secret_with_delayed_destroy.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+Command line application and sample code for creating a new secret with
+delayed destroy.
+"""
+
+import argparse
+
+# [START secretmanager_create_regional_secret_with_delayed_destroy]
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager_v1
+from google.protobuf.duration_pb2 import Duration
+
+
+def create_regional_secret_with_delayed_destroy(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+    version_destroy_ttl: int,
+) -> secretmanager_v1.Secret:
+    """
+    Create a new secret with the given name and version_destroy_ttl. A secret is a logical wrapper
+    around a collection of secret versions. Secret versions hold the actual
+    secret material.
+    """
+
+    # Endpoint to call the regional secret manager sever
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager_v1.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name of the parent project.
+    parent = f"projects/{project_id}/locations/{location_id}"
+
+    # Create the secret.
+    response = client.create_secret(
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {"version_destroy_ttl": Duration(seconds=version_destroy_ttl)},
+        }
+    )
+
+    # Print the new secret name.
+    print(f"Created secret: {response.name}")
+
+    return response
+
+# [END secretmanager_create_regional_secret_with_delayed_destroy]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument(
+        "location_id", help="id of the location where secret is to be created"
+    )
+    parser.add_argument("secret_id", help="id of the secret to create")
+    parser.add_argument(
+        "version_destroy_ttl", help="version_destroy_ttl you want to add"
+    )
+    args = parser.parse_args()
+
+    create_regional_secret_with_delayed_destroy(
+        args.project_id, args.location_id, args.secret_id, args.version_destroy_ttl
+    )

--- a/secretmanager/snippets/regional_samples/disable_regional_secret_delayed_destroy.py
+++ b/secretmanager/snippets/regional_samples/disable_regional_secret_delayed_destroy.py
@@ -63,11 +63,8 @@ if __name__ == "__main__":
         "location_id", help="id of the location where secret is to be created"
     )
     parser.add_argument("secret_id", help="id of the secret to act on")
-    parser.add_argument(
-        "version_destroy_ttl", help="version_destroy_ttl you want to add"
-    )
     args = parser.parse_args()
 
     disable_regional_secret_delayed_destroy(
-        args.project_id, args.location_id, args.secret_id, args.version_destroy_ttl
+        args.project_id, args.location_id, args.secret_id
     )

--- a/secretmanager/snippets/regional_samples/disable_regional_secret_delayed_destroy.py
+++ b/secretmanager/snippets/regional_samples/disable_regional_secret_delayed_destroy.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import argparse
+
+# [START secretmanager_disable_regional_secret_delayed_destroy]
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager_v1
+
+
+def disable_regional_secret_delayed_destroy(
+    project_id: str, location_id: str, secret_id: str
+) -> secretmanager_v1.Secret:
+    """
+    Disable delayed destroy on an existing secret with a version destroy ttl.
+    """
+
+    # Endpoint to call the regional secret manager sever
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager_v1.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name.
+    name = f"projects/{project_id}/locations/{location_id}/secrets/{secret_id}"
+
+    # Disable delayed destroy on secret
+    secret = {"name": name}
+    update_mask = {"paths": ["version_destroy_ttl"]}
+    response = client.update_secret(
+        request={"secret": secret, "update_mask": update_mask}
+    )
+
+    # Print the new secret name.
+    print(f"Disabled delayed destroy on secret: {response.name}")
+
+    return response
+
+# [END secretmanager_disable_regional_secret_delayed_destroy]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument(
+        "location_id", help="id of the location where secret is to be created"
+    )
+    parser.add_argument("secret_id", help="id of the secret to act on")
+    parser.add_argument(
+        "version_destroy_ttl", help="version_destroy_ttl you want to add"
+    )
+    args = parser.parse_args()
+
+    disable_regional_secret_delayed_destroy(
+        args.project_id, args.location_id, args.secret_id, args.version_destroy_ttl
+    )

--- a/secretmanager/snippets/regional_samples/disable_regional_secret_delayed_destroy.py
+++ b/secretmanager/snippets/regional_samples/disable_regional_secret_delayed_destroy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,6 +26,14 @@ def disable_regional_secret_delayed_destroy(
 ) -> secretmanager_v1.Secret:
     """
     Disable delayed destroy on an existing secret with a version destroy ttl.
+
+    Args:
+      project_id: Parent project id
+      location_id: Location of the secret
+      secret_id: ID of the secret or fully qualified identifier for the secret
+
+    Returns:
+      Regional secret with disabled delayed destroy
     """
 
     # Endpoint to call the regional secret manager sever

--- a/secretmanager/snippets/regional_samples/snippets_test.py
+++ b/secretmanager/snippets/regional_samples/snippets_test.py
@@ -218,7 +218,7 @@ def regional_secret_with_delayed_destroy(
     location_id: str,
     secret_id: str,
     version_destroy_ttl: int,
-):
+) -> Iterator[str]:
     print("creating secret with given secret id.")
 
     parent = f"projects/{project_id}/locations/{location_id}"

--- a/secretmanager/snippets/regional_samples/snippets_test.py
+++ b/secretmanager/snippets/regional_samples/snippets_test.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
+from datetime import timedelta
 import os
 import time
 from typing import Iterator, Tuple, Union
@@ -18,18 +19,21 @@ import uuid
 
 from google.api_core import exceptions, retry
 from google.cloud import secretmanager_v1
+from google.protobuf.duration_pb2 import Duration
 import pytest
 
 from regional_samples import access_regional_secret_version
 from regional_samples import add_regional_secret_version
 from regional_samples import create_regional_secret
 from regional_samples import create_regional_secret_with_annotations
+from regional_samples import create_regional_secret_with_delayed_destroy
 from regional_samples import create_regional_secret_with_labels
 from regional_samples import delete_regional_secret
 from regional_samples import delete_regional_secret_label
 from regional_samples import delete_regional_secret_with_etag
 from regional_samples import destroy_regional_secret_version
 from regional_samples import destroy_regional_secret_version_with_etag
+from regional_samples import disable_regional_secret_delayed_destroy
 from regional_samples import disable_regional_secret_version
 from regional_samples import disable_regional_secret_version_with_etag
 from regional_samples import edit_regional_secret_annotations
@@ -46,6 +50,7 @@ from regional_samples import list_regional_secrets
 from regional_samples import list_regional_secrets_with_filter
 from regional_samples import regional_quickstart
 from regional_samples import update_regional_secret
+from regional_samples import update_regional_secret_with_delayed_destroy
 from regional_samples import update_regional_secret_with_etag
 from regional_samples import view_regional_secret_annotations
 from regional_samples import view_regional_secret_labels
@@ -97,6 +102,11 @@ def annotation_key() -> str:
 @pytest.fixture()
 def annotation_value() -> str:
     return "annotationvalue"
+
+
+@pytest.fixture()
+def version_destroy_ttl() -> int:
+    return 604800  # 7 days in seconds
 
 
 @retry.Retry()
@@ -201,6 +211,33 @@ def regional_secret(
     yield secret_id, regional_secret.etag
 
 
+@pytest.fixture()
+def regional_secret_with_delayed_destroy(
+    regional_client: secretmanager_v1.SecretManagerServiceClient,
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+    version_destroy_ttl: int,
+):
+    print("creating secret with given secret id.")
+
+    parent = f"projects/{project_id}/locations/{location_id}"
+    time.sleep(5)
+    retry_client_create_regional_secret(
+        regional_client,
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {
+                "version_destroy_ttl": Duration(seconds=version_destroy_ttl),
+            },
+        },
+    )
+    print("debug")
+
+    yield secret_id
+
+
 def test_regional_quickstart(project_id: str, location_id: str, secret_id: str) -> None:
     regional_quickstart.regional_quickstart(project_id, location_id, secret_id)
 
@@ -257,6 +294,18 @@ def test_create_regional_secret_with_annotations(
         )
     )
     assert secret_id in secret.name
+
+
+def test_create_regional_secret_with_delayed_destroy(
+    regional_client: secretmanager_v1.SecretManagerServiceClient,
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+    version_destroy_ttl: int,
+) -> None:
+    secret = create_regional_secret_with_delayed_destroy.create_regional_secret_with_delayed_destroy(project_id, location_id, secret_id, version_destroy_ttl)
+    assert secret_id in secret.name
+    assert timedelta(seconds=version_destroy_ttl) == secret.version_destroy_ttl
 
 
 def test_create_regional_secret_with_label(
@@ -334,6 +383,17 @@ def test_destroy_regional_secret_version_with_etag(
         project_id, location_id, secret_id, version_id, etag
     )
     assert version.destroy_time
+
+
+def test_disable_regional_secret_delayed_destroy(
+    regional_client: secretmanager_v1.SecretManagerServiceClient,
+    regional_secret_with_delayed_destroy: str,
+    project_id: str,
+    location_id: str,
+) -> None:
+    secret_id = regional_secret_with_delayed_destroy
+    updated_secret = disable_regional_secret_delayed_destroy.disable_regional_secret_delayed_destroy(project_id, location_id, secret_id)
+    assert updated_secret.version_destroy_ttl == timedelta(0)
 
 
 def test_enable_disable_regional_secret_version(
@@ -610,6 +670,18 @@ def test_update_regional_secret(
         project_id, location_id, secret_id
     )
     assert updated_regional_secret.labels["secretmanager"] == "rocks"
+
+
+def test_update_regional_secret_with_delayed_destroy(
+    regional_secret_with_delayed_destroy: str,
+    project_id: str,
+    location_id: str,
+    version_destroy_ttl: int
+) -> None:
+    secret_id = regional_secret_with_delayed_destroy
+    updated_version_delayed_destroy = 118400
+    updated_secret = update_regional_secret_with_delayed_destroy.update_regional_secret_with_delayed_destroy(project_id, location_id, secret_id, updated_version_delayed_destroy)
+    assert updated_secret.version_destroy_ttl == timedelta(seconds=updated_version_delayed_destroy)
 
 
 def test_view_regional_secret_labels(

--- a/secretmanager/snippets/regional_samples/update_regional_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/regional_samples/update_regional_secret_with_delayed_destroy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,9 +24,18 @@ from google.protobuf.duration_pb2 import Duration
 
 def update_regional_secret_with_delayed_destroy(
     project_id: str, location_id: str, secret_id: str, new_version_destroy_ttl: int
-) -> secretmanager_v1.UpdateSecretRequest:
+) -> secretmanager_v1.Secret:
     """
     Update the version destroy ttl on an existing secret.
+
+    Args:
+      project_id: Parent project id
+      location_id: Location of the secret
+      secret_id: ID of the secret or fully qualified identifier for the secret
+      new_version_destroy_ttl: Secret Version TTL value in seconds
+
+    Returns:
+      Regional secret with updated version destroy ttl value
     """
 
     # Endpoint to call the regional secret manager sever
@@ -68,10 +77,10 @@ if __name__ == "__main__":
     )
     parser.add_argument("secret_id", help="id of the secret to act on")
     parser.add_argument(
-        "version_destroy_ttl", help="version_destroy_ttl you want to add"
+        "new_version_destroy_ttl", help="version_destroy_ttl you want to add (in seconds)"
     )
     args = parser.parse_args()
 
     update_regional_secret_with_delayed_destroy(
-        args.project_id, args.location_id, args.secret_id, args.version_destroy_ttl
+        args.project_id, args.location_id, args.secret_id, int(args.new_version_destroy_ttl)
     )

--- a/secretmanager/snippets/regional_samples/update_regional_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/regional_samples/update_regional_secret_with_delayed_destroy.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import argparse
+
+# [START secretmanager_update_regional_secret_delayed_destroy]
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager_v1
+from google.protobuf.duration_pb2 import Duration
+
+
+def update_regional_secret_with_delayed_destroy(
+    project_id: str, location_id: str, secret_id: str, new_version_destroy_ttl: int
+) -> secretmanager_v1.UpdateSecretRequest:
+    """
+    Update the version destroy ttl on an existing secret.
+    """
+
+    # Endpoint to call the regional secret manager sever
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager_v1.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name.
+    name = f"projects/{project_id}/locations/{location_id}/secrets/{secret_id}"
+
+    # Get the secret.
+    response = client.get_secret(request={"name": name})
+
+    # Update the secret.
+    secret = {"name": name, "version_destroy_ttl": Duration(seconds=new_version_destroy_ttl)}
+    update_mask = {"paths": ["version_destroy_ttl"]}
+    response = client.update_secret(
+        request={"secret": secret, "update_mask": update_mask}
+    )
+
+    # Print the new secret name.
+    print(f"Updated secret: {response.name}")
+
+    return response
+
+# [END secretmanager_update_regional_secret_delayed_destroy]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument(
+        "location_id", help="id of the location where secret is to be created"
+    )
+    parser.add_argument("secret_id", help="id of the secret to act on")
+    parser.add_argument(
+        "version_destroy_ttl", help="version_destroy_ttl you want to add"
+    )
+    args = parser.parse_args()
+
+    update_regional_secret_with_delayed_destroy(
+        args.project_id, args.location_id, args.secret_id, args.version_destroy_ttl
+    )


### PR DESCRIPTION
## Description

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [x] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved