### PR TITLE
chore(modelarmor): enable floor settings tests

### DIFF
--- a/model_armor/snippets/snippets_test.py
+++ b/model_armor/snippets/snippets_test.py
@@ -1168,7 +1168,6 @@ def test_quickstart(
     quickstart(project_id, location_id, template_id)
 
 
-@pytest.mark.skip(reason="Remove skip once the b/424365799 is resolved")
 def test_update_organization_floor_settings(
     floor_setting_organization_id: str,
 ) -> None:
@@ -1177,21 +1176,18 @@ def test_update_organization_floor_settings(
     assert response.enable_floor_setting_enforcement
 
 
-@pytest.mark.skip(reason="Remove skip once the b/424365799 is resolved")
 def test_update_folder_floor_settings(floor_setting_folder_id: str) -> None:
     response = update_folder_floor_settings(floor_setting_folder_id)
 
     assert response.enable_floor_setting_enforcement
 
 
-@pytest.mark.skip(reason="Remove skip once the b/424365799 is resolved")
 def test_update_project_floor_settings(floor_settings_project_id: str) -> None:
     response = update_project_floor_settings(floor_settings_project_id)
 
     assert response.enable_floor_setting_enforcement
 
 
-@pytest.mark.skip(reason="Remove skip once the b/424365799 is resolved")
 def test_get_organization_floor_settings(organization_id: str) -> None:
     expected_floor_settings_name = (
         f"organizations/{organization_id}/locations/global/floorSetting"
@@ -1201,7 +1197,6 @@ def test_get_organization_floor_settings(organization_id: str) -> None:
     assert response.name == expected_floor_settings_name
 
 
-@pytest.mark.skip(reason="Remove skip once the b/424365799 is resolved")
 def test_get_folder_floor_settings(folder_id: str) -> None:
     expected_floor_settings_name = (
         f"folders/{folder_id}/locations/global/floorSetting"
@@ -1211,7 +1206,6 @@ def test_get_folder_floor_settings(folder_id: str) -> None:
     assert response.name == expected_floor_settings_name
 
 
-@pytest.mark.skip(reason="Remove skip once the b/424365799 is resolved")
 def test_get_project_floor_settings(project_id: str) -> None:
     expected_floor_settings_name = (
         f"projects/{project_id}/locations/global/floorSetting"


### PR DESCRIPTION
## Description
Enabled Tests for Floor settings in model armor snippets as b/424365799 is fixed.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved