### PR TITLE
Change what we do with manually triggered dag_runs to being pruned too.

### DIFF
--- a/composer/workflows/airflow_db_cleanup.py
+++ b/composer/workflows/airflow_db_cleanup.py
@@ -66,7 +66,7 @@ from airflow.utils import timezone
 from airflow.version import version as airflow_version
 
 import dateutil.parser
-from sqlalchemy import desc, sql, text
+from sqlalchemy import desc, text
 from sqlalchemy.exc import ProgrammingError
 
 


### PR DESCRIPTION
## Description

We decided to change the way dag_runs triggered externally (not by schedule) are treated.

Previously they were skipped completely, but some customers are manually triggering DAGs and want to prune those informations too.

Now those dag_runs will get pruned the same way scheduled dag_runs are.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] Please **merge** this PR for me once it is approved