### PR TITLE
Adds "disable config" sample to manage_transfer_configs.py

### DIFF
--- a/bigquery-datatransfer/snippets/manage_transfer_configs.py
+++ b/bigquery-datatransfer/snippets/manage_transfer_configs.py
@@ -104,6 +104,38 @@ def update_credentials_with_service_account(override_values={}):
     # Return the config name for testing purposes, so that it can be deleted.
     return transfer_config
 
+def disable_config(override_values={}):
+    # [START bigquerydatatransfer_disable_config]
+    from google.cloud import bigquery_datatransfer
+    from google.protobuf import field_mask_pb2
+
+    transfer_client = bigquery_datatransfer.DataTransferServiceClient()
+
+    transfer_config_name = "projects/1234/locations/us/transferConfigs/abcd"
+    # [END bigquerydatatransfer_disable_config]
+    # To facilitate testing, we replace values with alternatives
+    # provided by the testing harness.
+    transfer_config_name = override_values.get(
+        "transfer_config_name", transfer_config_name
+    )
+    # [START bigquerydatatransfer_disable_config]
+
+    transfer_config = bigquery_datatransfer.TransferConfig(name=transfer_config_name)
+    transfer_config.disabled = True
+
+    transfer_config = transfer_client.update_transfer_config(
+        {
+            "transfer_config": transfer_config,
+            "update_mask": field_mask_pb2.FieldMask(paths=["disabled"]),
+        }
+    )
+
+    print(f"Updated config: '{transfer_config.name}'")
+    print(f"Is config disabled: '{transfer_config.disabled}'")
+    # [END bigquerydatatransfer_disable_config]
+    # Return the config name for testing purposes, so that it can be deleted.
+    return transfer_config
+
 
 def schedule_backfill_manual_transfer(override_values={}):
     # [START bigquerydatatransfer_schedule_backfill]


### PR DESCRIPTION
## Description

Adds a Python sample to disable a BQ DTS transfer configuration. We're missing a sample here in https://cloud.google.com/bigquery/docs/working-with-transfers#disable_a_transfer

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] Please **merge** this PR for me once it is approved