### PR TITLE
fix(firestore): add a note for devs and asserts for `firestore_data_delete_collection`

### DIFF
--- a/firestore/cloud-client/snippets_test.py
+++ b/firestore/cloud-client/snippets_test.py
@@ -22,6 +22,10 @@ import pytest
 
 import snippets
 
+# TODO(developer): Before running these tests locally,
+# set your FIRESTORE_PROJECT env variable
+# and create a Database named `(default)`
+
 os.environ["GOOGLE_CLOUD_PROJECT"] = os.environ["FIRESTORE_PROJECT"]
 
 UNIQUE_STRING = str(uuid.uuid4()).split("-")[0]
@@ -761,8 +765,12 @@ def test_delete_field(db):
 
 
 def test_delete_full_collection(db):
+    assert list(db.collection("cities").stream()) == []
+
     for i in range(5):
         db.collection("cities").document(f"City{i}").set({"name": f"CityName{i}"})
+    assert len(list(db.collection("cities").stream())) == 5
+
     snippets.delete_full_collection()
     assert list(db.collection("cities").stream()) == []
 


### PR DESCRIPTION
## Description

Fixes Internal: b/239029690

The sample works well, but requires manual steps before running local tests.
- Add a note for future developers before running tests (Set env vars, and create a firestore DB for testing)
- Add asserts to validate the state before deleting the collection

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved