### PR TITLE
fix(firestore): Update firestore samples for python to use recursive delete

### DIFF
--- a/firestore/cloud-async-client/snippets.py
+++ b/firestore/cloud-async-client/snippets.py
@@ -693,24 +693,16 @@ async def delete_full_collection():
     db = firestore.AsyncClient()
 
     # [START firestore_data_delete_collection_async]
-    async def delete_collection(coll_ref, batch_size):
-        docs = coll_ref.limit(batch_size).stream()
-        deleted = 0
+    async def delete_collection(coll_ref):
 
-        async for doc in docs:
-            print(f"Deleting doc {doc.id} => {doc.to_dict()}")
-            await doc.reference.delete()
-            deleted = deleted + 1
-
-        if deleted >= batch_size:
-            return delete_collection(coll_ref, batch_size)
+        await db.recursive_delete(coll_ref)
 
     # [END firestore_data_delete_collection_async]
 
-    await delete_collection(db.collection("cities"), 10)
-    await delete_collection(db.collection("data"), 10)
-    await delete_collection(db.collection("objects"), 10)
-    await delete_collection(db.collection("users"), 10)
+    await delete_collection(db.collection("cities"))
+    await delete_collection(db.collection("data"))
+    await delete_collection(db.collection("objects"))
+    await delete_collection(db.collection("users"))
 
 
 async def collection_group_query(db):

--- a/firestore/cloud-client/snippets.py
+++ b/firestore/cloud-client/snippets.py
@@ -839,28 +839,17 @@ def delete_full_collection():
     db = firestore.Client()
 
     # [START firestore_data_delete_collection]
-    def delete_collection(coll_ref, batch_size):
-        if batch_size == 0:
-            return
+    def delete_collection(coll_ref):
 
-        docs = coll_ref.list_documents(page_size=batch_size)
-        deleted = 0
-
-        for doc in docs:
-            print(f"Deleting doc {doc.id} => {doc.get().to_dict()}")
-            doc.delete()
-            deleted = deleted + 1
-
-        if deleted >= batch_size:
-            return delete_collection(coll_ref, batch_size)
+        print(f"Recursively deleting collection: {coll_ref}")
+        db.recursive_delete(coll_ref)
 
     # [END firestore_data_delete_collection]
 
-    delete_collection(db.collection("cities"), 10)
-    delete_collection(db.collection("data"), 10)
-    delete_collection(db.collection("objects"), 10)
-    delete_collection(db.collection("users"), 10)
-    delete_collection(db.collection("users"), 0)
+    delete_collection(db.collection("cities"))
+    delete_collection(db.collection("data"))
+    delete_collection(db.collection("objects"))
+    delete_collection(db.collection("users"))
 
 
 def collection_group_query(db):


### PR DESCRIPTION
     
   
## Description

Modified samples for Firestore Client and Async Firestore Client to use recursive_delete.

Fixes #b/470275866

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [x] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved