### PR TITLE
feat: Update session sample with the new SessionServiceClient

### DIFF
--- a/discoveryengine/requirements.txt
+++ b/discoveryengine/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-discoveryengine==0.13.8
+google-cloud-discoveryengine==0.13.11

--- a/discoveryengine/session_sample.py
+++ b/discoveryengine/session_sample.py
@@ -37,7 +37,7 @@ def create_session(
         discoveryengine.Session: The newly created Session.
     """
 
-    client = discoveryengine.ConversationalSearchServiceClient()
+    client = discoveryengine.SessionServiceClient()
 
     session = client.create_session(
         # The full resource name of the engine
@@ -71,7 +71,7 @@ def get_session(
         session_id: The ID of the session.
     """
 
-    client = discoveryengine.ConversationalSearchServiceClient()
+    client = discoveryengine.SessionServiceClient()
 
     # The full resource name of the session
     name = f"projects/{project_id}/locations/{location}/collections/default_collection/engines/{engine_id}/sessions/{session_id}"
@@ -104,7 +104,7 @@ def delete_session(
         session_id: The ID of the session.
     """
 
-    client = discoveryengine.ConversationalSearchServiceClient()
+    client = discoveryengine.SessionServiceClient()
 
     # The full resource name of the session
     name = f"projects/{project_id}/locations/{location}/collections/default_collection/engines/{engine_id}/sessions/{session_id}"
@@ -138,7 +138,7 @@ def update_session(
     Returns:
         discoveryengine.Session: The updated Session.
     """
-    client = discoveryengine.ConversationalSearchServiceClient()
+    client = discoveryengine.SessionServiceClient()
 
     # The full resource name of the session
     name = f"projects/{project_id}/locations/{location}/collections/default_collection/engines/{engine_id}/sessions/{session_id}"
@@ -178,7 +178,7 @@ def list_sessions(
         discoveryengine.ListSessionsResponse: The list of sessions.
     """
 
-    client = discoveryengine.ConversationalSearchServiceClient()
+    client = discoveryengine.SessionServiceClient()
 
     # The full resource name of the engine
     parent = f"projects/{project_id}/locations/{location}/collections/default_collection/engines/{engine_id}"


### PR DESCRIPTION
feat: Update session sample with the new SessionServiceClient instead of ConversationalSearchServiceClient.

## Description

ConversationalSearchServiceClient will be deprecated soon and we would like to use SessionServiceClient instead. The new service has the exact same methods as the previous one.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved