### PR TITLE
chore(appengine): Update flex hello-world app outdated dependencies

### DIFF
--- a/appengine/flexible/hello_world/app.yaml
+++ b/appengine/flexible/hello_world/app.yaml
@@ -18,6 +18,7 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   operating_system: ubuntu24
+  runtime_version: 3.12
 
 # This sample incurs costs to run on the App Engine flexible environment.
 # The settings below are to reduce costs during testing and are not appropriate

--- a/appengine/flexible/hello_world/requirements.txt
+++ b/appengine/flexible/hello_world/requirements.txt
@@ -1,5 +1,2 @@
-Flask==3.0.3; python_version > '3.6'
-Flask==2.3.3; python_version < '3.7'
-Werkzeug==3.0.3; python_version > '3.6'
-Werkzeug==2.3.8; python_version < '3.7'
-gunicorn==23.0.0
+Flask==3.0.3
+gunicorn==22.0.0


### PR DESCRIPTION
## Description

Fixes Internal:  b/475332227

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved