### PR TITLE
Fix some dag_runs removed unintentionally 

### DIFF
--- a/composer/workflows/airflow_db_cleanup.py
+++ b/composer/workflows/airflow_db_cleanup.py
@@ -360,7 +360,8 @@ def build_query(
 
     logging.info("INITIAL QUERY : " + str(query))
 
-    if dag_id:
+    if hasattr(airflow_db_model, `dag_id`):
+        logging.info("Filtering by dag_id: " + str(dag_id))
         query = query.filter(airflow_db_model.dag_id == dag_id)
 
     if airflow_db_model == DagRun:

--- a/composer/workflows/airflow_db_cleanup.py
+++ b/composer/workflows/airflow_db_cleanup.py
@@ -360,7 +360,7 @@ def build_query(
 
     logging.info("INITIAL QUERY : " + str(query))
 
-    if hasattr(airflow_db_model, `dag_id`):
+    if hasattr(airflow_db_model, 'dag_id'):
         logging.info("Filtering by dag_id: " + str(dag_id))
         query = query.filter(airflow_db_model.dag_id == dag_id)
 


### PR DESCRIPTION
## Description
A logic error in the final cleanup step is causing the incorrect deletion of past dag_runs.
During the last iteration when dag_id is None, the dag_id check is skipped entirely. This causes the system to delete any dag_run that is eligible for removal, not just the intended orphaned entries.

This error manifested when someone prepared a dag, which were scheduled with '@once' and start_date in the past.

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] Please **merge** this PR for me once it is approved