### PR TITLE
fix(run/django): use generated URLs in django-storages

### DIFF
--- a/run/django/mysite/settings.py
+++ b/run/django/mysite/settings.py
@@ -174,9 +174,23 @@ STATIC_URL = "/static/"
 STORAGES = {
     "default": {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+        "options": {
+            "bucket_name": GS_BUCKET_NAME,
+            "querystring_auth": True,  # generate signed URLs
+            "default_acl": None,  # don't make files public by default
+            "expiration": 300,  # seconds
+        },
     },
     "staticfiles": {
         "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
+        "options": {
+            "bucket_name": GS_BUCKET_NAME,
+            # You would normally have your static assets public.
+            # In this example, we re-use the same bucket with the same ACL settings.
+            "querystring_auth": True,  # generate signed URLs
+            "default_acl": None,  # don't make files public by default
+            "expiration": 300,  # seconds
+        },
     },
 }
 GS_DEFAULT_ACL = "publicRead"


### PR DESCRIPTION
b/436695635

## Description

Fixes #<ISSUE-NUMBER>

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved