### PR TITLE
chore(generative_ai): unmark test as fixture

### DIFF
--- a/generative_ai/embeddings/batch_example.py
+++ b/generative_ai/embeddings/batch_example.py
@@ -18,7 +18,7 @@ from google.cloud.aiplatform import BatchPredictionJob
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
 
 
-def embed_text_batch(OUTPUT_URI) -> BatchPredictionJob:
+def embed_text_batch(OUTPUT_URI: str) -> BatchPredictionJob:
     """Example of how to generate embeddings from text using batch processing.
 
     Read more: https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/batch-prediction-genai-embeddings

--- a/generative_ai/embeddings/batch_example.py
+++ b/generative_ai/embeddings/batch_example.py
@@ -16,10 +16,9 @@ import os
 from google.cloud.aiplatform import BatchPredictionJob
 
 PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
-OUTPUT_URI = os.getenv("GCS_OUTPUT_URI")
 
 
-def embed_text_batch() -> BatchPredictionJob:
+def embed_text_batch(OUTPUT_URI) -> BatchPredictionJob:
     """Example of how to generate embeddings from text using batch processing.
 
     Read more: https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings/batch-prediction-genai-embeddings

--- a/generative_ai/embeddings/test_embeddings_examples.py
+++ b/generative_ai/embeddings/test_embeddings_examples.py
@@ -22,7 +22,6 @@ import google.auth
 from google.cloud import aiplatform
 from google.cloud.aiplatform import initializer as aiplatform_init
 
-import pytest
 
 import batch_example
 import code_retrieval_example

--- a/generative_ai/embeddings/test_embeddings_examples.py
+++ b/generative_ai/embeddings/test_embeddings_examples.py
@@ -35,7 +35,6 @@ import multimodal_video_example
 
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
-@pytest.fixture(scope="session")
 def test_embed_text_batch() -> None:
     os.environ["GCS_OUTPUT_URI"] = "gs://python-docs-samples-tests/"
     batch_prediction_job = batch_example.embed_text_batch()

--- a/generative_ai/embeddings/test_embeddings_examples.py
+++ b/generative_ai/embeddings/test_embeddings_examples.py
@@ -35,8 +35,7 @@ import multimodal_video_example
 
 @backoff.on_exception(backoff.expo, ResourceExhausted, max_time=10)
 def test_embed_text_batch() -> None:
-    os.environ["GCS_OUTPUT_URI"] = "gs://python-docs-samples-tests/"
-    batch_prediction_job = batch_example.embed_text_batch()
+    batch_prediction_job = batch_example.embed_text_batch("gs://python-docs-samples-tests/")
     assert batch_prediction_job
 
 


### PR DESCRIPTION
## Description

Addresess issues identified in #13393, #13396

The tests in #13388 all passed originally, but it appears the batch test was marked as a fixture, and was not being executed, thus the changes appeared to succeed. 


From https://btx.cloud.google.com/invocations/c57aafde-585e-490e-a9e2-384a1d47d7a1/log
```
============================= test session starts ==============================
platform linux -- Python 3.12.7, pytest-8.2.0, pluggy-1.6.0 -- /workspace/generative_ai/embeddings/.nox/py-3-12/bin/python
cachedir: .pytest_cache
rootdir: /workspace
configfile: pytest.ini
plugins: asyncio-0.23.6, anyio-4.9.0
asyncio: mode=Mode.STRICT
collecting ... collected 7 items

test_embeddings_examples.py::test_multimodal_embedding_image_video_text PASSED [ 14%]
test_embeddings_examples.py::test_multimodal_embedding_video PASSED      [ 28%]
test_embeddings_examples.py::test_multimodal_embedding_image PASSED      [ 42%]
test_embeddings_examples.py::test_generate_embeddings_with_lower_dimension PASSED [ 57%]
test_embeddings_examples.py::test_text_embed_text PASSED                 [ 71%]
test_embeddings_examples.py::test_code_embed_text PASSED                 [ 85%]
test_embeddings_examples.py::test_tune_embedding_model PASSED            [100%]
```



- [x] Please **merge** this PR for me once it is approved