### PR TITLE
refactor(storagecontrol): update `managed_folder_create` sample

### DIFF
--- a/storagecontrol/managed_folder_create.py
+++ b/storagecontrol/managed_folder_create.py
@@ -12,36 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
+import argparse
 
 # [START storage_control_managed_folder_create]
 from google.cloud import storage_control_v2
 
 
-def create_managed_folder(bucket_name: str, managed_folder_id: str) -> None:
-    # The ID of your GCS bucket
-    # bucket_name = "your-unique-bucket-name"
+def create_managed_folder(
+    bucket_name: str = "your-bucket-name",
+    managed_folder_name: str = "your-folder-name"
+) -> None:
+    """Creates a managed folder in a Google Cloud Storage bucket.
+    Find more information here:
+    https://cloud.google.com/storage/docs/creating-buckets
 
-    # The name of the managed folder to be created
-    # managed_folder_id = "managed-folder-name"
+    A managed folder is a special type of folder
+    that can have its own IAM policies and access controls,
+    independent of the bucket's policies.
 
-    storage_control_client = storage_control_v2.StorageControlClient()
+    Args:
+        bucket_name: The name of the Google Cloud Storage bucket where the
+            managed folder will be created.
+        managed_folder_name: The name of the managed folder to be created.
+
+    Returns:
+        None. The function prints a success message to the console upon
+        successful creation of the managed folder.
+    """
+
+    client = storage_control_v2.StorageControlClient()
+
     # The storage bucket path uses the global access pattern, in which the "_"
     # denotes this bucket exists in the global namespace.
-    project_path = storage_control_client.common_project_path("_")
+    project_path = client.common_project_path("_")
     bucket_path = f"{project_path}/buckets/{bucket_name}"
 
-    request = storage_control_v2.CreateManagedFolderRequest(
-        parent=bucket_path,
-        managed_folder_id=managed_folder_id,
-    )
-    response = storage_control_client.create_managed_folder(request=request)
-
-    print(f"Created managed folder: {response.name}")
-
-
+    folder = client.create_managed_folder(
+            parent=bucket_path,
+            managed_folder=storage_control_v2.ManagedFolder(),
+            managed_folder_id=managed_folder_name,
+        )
+    print(f"Created managed folder: {folder.name}")
 # [END storage_control_managed_folder_create]
 
 
 if __name__ == "__main__":
-    create_managed_folder(bucket_name=sys.argv[1], managed_folder_id=sys.argv[2])
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "bucket_name",
+        help="The name of the GCS bucket.",
+    )
+    parser.add_argument(
+        "folder_name",
+        help="The name of the managed folder to create."
+    )
+
+    args = parser.parse_args()
+
+    create_managed_folder(args.bucket_name, args.folder_name)

--- a/storagecontrol/managed_folder_create_test.py
+++ b/storagecontrol/managed_folder_create_test.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+from google.cloud import storage
+
+import pytest
+
+import managed_folder_create
+import managed_folder_delete
+
+# NOTE(reviewers): Managed Folder module would require a whole set of tests
+# to create the folder, get it, and finally destroying it.
+# See an example in snippets_test.py of the whole use case.
+
+
+def test_storage_control_managed_folder_list(
+    capsys: pytest.LogCaptureFixture, gcs_bucket: storage.Bucket
+) -> None:
+    bucket_name = gcs_bucket.name
+    # Follow the naming requirements:
+    # https://cloud.google.com/storage/docs/buckets#naming
+    managed_folder_name = "create_managed_folder_" + str(uuid.uuid4())
+
+    managed_folder_create.create_managed_folder(
+        bucket_name=bucket_name,
+        managed_folder_name=managed_folder_name
+    )
+
+    out, _ = capsys.readouterr()
+    folder_resource_name = (
+        f"projects/_/buckets/{bucket_name}/managedFolders/{managed_folder_name}/"
+    )
+    assert folder_resource_name in out
+
+    # Cleanup
+    managed_folder_delete.delete_managed_folder(
+        bucket_name=bucket_name,
+        managed_folder_id=managed_folder_name
+    )


### PR DESCRIPTION
## Description

Based on the RPC Workshop, this sample is updated to the current style guide.

Note: I think that `create`, `get` and `delete` samples should be refactored in the same PR, as they depend on each other for a clean test environment. (After creating a folder it should be deleted, or the strategy in `conftest.py` should be adapted to these samples)

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] Please **merge** this PR for me once it is approved