### PR TITLE
fix(ci): update default django static bucket name

### DIFF
--- a/run/django/e2e_test_cleanup.yaml
+++ b/run/django/e2e_test_cleanup.yaml
@@ -52,7 +52,7 @@ substitutions:
   _REGION: us-central1
   _ARTIFACT_REGISTRY: cloud-run-source-deploy
   _IMAGE_NAME: ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/django-${_VERSION}
-  _STORAGE_BUCKET: ${PROJECT_ID}-bucket-${_VERSION}
+  _STORAGE_BUCKET: django-static-${PROJECT_ID}-${_VERSION}
   _DB_USER: django-${_VERSION}
   _DB_NAME: django-${_VERSION}
   _DB_INSTANCE: django-instance

--- a/run/django/e2e_test_setup.yaml
+++ b/run/django/e2e_test_setup.yaml
@@ -139,7 +139,7 @@ substitutions:
   _REGION: us-central1
   _ARTIFACT_REGISTRY: cloud-run-source-deploy
   _IMAGE_NAME: ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_ARTIFACT_REGISTRY}/django-${_VERSION}
-  _STORAGE_BUCKET: ${PROJECT_ID}-bucket-${_VERSION}
+  _STORAGE_BUCKET: django-static-${PROJECT_ID}-${_VERSION}
   _DB_USER: django-${_VERSION}
   _DB_NAME: django-${_VERSION}
   _DB_INSTANCE: django-instance


### PR DESCRIPTION
Updates the default bucket name for testing, to help identify assets in testing projects b/418598361

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved