### PR TITLE
docs(genai): Update quickstart_example.py to use us-east4 as default region

### DIFF
--- a/generative_ai/rag/quickstart_example.py
+++ b/generative_ai/rag/quickstart_example.py
@@ -39,7 +39,7 @@ def quickstart(
     # paths = ["https://drive.google.com/file/d/123", "gs://my_bucket/my_files_dir"]  # Supports Google Cloud Storage and Google Drive Links
 
     # Initialize Vertex AI API once per session
-    vertexai.init(project=PROJECT_ID, location="us-central1")
+    vertexai.init(project=PROJECT_ID, location="us-east4")
 
     # Create RagCorpus
     # Configure embedding model, for example "text-embedding-005".


### PR DESCRIPTION
## Description

- us-central1 became allowlist only for new projects