### PR TITLE
Replace the Datastore and Firestore locational endpoints URL examples

### DIFF
--- a/datastore/cloud-client/snippets.py
+++ b/datastore/cloud-client/snippets.py
@@ -916,7 +916,7 @@ def regional_endpoint():
     from google.cloud import datastore
     from google.api_core.client_options import ClientOptions
 
-    ENDPOINT = "https://nam5-datastore.googleapis.com"
+    ENDPOINT = "https://datastore.africa-south1.rep.googleapis.com"
     client_options = ClientOptions(api_endpoint=ENDPOINT)
     client = datastore.Client(client_options=client_options)
 

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -1007,7 +1007,7 @@ def create_and_build_bundle():
 
 def regional_endpoint():
     # [START firestore_regional_endpoint]
-    ENDPOINT = "nam5-firestore.googleapis.com"
+    ENDPOINT = "firestore.africa-south1.rep.googleapis.com"
     client_options = ClientOptions(api_endpoint=ENDPOINT)
     db = firestore.Client(client_options=client_options)
 


### PR DESCRIPTION
## Description

Replace the Datastore and Firestore locational endpoints URL examples with regional endpoints URLs

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved