### PR TITLE
fix(translate): update sample `translate_text` to unify across languages

### DIFF
--- a/translate/samples/snippets/snippets.py
+++ b/translate/samples/snippets/snippets.py
@@ -21,6 +21,8 @@ For more information, the documentation at
 https://cloud.google.com/translate/docs.
 """
 
+from __future__ import annotations
+
 import argparse
 
 
@@ -116,12 +118,29 @@ def translate_text_with_model(target: str, text: str, model: str = "nmt") -> dic
 
 
 # [START translate_translate_text]
-def translate_text(target: str, text: str) -> dict:
-    """Translates text into the target language.
+def translate_text(
+    text: str | bytes = "¡Hola amigos y amigas!",
+    target_language: str = "en",
+    source_language: str | None = None,
+) -> dict:
+    """Translates a given text into the specified target language.
 
-    Target must be an ISO 639-1 language code.
-    See https://g.co/cloud/translate/v2/translate-reference#supported_languages
+    Find a list of supported languages and codes here:
+    https://cloud.google.com/translate/docs/languages#nmt
+
+    Args:
+        text: The text to translate. Can be a string or bytes.
+              If bytes, it will be decoded as UTF-8.
+        target_language: The ISO 639 language code to translate the text into
+                         (e.g., 'en' for English, 'es' for Spanish).
+        source_language: Optional. The ISO 639 language code of the input text
+                         (e.g., 'fr' for French). If None, the API will attempt
+                         to detect the source language automatically.
+
+    Returns:
+        A dictionary containing the translation results.
     """
+
     from google.cloud import translate_v2 as translate
 
     translate_client = translate.Client()
@@ -129,17 +148,24 @@ def translate_text(target: str, text: str) -> dict:
     if isinstance(text, bytes):
         text = text.decode("utf-8")
 
-    # Text can also be a sequence of strings, in which case this method
-    # will return a sequence of results for each text.
-    result = translate_client.translate(text, target_language=target)
+    # Values can also be a list of strings, in which case this method
+    # will return a list of results for each text.
 
-    print("Text: {}".format(result["input"]))
-    print("Translation: {}".format(result["translatedText"]))
-    print("Detected source language: {}".format(result["detectedSourceLanguage"]))
+    # Find more information about translate function here:
+    # https://cloud.google.com/python/docs/reference/translate/latest/google.cloud.translate_v2.client.Client#google_cloud_translate_v2_client_Client_translate
+    result = translate_client.translate(
+        values=text,
+        target_language=target_language,
+        source_language=source_language
+    )
+
+    if "detectedSourceLanguage" in result:
+        print(f"Detected source language: {result['detectedSourceLanguage']}")
+
+    print(f"Input text: {result['input']}")
+    print(f"Translated text: {result['translatedText']}")
 
     return result
-
-
 # [END translate_translate_text]
 
 

--- a/translate/samples/snippets/snippets.py
+++ b/translate/samples/snippets/snippets.py
@@ -119,7 +119,7 @@ def translate_text_with_model(target: str, text: str, model: str = "nmt") -> dic
 
 # [START translate_translate_text]
 def translate_text(
-    text: str | bytes = "¡Hola amigos y amigas!",
+    text: str | bytes | list[str] = "¡Hola amigos y amigas!",
     target_language: str = "en",
     source_language: str | None = None,
 ) -> dict:
@@ -129,7 +129,7 @@ def translate_text(
     https://cloud.google.com/translate/docs/languages#nmt
 
     Args:
-        text: The text to translate. Can be a string or bytes.
+        text: The text to translate. Can be a string, bytes or a list of strings.
               If bytes, it will be decoded as UTF-8.
         target_language: The ISO 639 language code to translate the text into
                          (e.g., 'en' for English, 'es' for Spanish).
@@ -146,26 +146,32 @@ def translate_text(
     translate_client = translate.Client()
 
     if isinstance(text, bytes):
-        text = text.decode("utf-8")
+        text = [text.decode("utf-8")]
 
-    # Values can also be a list of strings, in which case this method
-    # will return a list of results for each text.
+    if isinstance(text, str):
+        text = [text]
+
+    # If a string is supplied, a single dictionary will be returned.
+    # In case a list of strings is supplied, this method
+    # will return a list of dictionaries.
 
     # Find more information about translate function here:
     # https://cloud.google.com/python/docs/reference/translate/latest/google.cloud.translate_v2.client.Client#google_cloud_translate_v2_client_Client_translate
-    result = translate_client.translate(
+    results = translate_client.translate(
         values=text,
         target_language=target_language,
         source_language=source_language
     )
 
-    if "detectedSourceLanguage" in result:
-        print(f"Detected source language: {result['detectedSourceLanguage']}")
+    for result in results:
+        if "detectedSourceLanguage" in result:
+            print(f"Detected source language: {result['detectedSourceLanguage']}")
 
-    print(f"Input text: {result['input']}")
-    print(f"Translated text: {result['translatedText']}")
+        print(f"Input text: {result['input']}")
+        print(f"Translated text: {result['translatedText']}")
+        print()
 
-    return result
+    return results
 # [END translate_translate_text]
 
 

--- a/translate/samples/snippets/snippets.py
+++ b/translate/samples/snippets/snippets.py
@@ -204,4 +204,4 @@ if __name__ == "__main__":
     elif args.command == "list-languages-with-target":
         list_languages_with_target(args.target)
     elif args.command == "translate-text":
-        translate_text(args.target, args.text)
+        translate_text(text=args.text, target_language=args.target)

--- a/translate/samples/snippets/snippets_test.py
+++ b/translate/samples/snippets/snippets_test.py
@@ -40,11 +40,11 @@ def test_list_languages_with_target(capsys: pytest.LogCaptureFixture) -> None:
 def test_translate_text(capsys: pytest.LogCaptureFixture) -> None:
     result = snippets.translate_text(text="Hello world", target_language="is")
     out, _ = capsys.readouterr()
-    assert "Halló heimur" in result["translatedText"]
+    assert "Halló heimur" in result[0]["translatedText"]
 
 
 def test_translate_utf8(capsys: pytest.LogCaptureFixture) -> None:
     text = "파인애플 13개"
     result = snippets.translate_text(text=text, target_language="en")
     out, _ = capsys.readouterr()
-    assert "13 pineapples" in result["translatedText"]
+    assert "13 pineapples" in result[0]["translatedText"]

--- a/translate/samples/snippets/snippets_test.py
+++ b/translate/samples/snippets/snippets_test.py
@@ -38,13 +38,13 @@ def test_list_languages_with_target(capsys: pytest.LogCaptureFixture) -> None:
 
 
 def test_translate_text(capsys: pytest.LogCaptureFixture) -> None:
-    result = snippets.translate_text("is", "Hello world")
+    result = snippets.translate_text(text="Hello world", target_language="is")
     out, _ = capsys.readouterr()
     assert "Halló heimur" in result["translatedText"]
 
 
 def test_translate_utf8(capsys: pytest.LogCaptureFixture) -> None:
     text = "파인애플 13개"
-    result = snippets.translate_text("en", text)
+    result = snippets.translate_text(text=text, target_language="en")
     out, _ = capsys.readouterr()
     assert "13 pineapples" in result["translatedText"]


### PR DESCRIPTION
## Description

Fixes Internal: b/421210226

Note to reviewers: As using `from typing import Union, Optional` will break the linting if inserted inside the region tags, `from __future__ import annotations` is proposed instead to comply with Python 3.9.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved