### PR TITLE
chore(batch prediction) Updates code samples to use gemini 2.5 flash instead of gemini 2.0 flash

### DIFF
--- a/genai/batch_prediction/batchpredict_with_bq.py
+++ b/genai/batch_prediction/batchpredict_with_bq.py
@@ -28,7 +28,7 @@ def generate_content(output_uri: str) -> str:
     job = client.batches.create(
         # To use a tuned model, set the model param to your tuned model using the following format:
         # model="projects/{PROJECT_ID}/locations/{LOCATION}/models/{MODEL_ID}
-        model="gemini-2.0-flash-001",
+        model="gemini-2.5-flash",
         src="bq://storage-samples.generative_ai.batch_requests_for_multimodal_input",
         config=CreateBatchJobConfig(dest=output_uri),
     )

--- a/genai/batch_prediction/batchpredict_with_gcs.py
+++ b/genai/batch_prediction/batchpredict_with_gcs.py
@@ -28,7 +28,7 @@ def generate_content(output_uri: str) -> str:
     job = client.batches.create(
         # To use a tuned model, set the model param to your tuned model using the following format:
         # model="projects/{PROJECT_ID}/locations/{LOCATION}/models/{MODEL_ID}
-        model="gemini-2.0-flash-001",
+        model="gemini-2.5-flash",
         # Source link: https://storage.cloud.google.com/cloud-samples-data/batch/prompt_for_batch_gemini_predict.jsonl
         src="gs://cloud-samples-data/batch/prompt_for_batch_gemini_predict.jsonl",
         config=CreateBatchJobConfig(dest=output_uri),


### PR DESCRIPTION
## Description
Updates code samples to use new model gemini 2.5 flash.

Internal: b/432138567

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved