### PR TITLE
docs: add region tag around run/mcp-server/test_server.py

### DIFF
--- a/run/mcp-server/Dockerfile
+++ b/run/mcp-server/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 # [START cloudrun_mcpserver_dockerfile_python]
-
 # Use the official Python image
 FROM python:3.13-slim
 

--- a/run/mcp-server/test_server.py
+++ b/run/mcp-server/test_server.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START cloudrun_test_mcpserver]
 import asyncio
 
 from fastmcp import Client
@@ -35,3 +36,4 @@ async def test_server():
 
 if __name__ == "__main__":
     asyncio.run(test_server())
+# [END cloudrun_test_mcpserver]


### PR DESCRIPTION
Add missing region tag around test code (needed for sample in docs)
and update Dockerfile region tag to not include newline.