### PR TITLE
chore: disable global blunderbuss assignments

### DIFF
--- a/.github/blunderbuss.yml
+++ b/.github/blunderbuss.yml
@@ -244,11 +244,6 @@ assign_prs_by:
       - "api: appengine"
     to:
       - jinglundong
-assign_issues:
-  - GoogleCloudPlatform/python-samples-owners
-
-assign_prs:
-  - GoogleCloudPlatform/python-samples-owners
 
 ###
 # Updates should be made to both assign_issues_by & assign_prs_by sections


### PR DESCRIPTION
## Description

Disabling global blunderbuss assignments (the backup assignments after label based triage). 

Context reference: https://b.corp.google.com/issues/421202292

## Checklist
- [ ] Please **merge** this PR for me once it is approved