### PR TITLE
fix: Update the default model name for the ranking api default name

### DIFF
--- a/discoveryengine/standalone_apis_sample.py
+++ b/discoveryengine/standalone_apis_sample.py
@@ -94,7 +94,7 @@ def rank_sample(
     )
     request = discoveryengine.RankRequest(
         ranking_config=ranking_config,
-        model="semantic-ranker-512@latest",
+        model="semantic-ranker-default@latest",
         top_n=10,
         query="What is Google Gemini?",
         records=[


### PR DESCRIPTION
The naming convention for the ranking api changed to:
- semantic-ranker-default@latest

This PR updates the default model name.

For more information see:
https://cloud.google.com/generative-ai-app-builder/docs/ranking

## Description

Fixes #13471

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] These samples need a new **API enabled** in testing projects to pass (let us know which ones) - No
- [X] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones) - No
- [X] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample  - Not needed
- [X] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample - No
- [X] Please **merge** this PR for me once it is approved - Yes please