### PR TITLE
Adding support for image and table annotation for DocAI

### DIFF
--- a/documentai/snippets/handle_response_sample.py
+++ b/documentai/snippets/handle_response_sample.py
@@ -463,13 +463,15 @@ def process_document_layout_sample(
     processor_version: str,
     file_path: str,
     mime_type: str,
+    enable_llm_layout_parsing: bool = false,
 ) -> documentai.Document:
     process_options = documentai.ProcessOptions(
         layout_config=documentai.ProcessOptions.LayoutConfig(
             chunking_config=documentai.ProcessOptions.LayoutConfig.ChunkingConfig(
                 chunk_size=1000,
                 include_ancestor_headings=True,
-            )
+            ),
+            enable_llm_layout_parsing=enable_llm_layout_parsing
         )
     )
 

--- a/documentai/snippets/handle_response_sample.py
+++ b/documentai/snippets/handle_response_sample.py
@@ -32,7 +32,8 @@ from google.cloud import documentai
 # processor_version = "rc" # Refer to https://cloud.google.com/document-ai/docs/manage-processor-versions for more information
 # file_path = "/path/to/local/pdf"
 # mime_type = "application/pdf" # Refer to https://cloud.google.com/document-ai/docs/file-types for supported file types
-
+# enable_image_annotation = "ENABLE_IMAGE_ANNOTATION_BOOLEAN" # Set to TRUE to enable processing. Refer to https://cloud.google.com/document-ai/docs/layout-parse-chunk#layout_parser_features
+# enable_table_annotation = "ENABLE_TABLE_ANNOTATION_BOOLEAN" # Set to TRUE to enable processing. Refer to https://cloud.google.com/document-ai/docs/layout-parse-chunk#layout_parser_features
 
 # [END documentai_process_ocr_document]
 # [END documentai_process_form_document]
@@ -463,7 +464,8 @@ def process_document_layout_sample(
     processor_version: str,
     file_path: str,
     mime_type: str,
-    enable_llm_layout_parsing: bool = false,
+    enable_image_annotation: bool = false,
+    enable_table_annotation: bool = false,
 ) -> documentai.Document:
     process_options = documentai.ProcessOptions(
         layout_config=documentai.ProcessOptions.LayoutConfig(
@@ -471,7 +473,8 @@ def process_document_layout_sample(
                 chunk_size=1000,
                 include_ancestor_headings=True,
             ),
-            enable_llm_layout_parsing=enable_llm_layout_parsing
+            enable_image_annotation=enable_image_annotation,
+            enable_table_annotation=enable_table_annotation,
         )
     )
 

--- a/documentai/snippets/handle_response_sample_test.py
+++ b/documentai/snippets/handle_response_sample_test.py
@@ -229,6 +229,7 @@ def test_process_document_layout():
         processor_version="pretrained",
         file_path="resources/superconductivity.pdf",
         mime_type="application/pdf",
+        enable_llm_layout_parsing = True,
     )
 
     assert document

--- a/documentai/snippets/handle_response_sample_test.py
+++ b/documentai/snippets/handle_response_sample_test.py
@@ -229,7 +229,8 @@ def test_process_document_layout():
         processor_version="pretrained",
         file_path="resources/superconductivity.pdf",
         mime_type="application/pdf",
-        enable_llm_layout_parsing = True,
+        enable_image_annotation = True,
+        enable_table_annotation = True,
     )
 
     assert document


### PR DESCRIPTION
## Description

Image Annotation is GA in DocAI Layout Parser, these changes were requested internally to update documentation and available code to match and support the offering. 

Bugs: b/413675713

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved