### PR TITLE
feat: Update create tuning job to include tuning with automatic evalu…

### DIFF
--- a/genai/tuning/tuning_job_create.py
+++ b/genai/tuning/tuning_job_create.py
@@ -18,19 +18,42 @@ def create_tuning_job() -> str:
     import time
 
     from google import genai
-    from google.genai.types import HttpOptions, CreateTuningJobConfig, TuningDataset
+    from google.genai.types import HttpOptions, CreateTuningJobConfig, TuningDataset, EvaluationConfig, OutputConfig, GcsDestination
 
-    client = genai.Client(http_options=HttpOptions(api_version="v1"))
+    # TODO(developer): Update and un-comment below line
+    # USER_GCS_FOLDER = "your-gcs-folder"
+
+    client = genai.Client(http_options=HttpOptions(api_version="v1beta1"))
 
     training_dataset = TuningDataset(
         gcs_uri="gs://cloud-samples-data/ai-platform/generative_ai/gemini/text/sft_train_data.jsonl",
     )
+    validation_dataset = TuningDataset(
+        gcs_uri="gs://cloud-samples-data/ai-platform/generative_ai/gemini/text/sft_validation_data.jsonl",
+    )
+
+    evaluation_config=EvaluationConfig(
+        metrics=[
+           Metric(
+                name="FLUENCY",
+                prompt_template="""Evaluate this {response}"""
+            )
+        ],
+        output_config=OutputConfig(
+            gcs_destination=GcsDestination(
+                output_uri_prefix=USER_GCS_FOLDER,
+            )
+        ),
+    )
+
 
     tuning_job = client.tunings.tune(
         base_model="gemini-2.5-flash",
         training_dataset=training_dataset,
         config=CreateTuningJobConfig(
             tuned_model_display_name="Example tuning job",
+            validation_dataset=validation_dataset,
+            evaluation_config=evaluation_config,
         ),
     )
 

--- a/genai/tuning/tuning_with_checkpoints_create.py
+++ b/genai/tuning/tuning_with_checkpoints_create.py
@@ -18,12 +18,32 @@ def create_with_checkpoints() -> str:
     import time
 
     from google import genai
-    from google.genai.types import HttpOptions, CreateTuningJobConfig, TuningDataset
+    from google.genai.types import HttpOptions, CreateTuningJobConfig, TuningDataset, EvaluationConfig, OutputConfig, GcsDestination
 
-    client = genai.Client(http_options=HttpOptions(api_version="v1"))
+    # TODO(developer): Update and un-comment below line
+    # USER_GCS_FOLDER = "your-gcs-folder"
+
+    client = genai.Client(http_options=HttpOptions(api_version="v1beta1"))
 
     training_dataset = TuningDataset(
         gcs_uri="gs://cloud-samples-data/ai-platform/generative_ai/gemini/text/sft_train_data.jsonl",
+    )
+    validation_dataset = TuningDataset(
+        gcs_uri="gs://cloud-samples-data/ai-platform/generative_ai/gemini/text/sft_validation_data.jsonl",
+    )
+
+    evaluation_config=EvaluationConfig(
+        metrics=[
+           Metric(
+                name="FLUENCY",
+                prompt_template="""Evaluate this {response}"""
+            )
+        ],
+        output_config=OutputConfig(
+            gcs_destination=GcsDestination(
+                output_uri_prefix=USER_GCS_FOLDER,
+            )
+        ),
     )
 
     tuning_job = client.tunings.tune(
@@ -33,6 +53,8 @@ def create_with_checkpoints() -> str:
             tuned_model_display_name="Example tuning job",
             # Set to True to disable tuning intermediate checkpoints. Default is False.
             export_last_checkpoint_only=False,
+            validation_dataset=validation_dataset,
+            evaluation_config=evaluation_config,
         ),
     )
 


### PR DESCRIPTION
…ation

## Description

Fixes #430697448

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ x] Please **merge** this PR for me once it is approved