### PR TITLE
Updated README file for generative_ai samples

### DIFF
--- a/generative_ai/README.md
+++ b/generative_ai/README.md
@@ -39,7 +39,7 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/extensions/overview">https://cloud.google.com/vertex-ai/generative-ai/docs/extensions/overview</a>
    </td>
-   <td>Learn how to connect foundation models to external systems. These samples cover how to register and use Vertex AI Extensions to allow your models to interact with third-party APIs.
+   <td>These samples show how to connect Gemini to external APIs and databases so your models can retrieve live data and execute real-world actions. **Note** that as Google Cloud transitions to the Gemini Enterprise Agent Platform, standalone Vertex AI Extensions are evolving into *Tools* managed within the centralized Agent Registry. While these examples teach the core mechanics of model-to-API communication, future production applications should adopt the new Agent Platform architecture..
    </td>
   </tr>
   <tr>

--- a/generative_ai/README.md
+++ b/generative_ai/README.md
@@ -1,15 +1,14 @@
-# Generative AI Samples on Google Cloud
+# Generative AI on Google Cloud: Python Samples
 
-Welcome to the Python samples folder for Generative AI on Vertex AI! In this folder, you can find the Python samples
-used in [Google Cloud Generative AI documentation](https://cloud.google.com/ai/generative-ai?hl=en).
+This directory contains the official Python code samples featured in the [Google Cloud Generative AI documentation](https://cloud.google.com/ai/generative-ai?hl=en). These scripts demonstrate how to integrate and build with Vertex AI.
 
-If you are looking for colab notebook, then this [link](https://github.com/GoogleCloudPlatform/generative-ai/tree/main).
+Looking for interactive, step-by-step tutorials? Check out our extensive collection of [Colab notebooks](https://github.com/GoogleCloudPlatform/generative-ai/tree/main).
 
 ## Getting Started
 
-To try and run these Code samples, we have following recommend using Google Cloud IDE or Google Colab.
+> **Note:** An active Google Cloud Project is required.
 
-Note: A Google Cloud Project is a pre-requisite.
+We recommend running these code samples using Google Cloud Shell Editor or Google Colab to minimize environment setup.
 
 ### Feature folders
 
@@ -21,47 +20,26 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><strong>Google Cloud Product</strong>
    </td>
-   <td><strong>Short Description (With the help of Gemini 1.5)</strong>
+   <td><strong>Short Description (With the help of Gemini 3.1)</strong>
    </td>
   </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/context_caching">Context Caching</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview">https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview</a>
-   </td>
-   <td>Code samples demonstrating how to use context caching with Vertex AI's generative models. This allows for more consistent and relevant responses across multiple interactions by storing previous conversation history.
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/controlled_generation">Controlled Generation</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output">https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output</a>
-   </td>
-   <td>Examples of how to control the output of generative models, such as specifying length, format, or sentiment.
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/count_token">Count Token</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/list-token">https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/list-token</a>
-   </td>
-   <td>Code demonstrating how to count tokens in text, which is crucial for managing costs and understanding model limitations.
-   </td>
-  </tr>
+
   <tr>
    <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/embeddings">Embeddings</a>
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings">https://cloud.google.com/vertex-ai/generative-ai/docs/embeddings</a>
    </td>
-   <td>Code showing how to generate and use embeddings from text or images. Embeddings can be used for tasks like semantic search, clustering, and classification.
+   <td>Learn how to use Vertex AI's text and multimodal embedding models. These samples show you how to convert your unstructured data into numerical vectors to power semantic search, clustering, and RAG applications.
    </td>
   </tr>
+
+
   <tr>
    <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/extensions">Extensions</a>
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/extensions/overview">https://cloud.google.com/vertex-ai/generative-ai/docs/extensions/overview</a>
    </td>
-   <td>Demonstrations of how to use extensions with generative models, enabling them to access and process real-time information, use tools, and interact with external systems.
+   <td>Learn how to connect foundation models to external systems. These samples cover how to register and use Vertex AI Extensions to allow your models to interact with third-party APIs.
    </td>
   </tr>
   <tr>
@@ -69,23 +47,16 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling">https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/function-calling</a>
    </td>
-   <td>Examples of how to use function calling to enable generative models to execute specific actions or retrieve information from external APIs.
+   <td>Function calling gives Gemini the ability to interact with your codebase. The model predicts which of your local functions needs to be run and returns the formatted arguments, leaving the actual execution up to your application.
    </td>
   </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/grounding">Grounding</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview">https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/overview</a>
-   </td>
-   <td>Code illustrating how to ground generative models with specific knowledge bases or data sources to improve the accuracy and relevance of their responses.
-   </td>
-  </tr>
+
   <tr>
    <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/image_generation">Image Generation</a>
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview">https://cloud.google.com/vertex-ai/generative-ai/docs/image/overview</a>
    </td>
-   <td>Samples showcasing how to generate images from text prompts using models like Imagen.
+   <td>Learn how to integrate the Imagen model into your applications. These examples cover text-to-image generation, editing, and using advanced parameters to get the exact visual output you need.
    </td>
   </tr>
   <tr>
@@ -93,7 +64,7 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/explore-models">https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/explore-models</a>
    </td>
-   <td>Resources related to exploring and utilizing pre-trained models available in Vertex AI's Model Garden.
+   <td>These examples show you how to provision endpoints and serve predictions from first-party, third-party, and open-source foundation models available in the Vertex AI Model Garden.
    </td>
   </tr>
   <tr>
@@ -101,7 +72,7 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/models/tune-models">https://cloud.google.com/vertex-ai/generative-ai/docs/models/tune-models</a>
    </td>
-   <td>Code and guides for fine-tuning pre-trained generative models on specific datasets or for specific tasks.
+   <td>Tailor Gemini and other foundation models to your specific domain. These examples cover how to format your datasets, kick off tuning jobs on Vertex AI, and deploy your custom-tuned models or adapters to production endpoints.
    </td>
   </tr>
   <tr>
@@ -109,7 +80,7 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/rag-api">https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/rag-api</a>
    </td>
-   <td>Information and resources about Retrieval Augmented Generation (RAG), which combines information retrieval with generative models.
+   <td>These examples cover the end-to-end RAG architecture: ingesting data, generating embeddings, querying a vector database, and passing the retrieved context to Gemini to generate informed, accurate answers.
    </td>
   </tr>
   <tr>
@@ -117,23 +88,7 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/reasoning-engine">https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/reasoning-engine</a>
    </td>
-   <td>Details about the Reasoning Engine, which enables more complex reasoning and logical deduction in generative models.
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/safety">Safety</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-attributes">https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/configure-safety-attributes</a>
-   </td>
-   <td>Examples of how to configure safety attributes and filters to mitigate risks and ensure responsible use of generative models.
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/system_instructions">System Instructions</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en">https://cloud.google.com/vertex-ai/generative-ai/docs/learn/prompts/system-instructions?hl=en</a>
-   </td>
-   <td>Code demonstrating how to provide system instructions to guide the behavior and responses of generative models.
+   <td>These examples cover how to use Vertex AI Reasoning Engine to build custom agents.
    </td>
   </tr>
   <tr>
@@ -141,23 +96,7 @@ Browse the folders below to find the Generative AI capabilities you're intereste
    </td>
    <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/send-chat-prompts-gemini">https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/send-chat-prompts-gemini</a>
    </td>
-   <td>Samples of how to generate text using Gemini models, including chat-based interactions and creative writing.
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/audio">Understand Audio</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding">https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/audio-understanding</a>
-   </td>
-   <td>Examples of how to use generative models for audio understanding tasks, such as transcription and audio classification.
-   </td>
-  </tr>
-  <tr>
-   <td><a href="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/generative_ai/video">Understand Video</a>
-   </td>
-   <td><a href="https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding">https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding</a>
-   </td>
-   <td>Samples showcasing how to use generative models for video understanding tasks, such as video summarization and content analysis.
+   <td>These samples demonstrate how to use Vertex AI's Gemini models to generate, summarize, and extract information from text.
    </td>
   </tr>
 </table>


### PR DESCRIPTION
A bunch of samples for generative AI were removed and the README file wasn't updated to reflect this. Also, the text was badly redacted.

## Description
These changes were indpired by: #13848, fixes internal b/500046563

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved