### PR TITLE
fix: ensure that tool can support Composer 3 version image names

### DIFF
--- a/composer/tools/composer_dags.py
+++ b/composer/tools/composer_dags.py
@@ -33,7 +33,7 @@ class DAG:
     """Provides necessary utils for Composer DAGs."""
 
     COMPOSER_AF_VERSION_RE = re.compile(
-        "composer-([0-9]+).([0-9]+).([0-9]+).*" "-airflow-([0-9]+).([0-9]+).([0-9]+).*"
+        "composer-([0-9]+)(?:.([0-9]+).([0-9]+))?.*-airflow-([0-9]+).([0-9]+).([0-9]+)"
     )
 
     @staticmethod


### PR DESCRIPTION


## Description

this refactors the regular expression 

as per https://cloud.google.com/composer/docs/composer-versions#images

Cloud Composer 3 images look like 
composer-3-airflow-2.10.5-build.11

versus earlier versions
composer-2.8.3-airflow-2.6.3
composer-1.16.16-airflow-1.10.12

so this ensures that if Composer is a major or full version it can be parsed. Airflow version is still fully specified

I did use https://regex101.com/ to validate the regular expression works as expected. 

Replaces #13545

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.


- [x] Please **merge** this PR for me once it is approved