### PR TITLE
chore(workflows): migrate samples 'execute_without_arguments' and 'execute_with_arguments' - step 1

### DIFF
--- a/workflows/cloud-client/execute_with_arguments.py
+++ b/workflows/cloud-client/execute_with_arguments.py
@@ -17,7 +17,7 @@ import os
 from google.cloud.workflows.executions_v1 import Execution
 
 
-def execute_workflow_with_argument(
+def execute_workflow_with_arguments(
     project_id: str,
     location: str,
     workflow_id: str
@@ -54,7 +54,7 @@ def execute_workflow_with_argument(
     # Construct the fully qualified location path.
     parent = workflows_client.workflow_path(project_id, location, workflow_id)
 
-    # Execute the workflow.
+    # Execute the workflow adding an dictionary of arguments.
     # Find more information about the Execution object here:
     # https://cloud.google.com/python/docs/reference/workflows/latest/google.cloud.workflows.executions_v1.types.Execution
     execution = executions_v1.Execution(
@@ -73,6 +73,8 @@ def execute_workflow_with_argument(
     backoff_delay = 1  # Start wait with delay of 1 second.
     print("Poll for result...")
 
+    # Keep polling the state until the execution finishes,
+    # using exponential backoff.
     while not execution_finished:
         execution = execution_client.get_execution(
             request={"name": response.name}
@@ -96,4 +98,4 @@ if __name__ == "__main__":
     PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
     assert PROJECT, "'GOOGLE_CLOUD_PROJECT' environment variable not set."
 
-    execute_workflow_with_argument(PROJECT, "us-central1", "myFirstWorkflow")
+    execute_workflow_with_arguments(PROJECT, "us-central1", "myFirstWorkflow")

--- a/workflows/cloud-client/execute_with_arguments_test.py
+++ b/workflows/cloud-client/execute_with_arguments_test.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@ import backoff
 
 from google.cloud.workflows.executions_v1.types import executions
 
-import pass_data_in_execution_request
+import execute_with_arguments
 
 
 @backoff.on_exception(backoff.expo, AssertionError, max_tries=5)
-def test_workflow_execution_with_arguments(project_id: str, location: str, workflow_id: str) -> None:
-    execution_result = pass_data_in_execution_request.execute_workflow_with_argument(
+def test_workflow_execution_with_arguments(
+    project_id: str, location: str, workflow_id: str
+) -> None:
+    execution_result = execute_with_arguments.execute_workflow_with_arguments(
         project_id, location, workflow_id
     )
     assert execution_result.state == executions.Execution.State.SUCCEEDED

--- a/workflows/cloud-client/execute_without_arguments.py
+++ b/workflows/cloud-client/execute_without_arguments.py
@@ -50,13 +50,10 @@ def execute_workflow_without_arguments(
     # location = "YOUR_LOCATION"  # For example: us-central1
     # workflow_id = "YOUR_WORKFLOW_ID"  # For example: myFirstWorkflow
 
-    # [START workflows_api_quickstart_client_libraries]
     # Initialize API clients.
     execution_client = executions_v1.ExecutionsClient()
     workflows_client = workflows_v1.WorkflowsClient()
-    # [END workflows_api_quickstart_client_libraries]
 
-    # [START workflows_api_quickstart_execution]
     # Construct the fully qualified location path.
     parent = workflows_client.workflow_path(project_id, location, workflow_id)
 
@@ -86,7 +83,6 @@ def execute_workflow_without_arguments(
         else:
             print(f"Execution finished with state: {execution.state.name}")
             print(f"Execution results: {execution.result}")
-    # [END workflows_api_quickstart_execution]
 # [END workflows_execute_without_arguments]
             return execution
 

--- a/workflows/cloud-client/execute_without_arguments.py
+++ b/workflows/cloud-client/execute_without_arguments.py
@@ -1,0 +1,98 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from google.cloud.workflows.executions_v1 import Execution
+
+
+def execute_workflow_without_arguments(
+    project_id: str,
+    location: str,
+    workflow_id: str
+) -> Execution:
+    """Execute a workflow and print the execution results.
+
+    A workflow consists of a series of steps described
+    using the Workflows syntax, and can be written in either YAML or JSON.
+
+    Args:
+        project: The ID of the Google Cloud project
+            which contains the workflow to execute.
+        location: The location for the workflow.
+        workflow: The ID of the workflow to execute.
+
+    Returns:
+        The execution response.
+    """
+
+# [START workflows_execute_without_arguments]
+    import time
+
+    from google.cloud import workflows_v1
+    from google.cloud.workflows import executions_v1
+
+    from google.cloud.workflows.executions_v1.types import executions
+
+    # TODO(developer): Update and uncomment the following lines.
+    # project_id = "YOUR_PROJECT_ID"
+    # location = "YOUR_LOCATION"  # For example: us-central1
+    # workflow_id = "YOUR_WORKFLOW_ID"  # For example: myFirstWorkflow
+
+    # [START workflows_api_quickstart_client_libraries]
+    # Initialize API clients.
+    execution_client = executions_v1.ExecutionsClient()
+    workflows_client = workflows_v1.WorkflowsClient()
+    # [END workflows_api_quickstart_client_libraries]
+
+    # [START workflows_api_quickstart_execution]
+    # Construct the fully qualified location path.
+    parent = workflows_client.workflow_path(project_id, location, workflow_id)
+
+    # Execute the workflow.
+    response = execution_client.create_execution(request={"parent": parent})
+    print(f"Created execution: {response.name}")
+
+    # Wait for execution to finish, then print results.
+    execution_finished = False
+    backoff_delay = 1  # Start wait with delay of 1 second.
+    print("Poll for result...")
+
+    # Keep polling the state until the execution finishes,
+    # using exponential backoff.
+    while not execution_finished:
+        execution = execution_client.get_execution(
+            request={"name": response.name}
+        )
+        execution_finished = execution.state != executions.Execution.State.ACTIVE
+
+        # If we haven't seen the result yet, keep waiting.
+        if not execution_finished:
+            print("- Waiting for results...")
+            time.sleep(backoff_delay)
+            # Double the delay to provide exponential backoff.
+            backoff_delay *= 2
+        else:
+            print(f"Execution finished with state: {execution.state.name}")
+            print(f"Execution results: {execution.result}")
+    # [END workflows_api_quickstart_execution]
+# [END workflows_execute_without_arguments]
+            return execution
+
+
+if __name__ == "__main__":
+    PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+    assert PROJECT, "'GOOGLE_CLOUD_PROJECT' environment variable not set."
+
+    execute_workflow_without_arguments(PROJECT, "us-central1", "myFirstWorkflow")

--- a/workflows/cloud-client/execute_without_arguments_test.py
+++ b/workflows/cloud-client/execute_without_arguments_test.py
@@ -1,0 +1,30 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import backoff
+
+from google.cloud.workflows.executions_v1.types import executions
+
+import execute_without_arguments
+
+
+@backoff.on_exception(backoff.expo, AssertionError, max_tries=5)
+def test_workflow_execution_without_arguments(
+    project_id: str, location: str, workflow_id: str
+) -> None:
+    result = execute_without_arguments.execute_workflow_without_arguments(
+        project_id, location, workflow_id
+    )
+    assert result.state == executions.Execution.State.SUCCEEDED
+    assert result.result


### PR DESCRIPTION
## Description

Fixes Internal: b/414453548

- Copy main.py to execute_without_arguments.py
- Rename pass_data_in_execution_request.py to execute_with_arguments.py

`main.py` will be deleted in the next step after the references in documentation are migrated.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved