### PR TITLE
chore(genai): Update gemini model version to 2.5 in live websocket audiogen with txt

### DIFF
--- a/genai/live/live_websocket_audiogen_with_txt.py
+++ b/genai/live/live_websocket_audiogen_with_txt.py
@@ -47,7 +47,7 @@ async def generate_content() -> str:
     # Configuration Constants
     PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
     LOCATION = "us-central1"
-    GEMINI_MODEL_NAME = "gemini-2.0-flash-live-preview-04-09"
+    GEMINI_MODEL_NAME = "gemini-live-2.5-flash-native-audio"
     # To generate a bearer token in CLI, use:
     #   $ gcloud auth application-default print-access-token
     # It's recommended to fetch this token dynamically rather than hardcoding.


### PR DESCRIPTION

## Description

Fixes #481469433

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved