### PR TITLE
feat(storagecontrol): Added samples for Anywhere Cache

### DIFF
--- a/storagecontrol/create_anywhere_cache.py
+++ b/storagecontrol/create_anywhere_cache.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_create_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def create_anywhere_cache(
+    bucket_name: str, zone: str, admission_policy: str = "ADMIT_ON_FIRST_MISS"
+) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone where the Anywhere Cache will be created
+    # zone = "us-central1-a"
+
+    # The admission policy for the Anywhere Cache
+    # admission_policy = "ADMIT_ON_FIRST_MISS"
+
+    client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = client.common_project_path("_")
+    bucket_path = f"{project_path}/buckets/{bucket_name}"
+
+    anywhere_cache = storage_control_v2.AnywhereCache(
+        admission_policy=admission_policy,
+    )
+
+    request = storage_control_v2.CreateAnywhereCacheRequest(
+        parent=bucket_path,
+        anywhere_cache=anywhere_cache,
+        anywhere_cache_id=zone,
+    )
+
+    # create_anywhere_cache is a long-running operation.
+    # Real applications may want to setup a callback or poll for the operation to complete.
+    operation = client.create_anywhere_cache(request=request)
+    response = operation.result()
+
+    print(f"Created Anywhere Cache: {response.name}")
+
+
+# [END storage_control_create_anywhere_cache]
+
+
+if __name__ == "__main__":
+    create_anywhere_cache(
+        bucket_name=sys.argv[1], zone=sys.argv[2], admission_policy=sys.argv[3]
+    )

--- a/storagecontrol/disable_anywhere_cache.py
+++ b/storagecontrol/disable_anywhere_cache.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_disable_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def disable_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone of the Anywhere Cache
+    # zone = "us-central1-a"
+
+    client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = client.common_project_path("_")
+    name = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.DisableAnywhereCacheRequest(
+        name=name,
+    )
+    response = client.disable_anywhere_cache(request=request)
+
+    print(f"Disabled Anywhere Cache: {response.name}")
+
+
+# [END storage_control_disable_anywhere_cache]
+
+
+if __name__ == "__main__":
+    disable_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/get_anywhere_cache.py
+++ b/storagecontrol/get_anywhere_cache.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_get_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def get_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone of the Anywhere Cache
+    # zone = "us-central1-a"
+
+    client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = client.common_project_path("_")
+    name = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.GetAnywhereCacheRequest(
+        name=name,
+    )
+    response = client.get_anywhere_cache(request=request)
+
+    print(f"Anywhere Cache: {response.name}")
+    print(f"Admission Policy: {response.admission_policy}")
+    print(f"State: {response.state}")
+
+
+# [END storage_control_get_anywhere_cache]
+
+
+if __name__ == "__main__":
+    get_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/list_anywhere_cache.py
+++ b/storagecontrol/list_anywhere_cache.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_list_anywhere_caches]
+from google.cloud import storage_control_v2
+
+
+def list_anywhere_caches(bucket_name: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = client.common_project_path("_")
+    bucket_path = f"{project_path}/buckets/{bucket_name}"
+
+    request = storage_control_v2.ListAnywhereCachesRequest(
+        parent=bucket_path,
+    )
+    page_result = client.list_anywhere_caches(request=request)
+
+    for response in page_result:
+        print(f"Anywhere Cache: {response.name}")
+
+
+# [END storage_control_list_anywhere_caches]
+
+
+if __name__ == "__main__":
+    list_anywhere_caches(bucket_name=sys.argv[1])

--- a/storagecontrol/pause_anywhere_cache.py
+++ b/storagecontrol/pause_anywhere_cache.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_pause_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def pause_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone of the Anywhere Cache
+    # zone = "us-central1-a"
+
+    client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = client.common_project_path("_")
+    name = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.PauseAnywhereCacheRequest(
+        name=name,
+    )
+    response = client.pause_anywhere_cache(request=request)
+
+    print(f"Paused Anywhere Cache: {response.name}")
+
+
+# [END storage_control_pause_anywhere_cache]
+
+
+if __name__ == "__main__":
+    pause_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/resume_anywhere_cache.py
+++ b/storagecontrol/resume_anywhere_cache.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_resume_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def resume_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone of the Anywhere Cache
+    # zone = "us-central1-a"
+
+    client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = client.common_project_path("_")
+    name = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.ResumeAnywhereCacheRequest(
+        name=name,
+    )
+    response = client.resume_anywhere_cache(request=request)
+
+    print(f"Resumed Anywhere Cache: {response.name}")
+
+
+# [END storage_control_resume_anywhere_cache]
+
+
+if __name__ == "__main__":
+    resume_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/snippets_test.py
+++ b/storagecontrol/snippets_test.py
@@ -16,16 +16,22 @@ from google.cloud import storage
 
 import pytest
 
+import create_anywhere_cache
 import create_folder
 import delete_folder
+import disable_anywhere_cache
+import get_anywhere_cache
 import get_folder
+import list_anywhere_cache
 import list_folders
 import managed_folder_create
 import managed_folder_delete
 import managed_folder_get
 import managed_folder_list
+import pause_anywhere_cache
 import rename_folder
-
+import resume_anywhere_cache
+import update_anywhere_cache
 
 # === Folders === #
 
@@ -65,6 +71,58 @@ def test_folder_create_get_list_rename_delete(
     delete_folder.delete_folder(bucket_name=bucket_name, folder_name=new_name)
     out, _ = capsys.readouterr()
     assert new_name in out
+
+
+# === Anywhere Cache === #
+
+
+def test_anywhere_cache_create_get_list_update_pause_resume_disable(
+    capsys: pytest.LogCaptureFixture,
+    ubla_enabled_bucket: storage.Bucket,
+) -> None:
+    bucket_name = ubla_enabled_bucket.name
+    zone = "us-central1-a"
+
+    # Test create anywhere cache
+    create_anywhere_cache.create_anywhere_cache(
+        bucket_name=bucket_name, zone=zone, admission_policy="ADMIT_ON_FIRST_MISS"
+    )
+    out, _ = capsys.readouterr()
+    assert f"buckets/{bucket_name}/anywhereCaches/{zone}" in out
+
+    # Test get anywhere cache
+    get_anywhere_cache.get_anywhere_cache(bucket_name=bucket_name, zone=zone)
+    out, _ = capsys.readouterr()
+    assert f"buckets/{bucket_name}/anywhereCaches/{zone}" in out
+    assert "ADMIT_ON_FIRST_MISS" in out
+
+    # Test list anywhere caches
+    list_anywhere_cache.list_anywhere_caches(bucket_name=bucket_name)
+    out, _ = capsys.readouterr()
+    assert f"buckets/{bucket_name}/anywhereCaches/{zone}" in out
+
+    # Test update anywhere cache
+    update_anywhere_cache.update_anywhere_cache(
+        bucket_name=bucket_name, zone=zone, admission_policy="ADMIT_ON_FIRST_MISS"
+    )
+    out, _ = capsys.readouterr()
+    assert f"buckets/{bucket_name}/anywhereCaches/{zone}" in out
+    assert "ADMIT_ON_FIRST_MISS" in out
+
+    # Test pause anywhere cache
+    pause_anywhere_cache.pause_anywhere_cache(bucket_name=bucket_name, zone=zone)
+    out, _ = capsys.readouterr()
+    assert f"buckets/{bucket_name}/anywhereCaches/{zone}" in out
+
+    # Test resume anywhere cache
+    resume_anywhere_cache.resume_anywhere_cache(bucket_name=bucket_name, zone=zone)
+    out, _ = capsys.readouterr()
+    assert f"buckets/{bucket_name}/anywhereCaches/{zone}" in out
+
+    # Test disable anywhere cache
+    disable_anywhere_cache.disable_anywhere_cache(bucket_name=bucket_name, zone=zone)
+    out, _ = capsys.readouterr()
+    assert f"buckets/{bucket_name}/anywhereCaches/{zone}" in out
 
 
 # === Managed Folders === #

--- a/storagecontrol/update_anywhere_cache.py
+++ b/storagecontrol/update_anywhere_cache.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from google.cloud import storage_control_v2
+from google.protobuf import field_mask_pb2
+
+# [START storage_control_update_anywhere_cache]
+
+
+def update_anywhere_cache(
+    bucket_name: str, zone: str, admission_policy: str = "ADMIT_ON_FIRST_MISS"
+) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone of the Anywhere Cache
+    # zone = "us-central1-a"
+
+    # The new admission policy for the Anywhere Cache
+    # admission_policy = "ADMIT_ON_FIRST_MISS"
+
+    client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = client.common_project_path("_")
+    name = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    anywhere_cache = storage_control_v2.AnywhereCache(
+        name=name,
+        admission_policy=admission_policy,
+    )
+
+    update_mask = field_mask_pb2.FieldMask(paths=["admission_policy"])
+
+    request = storage_control_v2.UpdateAnywhereCacheRequest(
+        anywhere_cache=anywhere_cache,
+        update_mask=update_mask,
+    )
+
+    # update_anywhere_cache is a long-running operation.
+    # Real applications may want to setup a callback or poll for the operation to complete.
+    operation = client.update_anywhere_cache(request=request)
+    response = operation.result()
+
+    print(f"Updated Anywhere Cache: {response.name}")
+    print(f"New Admission Policy: {response.admission_policy}")
+
+
+# [END storage_control_update_anywhere_cache]
+
+
+if __name__ == "__main__":
+    update_anywhere_cache(
+        bucket_name=sys.argv[1], zone=sys.argv[2], admission_policy=sys.argv[3]
+    )


### PR DESCRIPTION
Implemented 7 new code samples for Google Cloud Storage Anywhere Cache:
- create_anywhere_cache.py
- get_anywhere_cache.py
- list_anywhere_cache.py
- update_anywhere_cache.py
- pause_anywhere_cache.py
- resume_anywhere_cache.py
- disable_anywhere_cache.py

Updated snippets_test.py with integration tests for these samples. Added required copyright headers and LRO blocking comments. Ensured other files in storagecontrol/ remain unchanged.
