### PR TITLE
feat: set specific linting version for tests, min tested or 3.10

### DIFF
--- a/noxfile-template.py
+++ b/noxfile-template.py
@@ -97,6 +97,11 @@ TESTED_VERSIONS = sorted([v for v in ALL_VERSIONS if v not in IGNORED_VERSIONS])
 
 INSTALL_LIBRARY_FROM_SOURCE = bool(os.environ.get("INSTALL_LIBRARY_FROM_SOURCE", False))
 
+# Use the oldest tested Python version for linting (defaults to 3.10)
+LINTING_VERSION = "3.10"
+if len(TESTED_VERSIONS) > 0:
+    LINTING_VERSION = TESTED_VERSIONS[0]
+
 # Error if a python version is missing
 nox.options.error_on_missing_interpreters = True
 
@@ -146,7 +151,7 @@ FLAKE8_COMMON_ARGS = [
 ]
 
 
-@nox.session
+@nox.session(python=LINTING_VERSION)
 def lint(session: nox.sessions.Session) -> None:
     if not TEST_CONFIG["enforce_type_hints"]:
         session.install("flake8", "flake8-import-order")
@@ -167,7 +172,7 @@ def lint(session: nox.sessions.Session) -> None:
 #
 
 
-@nox.session
+@nox.session(python=LINTING_VERSION)
 def blacken(session: nox.sessions.Session) -> None:
     session.install("black")
     python_files = [path for path in os.listdir(".") if path.endswith(".py")]


### PR DESCRIPTION
## Description

Introduces explicit Python version for lint commands. 

Fixes b/425186923

A few samples (search for any noxfile-config.py files that have ignored_versions matching tested_versions, currently applies to appengine flex samples) have skipped tests by ignoring testsing all versions, so use a default, or set to earliest python that is tested.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved