### PR TITLE
feat(secretmanager): Added samples for tags field

### DIFF
--- a/secretmanager/snippets/bind_tags_to_secret.py
+++ b/secretmanager/snippets/bind_tags_to_secret.py
@@ -29,11 +29,11 @@ def bind_tags_to_secret(
     project_id: str,
     secret_id: str,
     tag_value: str,
-) -> secretmanager.Secret:
+) -> resourcemanager_v3.TagBinding:
     """
-    Create a new secret with the given name. A secret is a logical wrapper
-    around a collection of secret versions. Secret versions hold the actual
-    secret material.
+    Create a new secret with the given name, and then bind an existing tag to it.
+    A secret is a logical wrapper around a collection of secret versions. Secret
+    versions hold the actual secret material.
     """
 
     # Create the Secret Manager client.

--- a/secretmanager/snippets/bind_tags_to_secret.py
+++ b/secretmanager/snippets/bind_tags_to_secret.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for creating a new secret then
+bind the tag to that secret.
+"""
+
+# [START secretmanager_bind_tags_to_secret]
+import argparse
+
+# Import the Secret Manager and Resource Manager client library.
+from google.cloud import resourcemanager_v3
+from google.cloud import secretmanager
+
+
+def bind_tags_to_secret(
+    project_id: str,
+    secret_id: str,
+    tag_value: str,
+) -> secretmanager.Secret:
+    """
+    Create a new secret with the given name. A secret is a logical wrapper
+    around a collection of secret versions. Secret versions hold the actual
+    secret material.
+    """
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    # Build the resource name of the parent project.
+    parent = f"projects/{project_id}"
+
+    # Create the secret.
+    secret_response = client.create_secret(
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {
+                "replication": {"automatic": {}},
+            },
+        }
+    )
+
+    # Print the new secret name.
+    print(f"Created secret: {secret_response.name}")
+
+    # Create the resource manager client
+    resource_manager_client = resourcemanager_v3.TagBindingsClient()
+
+    # Create the tag binding
+    request = resourcemanager_v3.CreateTagBindingRequest(
+        tag_binding=resourcemanager_v3.TagBinding(
+            parent=f"//secretmanager.googleapis.com/{secret_response.name}",
+            tag_value=f"{tag_value}",
+        ),
+    )
+
+    # Create the tag binding
+    operation = resource_manager_client.create_tag_binding(request=request)
+
+    # Wait for the operation to complete
+    response = operation.result()
+
+    # Print the tag binding
+    print(f"Created tag binding: {response.name}")
+
+    return response
+
+
+# [END secretmanager_bind_tags_to_secret]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("secret_id", help="id of the secret to create")
+    parser.add_argument("tag_value", help="value of the tag you want to add")
+    args = parser.parse_args()
+
+    bind_tags_to_secret(args.project_id, args.secret_id, args.tag_value)

--- a/secretmanager/snippets/create_secret_with_tags.py
+++ b/secretmanager/snippets/create_secret_with_tags.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for creating a new secret with
+tags.
+"""
+
+# [START secretmanager_create_secret_with_tags]
+import argparse
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager
+
+
+def create_secret_with_tags(
+    project_id: str,
+    secret_id: str,
+    tag_key: str,
+    tag_value: str,
+) -> secretmanager.Secret:
+    """
+    Create a new secret with the given name. A secret is a logical wrapper
+    around a collection of secret versions. Secret versions hold the actual
+    secret material.
+    """
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient()
+
+    # Build the resource name of the parent project.
+    parent = f"projects/{project_id}"
+
+    # Create the secret.
+    response = client.create_secret(
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {
+                "replication": {"automatic": {}},
+                "tags": {
+                    tag_key: tag_value
+                }
+            },
+        }
+    )
+
+    # Print the new secret name.
+    print(f"Created secret: {response.name}")
+
+    return response
+
+
+# [END secretmanager_create_secret_with_tags]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("secret_id", help="id of the secret to create")
+    parser.add_argument("tag_key", help="key of the tag you want to add")
+    parser.add_argument("tag_value", help="value of the tag you want to add")
+    args = parser.parse_args()
+
+    create_secret_with_tags(args.project_id, args.secret_id, args.tag_key, args.tag_value)

--- a/secretmanager/snippets/create_secret_with_tags.py
+++ b/secretmanager/snippets/create_secret_with_tags.py
@@ -31,9 +31,9 @@ def create_secret_with_tags(
     tag_value: str,
 ) -> secretmanager.Secret:
     """
-    Create a new secret with the given name. A secret is a logical wrapper
-    around a collection of secret versions. Secret versions hold the actual
-    secret material.
+    Create a new secret with the given name and associated tags. A secret is a
+    logical wrapper around a collection of secret versions. Secret versions hold
+    the actual secret material.
     """
 
     # Create the Secret Manager client.

--- a/secretmanager/snippets/regional_samples/bind_tags_to_regional_secret.py
+++ b/secretmanager/snippets/regional_samples/bind_tags_to_regional_secret.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for creating a new secret then
+bind the tag to that secret.
+"""
+
+# [START secretmanager_bind_tags_to_regional_secret]
+import argparse
+
+# Import the Secret Manager and Resource Manager client library.
+from google.cloud import resourcemanager_v3
+from google.cloud import secretmanager
+
+
+def bind_tags_to_regional_secret(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+    tag_value: str,
+) -> secretmanager.Secret:
+    """
+    Create a new secret with the given name. A secret is a logical wrapper
+    around a collection of secret versions. Secret versions hold the actual
+    secret material.
+    """
+
+    # Endpoint to call the regional secret manager sever
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name of the parent project.
+    parent = f"projects/{project_id}/locations/{location_id}"
+
+    # Create the secret.
+    secret_response = client.create_secret(
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+        }
+    )
+
+    # Print the new secret name.
+    print(f"Created secret: {secret_response.name}")
+
+    # Endpoint to call the regional secret manager sever
+    resource_manager_api_endpoint = f"{location_id}-cloudresourcemanager.googleapis.com"
+
+    # Create the resource manager client
+    resource_manager_client = resourcemanager_v3.TagBindingsClient(
+        client_options={"api_endpoint": resource_manager_api_endpoint},
+    )
+
+    # Create the tag binding
+    request = resourcemanager_v3.CreateTagBindingRequest(
+        tag_binding=resourcemanager_v3.TagBinding(
+            parent=f"//secretmanager.googleapis.com/{secret_response.name}",
+            tag_value=f"{tag_value}",
+        ),
+    )
+
+    # Create the tag binding
+    operation = resource_manager_client.create_tag_binding(request=request)
+
+    # Wait for the operation to complete
+    response = operation.result()
+
+    # Print the tag binding
+    print(f"Created tag binding: {response.name}")
+
+    return response
+
+
+# [END secretmanager_bind_tags_to_regional_secret]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument(
+        "location_id", help="id of the location where secret is to be created"
+    )
+    parser.add_argument("secret_id", help="id of the secret to create")
+    parser.add_argument("tag_value", help="value of the tag you want to add")
+    args = parser.parse_args()
+
+    bind_tags_to_regional_secret(args.project_id, args.location_id, args.secret_id, args.tag_value)

--- a/secretmanager/snippets/regional_samples/bind_tags_to_regional_secret.py
+++ b/secretmanager/snippets/regional_samples/bind_tags_to_regional_secret.py
@@ -30,11 +30,11 @@ def bind_tags_to_regional_secret(
     location_id: str,
     secret_id: str,
     tag_value: str,
-) -> secretmanager.Secret:
+) -> resourcemanager_v3.TagBinding:
     """
-    Create a new secret with the given name. A secret is a logical wrapper
-    around a collection of secret versions. Secret versions hold the actual
-    secret material.
+    Create a new regional secret with the given name, and then bind an existing
+    tag to it. A secret is a logical wrapper around a collection of secret
+    versions. Secret versions hold the actual secret material.
     """
 
     # Endpoint to call the regional secret manager sever

--- a/secretmanager/snippets/regional_samples/create_regional_secret_with_tags.py
+++ b/secretmanager/snippets/regional_samples/create_regional_secret_with_tags.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for creating a new secret with
+tags.
+"""
+
+# [START secretmanager_create_regional_secret_with_tags]
+import argparse
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager_v1
+
+
+def create_regional_secret_with_tags(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+    tag_key: str,
+    tag_value: str,
+) -> secretmanager_v1.Secret:
+    """
+    Create a new secret with the given name. A secret is a logical wrapper
+    around a collection of secret versions. Secret versions hold the actual
+    secret material.
+    """
+
+    # Endpoint to call the regional Secret Manager API.
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager_v1.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name of the parent secret.
+    parent = f"projects/{project_id}/locations/{location_id}"
+
+    # Create the secret.
+    response = client.create_secret(
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {
+                "tags": {
+                    tag_key: tag_value
+                }
+            },
+        }
+    )
+
+    # Print the new secret name.
+    print(f"Created secret: {response.name}")
+
+    return response
+
+
+# [END secretmanager_create_regional_secret_with_tags]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument(
+        "location_id", help="id of the location where secret is to be created"
+    )
+    parser.add_argument("secret_id", help="id of the secret to create")
+    parser.add_argument("tag_key", help="key of the tag you want to add")
+    parser.add_argument("tag_value", help="value of the tag you want to add")
+    args = parser.parse_args()
+
+    create_regional_secret_with_tags(
+        args.project_id, args.location_id, args.secret_id, args.tag_key, args.tag_value
+    )

--- a/secretmanager/snippets/regional_samples/create_regional_secret_with_tags.py
+++ b/secretmanager/snippets/regional_samples/create_regional_secret_with_tags.py
@@ -32,9 +32,9 @@ def create_regional_secret_with_tags(
     tag_value: str,
 ) -> secretmanager_v1.Secret:
     """
-    Create a new secret with the given name. A secret is a logical wrapper
-    around a collection of secret versions. Secret versions hold the actual
-    secret material.
+    Create a new regional secret with the given name and associated tags. A
+    secret is a logical wrapper around a collection of secret versions. Secret
+    versions hold the actual secret material.
     """
 
     # Endpoint to call the regional Secret Manager API.

--- a/secretmanager/snippets/regional_samples/snippets_test.py
+++ b/secretmanager/snippets/regional_samples/snippets_test.py
@@ -187,9 +187,9 @@ def retry_client_create_tag_value(
 def retry_client_delete_tag_value(
     tag_values_client: resourcemanager_v3.TagValuesClient,
     request: Union[resourcemanager_v3.DeleteTagValueRequest, dict],
-) -> None:
+) -> str:
     # Retry to avoid 503 error & flaky issues
-    time.sleep(10)  # Added a sleep to wait for the tag unbinding
+    time.sleep(15)  # Added a sleep to wait for the tag unbinding
     operation = tag_values_client.delete_tag_value(request=request)
     response = operation.result()
     return response.name
@@ -199,7 +199,7 @@ def retry_client_delete_tag_value(
 def retry_client_delete_tag_key(
     tag_keys_client: resourcemanager_v3.TagKeysClient,
     request: Union[resourcemanager_v3.DeleteTagKeyRequest, dict],
-) -> None:
+) -> str:
     # Retry to avoid 503 error & flaky issues
     operation = tag_keys_client.delete_tag_key(request=request)
     response = operation.result()
@@ -295,7 +295,7 @@ def tag_key_and_tag_value(
         request={
             "tag_key": {
                 "parent": f"projects/{project_id}",
-                "short_name": f"{short_key_name}"
+                "short_name": short_key_name,
             }
         },
     )
@@ -306,8 +306,8 @@ def tag_key_and_tag_value(
         tag_values_client,
         request={
             "tag_value": {
-                "parent": f"{tag_key}",
-                "short_name": f"{short_value_name}",
+                "parent": tag_key,
+                "short_name": short_value_name,
             }
         },
     )

--- a/secretmanager/snippets/regional_samples/snippets_test.py
+++ b/secretmanager/snippets/regional_samples/snippets_test.py
@@ -18,16 +18,19 @@ from typing import Iterator, Tuple, Union
 import uuid
 
 from google.api_core import exceptions, retry
+from google.cloud import resourcemanager_v3
 from google.cloud import secretmanager_v1
 from google.protobuf.duration_pb2 import Duration
 import pytest
 
 from regional_samples import access_regional_secret_version
 from regional_samples import add_regional_secret_version
+from regional_samples import bind_tags_to_regional_secret
 from regional_samples import create_regional_secret
 from regional_samples import create_regional_secret_with_annotations
 from regional_samples import create_regional_secret_with_delayed_destroy
 from regional_samples import create_regional_secret_with_labels
+from regional_samples import create_regional_secret_with_tags
 from regional_samples import delete_regional_secret
 from regional_samples import delete_regional_secret_label
 from regional_samples import delete_regional_secret_with_etag
@@ -80,6 +83,16 @@ def regional_client(location_id: str) -> secretmanager_v1.SecretManagerServiceCl
 
 
 @pytest.fixture()
+def tag_keys_client() -> resourcemanager_v3.TagKeysClient:
+    return resourcemanager_v3.TagKeysClient()
+
+
+@pytest.fixture()
+def tag_values_client() -> resourcemanager_v3.TagValuesClient:
+    return resourcemanager_v3.TagValuesClient()
+
+
+@pytest.fixture()
 def project_id() -> str:
     return os.environ["GOOGLE_CLOUD_PROJECT"]
 
@@ -109,6 +122,16 @@ def version_destroy_ttl() -> int:
     return 604800  # 7 days in seconds
 
 
+@pytest.fixture()
+def short_key_name() -> str:
+    return f"python-test-key-{uuid.uuid4()}"
+
+
+@pytest.fixture()
+def short_value_name() -> str:
+    return f"python-test-value-{uuid.uuid4()}"
+
+
 @retry.Retry()
 def retry_client_create_regional_secret(
     regional_client: secretmanager_v1.SecretManagerServiceClient,
@@ -134,6 +157,53 @@ def retry_client_access_regional_secret_version(
 ) -> secretmanager_v1.AccessSecretVersionResponse:
     # Retry to avoid 503 error & flaky issues
     return regional_client.access_secret_version(request=request)
+
+
+@retry.Retry()
+def retry_client_create_tag_key(
+    tag_keys_client: resourcemanager_v3.TagKeysClient,
+    request: Union[resourcemanager_v3.CreateTagKeyRequest, dict],
+) -> str:
+    # Retry to avoid 503 error & flaky issues
+    operation = tag_keys_client.create_tag_key(request=request)
+    response = operation.result()
+
+    return response.name
+
+
+@retry.Retry()
+def retry_client_create_tag_value(
+    tag_values_client: resourcemanager_v3.TagValuesClient,
+    request: Union[resourcemanager_v3.CreateTagValueRequest, dict],
+) -> str:
+    # Retry to avoid 503 error & flaky issues
+    operation = tag_values_client.create_tag_value(request=request)
+    response = operation.result()
+
+    return response.name
+
+
+@retry.Retry()
+def retry_client_delete_tag_value(
+    tag_values_client: resourcemanager_v3.TagValuesClient,
+    request: Union[resourcemanager_v3.DeleteTagValueRequest, dict],
+) -> None:
+    # Retry to avoid 503 error & flaky issues
+    time.sleep(10)  # Added a sleep to wait for the tag unbinding
+    operation = tag_values_client.delete_tag_value(request=request)
+    response = operation.result()
+    return response.name
+
+
+@retry.Retry()
+def retry_client_delete_tag_key(
+    tag_keys_client: resourcemanager_v3.TagKeysClient,
+    request: Union[resourcemanager_v3.DeleteTagKeyRequest, dict],
+) -> None:
+    # Retry to avoid 503 error & flaky issues
+    operation = tag_keys_client.delete_tag_key(request=request)
+    response = operation.result()
+    return response.name
 
 
 @pytest.fixture()
@@ -212,6 +282,52 @@ def regional_secret(
 
 
 @pytest.fixture()
+def tag_key_and_tag_value(
+    tag_keys_client: resourcemanager_v3.TagKeysClient,
+    tag_values_client: resourcemanager_v3.TagValuesClient,
+    project_id: str,
+    short_key_name: str,
+    short_value_name: str,
+) -> Iterator[Tuple[str, str]]:
+
+    tag_key = retry_client_create_tag_key(
+        tag_keys_client,
+        request={
+            "tag_key": {
+                "parent": f"projects/{project_id}",
+                "short_name": f"{short_key_name}"
+            }
+        },
+    )
+
+    print(f"created tag key {tag_key}")
+
+    tag_value = retry_client_create_tag_value(
+        tag_values_client,
+        request={
+            "tag_value": {
+                "parent": f"{tag_key}",
+                "short_name": f"{short_value_name}",
+            }
+        },
+    )
+
+    print(f"created tag value {tag_value}")
+
+    yield tag_key, tag_value
+
+    print(f"deleting tag value {tag_value} and tag key {tag_key}")
+
+    try:
+        time.sleep(5)
+        retry_client_delete_tag_value(tag_values_client, request={"name": tag_value})
+        retry_client_delete_tag_key(tag_keys_client, request={"name": tag_key})
+    except exceptions.NotFound:
+        # Tag was already deleted, probably in the test
+        print("Tag value or tag key was not found.")
+
+
+@pytest.fixture()
 def regional_secret_with_delayed_destroy(
     regional_client: secretmanager_v1.SecretManagerServiceClient,
     project_id: str,
@@ -277,6 +393,35 @@ def test_create_regional_secret(
         project_id, location_id, secret_id, ttl
     )
     assert secret_id in secret.name
+
+
+def test_create_regional_secret_with_tags(
+    project_id: str,
+    location_id: str,
+    tag_key_and_tag_value: Tuple[str, str],
+    secret_id: str,
+) -> None:
+    tag_key, tag_value = tag_key_and_tag_value
+    secret = create_regional_secret_with_tags.create_regional_secret_with_tags(
+        project_id, location_id, secret_id, tag_key, tag_value
+    )
+
+    assert secret_id in secret.name
+
+
+def test_bind_tags_to_regional_secret(
+    project_id: str,
+    location_id: str,
+    tag_key_and_tag_value: Tuple[str, str],
+    secret_id: str,
+) -> None:
+    _, tag_value = tag_key_and_tag_value
+    tag_resp = bind_tags_to_regional_secret.bind_tags_to_regional_secret(
+        project_id, location_id, secret_id, tag_value
+    )
+
+    assert secret_id in tag_resp.parent
+    assert tag_value in tag_resp.tag_value
 
 
 def test_create_regional_secret_with_annotations(

--- a/secretmanager/snippets/requirements.txt
+++ b/secretmanager/snippets/requirements.txt
@@ -1,4 +1,4 @@
-google_cloud_resource_manager==1.14.2
+google-cloud-resource-manager==1.14.2
 google-cloud-secret-manager==2.24.0
 google-crc32c==1.6.0
 protobuf==5.29.4

--- a/secretmanager/snippets/requirements.txt
+++ b/secretmanager/snippets/requirements.txt
@@ -1,3 +1,4 @@
-google-cloud-secret-manager==2.21.1
+google_cloud_resource_manager==1.14.2
+google-cloud-secret-manager==2.24.0
 google-crc32c==1.6.0
 protobuf==5.29.4

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -193,9 +193,9 @@ def retry_client_create_tag_value(
 def retry_client_delete_tag_value(
     tag_values_client: resourcemanager_v3.TagValuesClient,
     request: Optional[Union[resourcemanager_v3.DeleteTagValueRequest, dict]],
-) -> None:
+) -> str:
     # Retry to avoid 503 error & flaky issues
-    time.sleep(10)  # Added a sleep to wait for the tag unbinding
+    time.sleep(15)  # Added a sleep to wait for the tag unbinding
     operation = tag_values_client.delete_tag_value(request=request)
     response = operation.result()
     return response.name
@@ -205,7 +205,7 @@ def retry_client_delete_tag_value(
 def retry_client_delete_tag_key(
     tag_keys_client: resourcemanager_v3.TagKeysClient,
     request: Optional[Union[resourcemanager_v3.DeleteTagKeyRequest, dict]],
-) -> None:
+) -> str:
     # Retry to avoid 503 error & flaky issues
     operation = tag_keys_client.delete_tag_key(request=request)
     response = operation.result()
@@ -243,7 +243,7 @@ def tag_key_and_tag_value(
         request={
             "tag_key": {
                 "parent": f"projects/{project_id}",
-                "short_name": f"{short_key_name}"
+                "short_name": short_key_name,
             }
         },
     )
@@ -254,8 +254,8 @@ def tag_key_and_tag_value(
         tag_values_client,
         request={
             "tag_value": {
-                "parent": f"{tag_key}",
-                "short_name": f"{short_value_name}",
+                "parent": tag_key,
+                "short_name": short_value_name,
             }
         },
     )

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -19,6 +19,7 @@ from typing import Iterator, Optional, Tuple, Union
 import uuid
 
 from google.api_core import exceptions, retry
+from google.cloud import resourcemanager_v3
 from google.cloud import secretmanager
 from google.protobuf.duration_pb2 import Duration
 
@@ -26,11 +27,13 @@ import pytest
 
 from access_secret_version import access_secret_version
 from add_secret_version import add_secret_version
+from bind_tags_to_secret import bind_tags_to_secret
 from consume_event_notification import consume_event_notification
 from create_secret import create_secret
 from create_secret_with_annotations import create_secret_with_annotations
 from create_secret_with_delayed_destroy import create_secret_with_delayed_destroy
 from create_secret_with_labels import create_secret_with_labels
+from create_secret_with_tags import create_secret_with_tags
 from create_secret_with_user_managed_replication import create_ummr_secret
 from create_update_secret_label import create_update_secret_label
 from delete_secret import delete_secret
@@ -64,6 +67,16 @@ from view_secret_labels import view_secret_labels
 @pytest.fixture()
 def client() -> secretmanager.SecretManagerServiceClient:
     return secretmanager.SecretManagerServiceClient()
+
+
+@pytest.fixture()
+def tag_keys_client() -> resourcemanager_v3.TagKeysClient:
+    return resourcemanager_v3.TagKeysClient()
+
+
+@pytest.fixture()
+def tag_values_client() -> resourcemanager_v3.TagValuesClient:
+    return resourcemanager_v3.TagValuesClient()
 
 
 @pytest.fixture()
@@ -106,6 +119,16 @@ def version_destroy_ttl() -> str:
     return 604800  # 7 days in seconds
 
 
+@pytest.fixture()
+def short_key_name() -> str:
+    return f"python-test-key-{uuid.uuid4()}"
+
+
+@pytest.fixture()
+def short_value_name() -> str:
+    return f"python-test-value-{uuid.uuid4()}"
+
+
 @retry.Retry()
 def retry_client_create_secret(
     client: secretmanager.SecretManagerServiceClient,
@@ -142,6 +165,53 @@ def retry_client_add_secret_version(
     return client.add_secret_version(request=request)
 
 
+@retry.Retry()
+def retry_client_create_tag_key(
+    tag_keys_client: resourcemanager_v3.TagKeysClient,
+    request: Optional[Union[resourcemanager_v3.CreateTagKeyRequest, dict]],
+) -> str:
+    # Retry to avoid 503 error & flaky issues
+    operation = tag_keys_client.create_tag_key(request=request)
+    response = operation.result()
+
+    return response.name
+
+
+@retry.Retry()
+def retry_client_create_tag_value(
+    tag_values_client: resourcemanager_v3.TagValuesClient,
+    request: Optional[Union[resourcemanager_v3.CreateTagValueRequest, dict]],
+) -> str:
+    # Retry to avoid 503 error & flaky issues
+    operation = tag_values_client.create_tag_value(request=request)
+    response = operation.result()
+
+    return response.name
+
+
+@retry.Retry()
+def retry_client_delete_tag_value(
+    tag_values_client: resourcemanager_v3.TagValuesClient,
+    request: Optional[Union[resourcemanager_v3.DeleteTagValueRequest, dict]],
+) -> None:
+    # Retry to avoid 503 error & flaky issues
+    time.sleep(10)  # Added a sleep to wait for the tag unbinding
+    operation = tag_values_client.delete_tag_value(request=request)
+    response = operation.result()
+    return response.name
+
+
+@retry.Retry()
+def retry_client_delete_tag_key(
+    tag_keys_client: resourcemanager_v3.TagKeysClient,
+    request: Optional[Union[resourcemanager_v3.DeleteTagKeyRequest, dict]],
+) -> None:
+    # Retry to avoid 503 error & flaky issues
+    operation = tag_keys_client.delete_tag_key(request=request)
+    response = operation.result()
+    return response.name
+
+
 @pytest.fixture()
 def secret_id(
     client: secretmanager.SecretManagerServiceClient, project_id: str
@@ -157,6 +227,52 @@ def secret_id(
     except exceptions.NotFound:
         # Secret was already deleted, probably in the test
         print(f"Secret {secret_id} was not found.")
+
+
+@pytest.fixture()
+def tag_key_and_tag_value(
+    tag_keys_client: resourcemanager_v3.TagKeysClient,
+    tag_values_client: resourcemanager_v3.TagValuesClient,
+    project_id: str,
+    short_key_name: str,
+    short_value_name: str,
+) -> Iterator[Tuple[str, str]]:
+
+    tag_key = retry_client_create_tag_key(
+        tag_keys_client,
+        request={
+            "tag_key": {
+                "parent": f"projects/{project_id}",
+                "short_name": f"{short_key_name}"
+            }
+        },
+    )
+
+    print(f"created tag key {tag_key}")
+
+    tag_value = retry_client_create_tag_value(
+        tag_values_client,
+        request={
+            "tag_value": {
+                "parent": f"{tag_key}",
+                "short_name": f"{short_value_name}",
+            }
+        },
+    )
+
+    print(f"created tag value {tag_value}")
+
+    yield tag_key, tag_value
+
+    print(f"deleting tag value {tag_value} and tag key {tag_key}")
+
+    try:
+        time.sleep(5)
+        retry_client_delete_tag_value(tag_values_client, request={"name": tag_value})
+        retry_client_delete_tag_key(tag_keys_client, request={"name": tag_key})
+    except exceptions.NotFound:
+        # Tag was already deleted, probably in the test
+        print("Tag value or tag key was not found.")
 
 
 @pytest.fixture()
@@ -278,6 +394,29 @@ def test_create_secret(
 
     assert secret_id in secret.name
     assert secret.expire_time
+
+
+def test_create_secret_with_tags(
+    project_id: str,
+    tag_key_and_tag_value: Tuple[str, str],
+    secret_id: str,
+) -> None:
+    tag_key, tag_value = tag_key_and_tag_value
+    secret = create_secret_with_tags(project_id, secret_id, tag_key, tag_value)
+
+    assert secret_id in secret.name
+
+
+def test_bind_tags_to_secret(
+    project_id: str,
+    tag_key_and_tag_value: Tuple[str, str],
+    secret_id: str,
+) -> None:
+    _, tag_value = tag_key_and_tag_value
+    tag_resp = bind_tags_to_secret(project_id, secret_id, tag_value)
+
+    assert secret_id in tag_resp.parent
+    assert tag_value in tag_resp.tag_value
 
 
 def test_create_secret_without_ttl(


### PR DESCRIPTION
## Description

Created samples for Global and Regional Secret Manager API

Samples (Global, Regional)

- Create Secret With Tags
- Bind Tags to Secret

Ref: https://cloud.google.com/secret-manager/docs/create-and-manage-tags

## Checklist
- [X] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [X] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [X] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [X] These samples need a new **API enabled** in testing projects to pass (let us know which ones) (Resource Manager API needs to enabled)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [X] Please **merge** this PR for me once it is approved