### PR TITLE
chore(discoveryengine): update gemini to 2.5-flash in answer query sample 

### DIFF
--- a/discoveryengine/answer_query_sample.py
+++ b/discoveryengine/answer_query_sample.py
@@ -69,7 +69,7 @@ def answer_query_sample(
         ignore_non_answer_seeking_query=False,  # Optional: Ignore non-answer seeking query
         ignore_low_relevant_content=False,  # Optional: Return fallback answer when content is not relevant
         model_spec=discoveryengine.AnswerQueryRequest.AnswerGenerationSpec.ModelSpec(
-            model_version="gemini-2.0-flash-001/answer_gen/v1",  # Optional: Model to use for answer generation
+            model_version="gemini-2.5-flash/answer_gen/v1",  # Optional: Model to use for answer generation
         ),
         prompt_spec=discoveryengine.AnswerQueryRequest.AnswerGenerationSpec.PromptSpec(
             preamble="Give a detailed answer.",  # Optional: Natural language instructions for customizing the answer.


### PR DESCRIPTION
Fixes #481443740

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved