### PR TITLE
ci: add mypy presubmit workflow for Python samples

### DIFF
--- a/.github/workflows/mypy-presubmit.yml
+++ b/.github/workflows/mypy-presubmit.yml
@@ -1,0 +1,30 @@
+name: mypy-presubmit
+
+on:
+  pull_request:
+    paths:
+      - "samples/python/**"
+      - ".github/workflows/mypy-presubmit.yml"
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mypy
+          pip install -r samples/python/requirements.txt || true
+
+      - name: Run mypy on samples
+        run: |
+          mypy samples/python --ignore-missing-imports


### PR DESCRIPTION
Summary
This PR adds a GitHub Actions presubmit workflow that runs mypy on the Python samples directory.

Details
- The workflow runs automatically on pull requests that modify Python sample files.
- It installs `mypy` and the sample dependencies.
- It performs type checking with:
    mypy samples/python --ignore-missing-imports
- This helps catch type errors early and improves the developer experience for anyone using or contributing to the samples.

Motivation
As requested in issue #13303, adding a presubmit ensures that type failures in Python samples are detected before merging, preventing runtime errors for end users and maintaining code quality.

How to Test
- This workflow will run automatically on all new pull requests affecting the samples.

What was done in this PR
Step 1 Created a new workflow file**: `workflows/mypy-presubmit.yml` inside the `.github/` folder.  
Step 2 Configured the workflow to run on pull requests** that modify Python sample files (`samples/python/**`).  
Step 3 Installed dependencies** in the workflow:
   - `mypy` for type checking  
   - `requirements.txt` from the samples folder (if it exists)  
step 4 Added a mypy type check step**:  
   ```bash
   mypy samples/python --ignore-missing-imports did we 100% do this in 

References
- Closes #13303
