### PR TITLE
chore(multiple samples) Updating django instances and some of it dependencies.

### DIFF
--- a/appengine/flexible/django_cloudsql/noxfile_config.py
+++ b/appengine/flexible/django_cloudsql/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/appengine/flexible/django_cloudsql/requirements-test.txt
+++ b/appengine/flexible/django_cloudsql/requirements-test.txt
@@ -1,2 +1,2 @@
 pytest==9.0.3; python_version >= "3.10"
-pytest-django==4.9.0
+pytest-django==4.12.0

--- a/appengine/flexible/django_cloudsql/requirements.txt
+++ b/appengine/flexible/django_cloudsql/requirements.txt
@@ -1,6 +1,6 @@
-Django==6.0.1; python_version >= "3.12"
+Django==6.0.5; python_version >= "3.12"
 gunicorn==23.0.0
 psycopg2-binary==2.9.11
-django-environ==0.12.0
+django-environ==0.13.0
 google-cloud-secret-manager==2.21.1
 django-storages[google]==1.14.6

--- a/appengine/flexible/hello_world_django/noxfile_config.py
+++ b/appengine/flexible/hello_world_django/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/appengine/flexible/hello_world_django/requirements.txt
+++ b/appengine/flexible/hello_world_django/requirements.txt
@@ -1,2 +1,2 @@
-Django==6.0.1; python_version >= "3.12"
+Django==6.0.5; python_version >= "3.12"
 gunicorn==23.0.0

--- a/appengine/standard_python3/bundled-services/blobstore/django/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/blobstore/django/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
@@ -1,5 +1,4 @@
-Django==5.1.15; python_version >= "3.10"
-Django==4.2.16; python_version < "3.10"
-django-environ==0.10.0
+Django==6.0.5; python_version >= "3.12"
+django-environ==0.13.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.2.3

--- a/appengine/standard_python3/bundled-services/deferred/django/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/deferred/django/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/appengine/standard_python3/bundled-services/deferred/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/deferred/django/requirements.txt
@@ -1,6 +1,4 @@
-Django==5.1.7; python_version >= "3.10"
-Django==4.2.16; python_version >= "3.8" and python_version < "3.10"
-Django==3.2.25; python_version < "3.8"
-django-environ==0.10.0
+Django==6.0.5; python_version >= "3.12"
+django-environ==0.13.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.3.1

--- a/appengine/standard_python3/bundled-services/mail/django/noxfile_config.py
+++ b/appengine/standard_python3/bundled-services/mail/django/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/appengine/standard_python3/bundled-services/mail/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/mail/django/requirements.txt
@@ -1,6 +1,4 @@
-Django==5.1.15; python_version >= "3.10"
-Django==4.2.16; python_version >= "3.8" and python_version < "3.10"
-Django==3.2.25; python_version < "3.8"
-django-environ==0.10.0
+Django==6.0.5; python_version >= "3.12"
+django-environ==0.13.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.2.3

--- a/appengine/standard_python3/django/noxfile_config.py
+++ b/appengine/standard_python3/django/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/appengine/standard_python3/django/requirements.txt
+++ b/appengine/standard_python3/django/requirements.txt
@@ -1,6 +1,4 @@
-Django==5.1.15; python_version >= "3.10"
-Django==4.2.17; python_version >= "3.8" and python_version < "3.10"
-Django==3.2.25; python_version < "3.8"
-django-environ==0.10.0
+Django==6.0.5; python_version >= "3.12"
+django-environ==0.13.0
 psycopg2-binary==2.9.9
 google-cloud-secret-manager==2.16.1

--- a/kubernetes_engine/django_tutorial/requirements.txt
+++ b/kubernetes_engine/django_tutorial/requirements.txt
@@ -4,6 +4,5 @@ Django==6.0.1; python_version >= "3.12"
 #mysqlclient==1.4.1
 wheel==0.40.0
 gunicorn==23.0.0; python_version > '3.0'
-gunicorn==23.0.0; python_version < '3.0'
 # psycopg2==2.8.4 # uncomment if you prefer to build from source
 psycopg2-binary==2.9.11

--- a/run/django/noxfile_config.py
+++ b/run/django/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature the
     "enforce_type_hints": True,

--- a/run/django/requirements-test.txt
+++ b/run/django/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 pytest==9.0.3; python_version >= "3.10"
-pytest-django==4.9.0
+pytest-django==4.12.0
 requests==2.31.0

--- a/run/django/requirements.txt
+++ b/run/django/requirements.txt
@@ -1,7 +1,6 @@
-Django==5.2.5; python_version >= "3.10"
-Django==4.2.24; python_version >= "3.8" and python_version < "3.10"
+Django==6.0.5; python_version >= "3.12"
 django-storages[google]==1.14.6
-django-environ==0.12.0
+django-environ==0.13.0
 psycopg2-binary==2.9.10
 gunicorn==23.0.0
 google-cloud-secret-manager==2.21.1


### PR DESCRIPTION

## Description

   * Django Upgrade: Updated Django to version 6.0.5 (pinned to python_version >= "3.12") across App Engine, Cloud Run, and Kubernetes Engine samples. Removed all outdated conditional dependencies for older
     Django versions (3.x, 4.x, 5.x).
   * Dependency Bumps:
       * Upgraded django-environ from 0.10.0/0.12.0 to 0.13.0.
       * Upgraded pytest-django from 4.9.0 to 4.12.0 in all requirements-test.txt files.
       * Cleaned up redundant gunicorn Python 2 entries in kubernetes_engine/django_tutorial/requirements.txt.
   * Nox Configuration Updates: Modified noxfile_config.py across 7 Django samples to update the ignored_versions list. Python 3.8, 3.9, 3.10, 3.11, and 3.13 are now explicitly ignored for testing, aligning
     tests with the new Django 6.x requirements.


Note: run/django is not working properly, this is a known bug documented in b/479621565

Fixes b/511192727

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved