### PR TITLE
Update create_note.py

### DIFF
--- a/containeranalysis/snippets/create_note.py
+++ b/containeranalysis/snippets/create_note.py
@@ -27,15 +27,10 @@ def create_note(note_id: str, project_id: str) -> types.grafeas.Note:
     grafeas_client = client.get_grafeas_client()
     project_name = f"projects/{project_id}"
     note = {
-        "vulnerability": {
-            "details": [
-                {
-                    "affected_cpe_uri": "your-uri-here",
-                    "affected_package": "your-package-here",
-                    "affected_version_start": {"kind": Version.VersionKind.MINIMUM},
-                    "fixed_version": {"kind": Version.VersionKind.MAXIMUM},
-                }
-            ]
+        "attestation": {
+            "hint": {
+                "human_readable_name": "my-attestation-authority",
+            }
         }
     }
     response = grafeas_client.create_note(


### PR DESCRIPTION
Update create_note.py to replace references to storing vulnerabilities with storing attestations in the Artifact Analysis documentation, including code samples. The updated code sample will appear in https://cloud.google.com/artifact-analysis/docs/create-notes-occurrences and any other topics that reference it in the google cloud documentation. Additional pull requests will be sent to update the equivalent code samples for Go, Java, node.js, and Ruby.