### PR TITLE
chore(several samples) Updating all instances of Pytest up to version 9.0.3 Part III

### DIFF
--- a/appengine/flexible/tasks/Dockerfile
+++ b/appengine/flexible/tasks/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11
+FROM python:3.14
 
 # Copy local code to the container image.
 ENV APP_HOME /app

--- a/appengine/flexible/tasks/noxfile_config.py
+++ b/appengine/flexible/tasks/noxfile_config.py
@@ -22,7 +22,8 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7"],
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
+    "ignored_versions": ["2.7", "3.7", "3.10"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/auth/custom-credentials/aws/Dockerfile
+++ b/auth/custom-credentials/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 RUN useradd -m appuser
 

--- a/auth/custom-credentials/aws/noxfile_config.py
+++ b/auth/custom-credentials/aws/noxfile_config.py
@@ -13,5 +13,6 @@
 # limitations under the License.
 
 TEST_CONFIG_OVERRIDE = {
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"],
 }

--- a/cloud-sql/mysql/sqlalchemy/Dockerfile
+++ b/cloud-sql/mysql/sqlalchemy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.13
+FROM python:3.14
 
 RUN apt-get update
 

--- a/cloud-sql/postgres/sqlalchemy/Dockerfile
+++ b/cloud-sql/postgres/sqlalchemy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.13
+FROM python:3.14
 
 RUN apt-get update
 

--- a/cloud-sql/sql-server/sqlalchemy/Dockerfile
+++ b/cloud-sql/sql-server/sqlalchemy/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.13
+FROM python:3.14
 
 RUN apt-get update
 

--- a/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/Dockerfile
+++ b/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11
+FROM python:3.14
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/noxfile_config.py
+++ b/composer/blog/gcp-tech-blog/unit-test-dags-cloud-build/noxfile_config.py
@@ -32,6 +32,7 @@ _tmpdir = tempfile.TemporaryDirectory()
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # Skipping for Python 3.9 due to numpy compilation failure.
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.9", "3.10", "3.11"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them

--- a/dataflow/custom-containers/miniconda/Dockerfile
+++ b/dataflow/custom-containers/miniconda/Dockerfile
@@ -18,7 +18,7 @@ FROM continuumio/miniconda3:22.11.1-alpine AS builder
 
 # Create a virtual environment and make it standalone with conda-pack.
 # https://conda.github.io/conda-pack
-RUN conda create -y -n env python=3.9 \
+RUN conda create -y -n env python=3.14 \
     && conda install -y conda-pack \
     && conda-pack -n env -o /tmp/env.tar \
     && mkdir /opt/python \

--- a/dataflow/custom-containers/miniconda/Dockerfile
+++ b/dataflow/custom-containers/miniconda/Dockerfile
@@ -31,7 +31,7 @@ FROM ubuntu:latest
 WORKDIR /pipeline
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
-COPY --from=apache/beam_python3.9_sdk:2.55.1 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]
 
 # Copy the python installation from the builder stage.

--- a/dataflow/custom-containers/miniconda/noxfile_config.py
+++ b/dataflow/custom-containers/miniconda/noxfile_config.py
@@ -22,11 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ We're opting out of all Python versions except 3.9.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/custom-containers/miniconda/noxfile_config.py
+++ b/dataflow/custom-containers/miniconda/noxfile_config.py
@@ -25,6 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.9.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them

--- a/dataflow/custom-containers/minimal/Dockerfile
+++ b/dataflow/custom-containers/minimal/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.9-slim
+FROM python:3.14-slim
 
 WORKDIR /pipeline
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
-COPY --from=apache/beam_python3.9_sdk:2.55.1 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]
 
 # Install the requirements.

--- a/dataflow/custom-containers/minimal/noxfile_config.py
+++ b/dataflow/custom-containers/minimal/noxfile_config.py
@@ -22,11 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ We're opting out of all Python versions except 3.9.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/custom-containers/minimal/noxfile_config.py
+++ b/dataflow/custom-containers/minimal/noxfile_config.py
@@ -25,6 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.9.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them

--- a/dataflow/custom-containers/ubuntu/Dockerfile
+++ b/dataflow/custom-containers/ubuntu/Dockerfile
@@ -17,7 +17,7 @@ FROM ubuntu:focal
 WORKDIR /pipeline
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
-COPY --from=apache/beam_python3.8_sdk:2.40.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]
 
 # Install Python with pip, dev tools, distutils, and a C++ compiler.

--- a/dataflow/custom-containers/ubuntu/noxfile_config.py
+++ b/dataflow/custom-containers/ubuntu/noxfile_config.py
@@ -22,11 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ We're opting out of all Python versions except 3.9.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/custom-containers/ubuntu/noxfile_config.py
+++ b/dataflow/custom-containers/ubuntu/noxfile_config.py
@@ -25,6 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.9.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them

--- a/dataflow/flex-templates/pipeline_with_dependencies/Dockerfile
+++ b/dataflow/flex-templates/pipeline_with_dependencies/Dockerfile
@@ -24,7 +24,7 @@
 # This Dockerfile illustrates how to use a custom base image when building
 # a custom contaier images for Dataflow. A 'slim' base image is smaller in size,
 # but does not include some preinstalled libraries, like google-cloud-debugger.
-# To use a standard image, use apache/beam_python3.11_sdk:2.54.0 instead.
+# To use a standard image, use apache/beam_python3.14_sdk:2.73.0 instead.
 # Use consistent versions of Python interpreter in the project.
 FROM python:3.14-slim
 

--- a/dataflow/flex-templates/pipeline_with_dependencies/Dockerfile
+++ b/dataflow/flex-templates/pipeline_with_dependencies/Dockerfile
@@ -26,12 +26,12 @@
 # but does not include some preinstalled libraries, like google-cloud-debugger.
 # To use a standard image, use apache/beam_python3.11_sdk:2.54.0 instead.
 # Use consistent versions of Python interpreter in the project.
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Copy SDK entrypoint binary from Apache Beam image, which makes it possible to
 # use the image as SDK container image. If you explicitly depend on
 # apache-beam in setup.py, use the same version of Beam in both files.
-COPY --from=apache/beam_python3.11_sdk:2.54.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 
 # Copy Flex Template launcher binary from the launcher image, which makes it
 # possible to use the image as a Flex Template base image.

--- a/dataflow/flex-templates/pipeline_with_dependencies/noxfile_config.py
+++ b/dataflow/flex-templates/pipeline_with_dependencies/noxfile_config.py
@@ -19,5 +19,6 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.11.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.12", "3.13"],
 }

--- a/dataflow/flex-templates/pipeline_with_dependencies/noxfile_config.py
+++ b/dataflow/flex-templates/pipeline_with_dependencies/noxfile_config.py
@@ -16,9 +16,8 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ We're opting out of all Python versions except 3.11.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
 }

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 
 # Copy Flex Template launcher binary from the launcher image, which makes it
 # possible to use the image as a Flex Template base image.
-COPY --from=gcr.io/dataflow-templates-base/python310-template-launcher-base:latest /opt/google/dataflow/python_template_launcher /opt/google/dataflow/python_template_launcher
+COPY --from=gcr.io/dataflow-templates-base/python314-template-launcher-base:latest /opt/google/dataflow/python_template_launcher /opt/google/dataflow/python_template_launcher
 
 # Copy the model directory downloaded from Kaggle and the pipeline code.
 COPY pytorch_model pytorch_model

--- a/dataflow/gemma-flex-template/Dockerfile
+++ b/dataflow/gemma-flex-template/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --upgrade pip \
 # Copy SDK entrypoint binary from Apache Beam image, which makes it possible to
 # use the image as SDK container image.
 # The Beam version should match the version specified in requirements.txt
-COPY --from=apache/beam_python3.10_sdk:2.62.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 
 # Copy Flex Template launcher binary from the launcher image, which makes it
 # possible to use the image as a Flex Template base image.

--- a/dataflow/gemma-flex-template/noxfile_config.py
+++ b/dataflow/gemma-flex-template/noxfile_config.py
@@ -16,11 +16,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # Opting out of all Python versions except 3.10.
     # The Python version used is defined by the Dockerfile and the job
     # submission enviornment must match.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     "envs": {
         "PYTHONPATH": ".."
     },

--- a/dataflow/gemma-flex-template/noxfile_config.py
+++ b/dataflow/gemma-flex-template/noxfile_config.py
@@ -19,7 +19,8 @@ TEST_CONFIG_OVERRIDE = {
     # Opting out of all Python versions except 3.10.
     # The Python version used is defined by the Dockerfile and the job
     # submission enviornment must match.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12", "3.13"],
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     "envs": {
         "PYTHONPATH": ".."
     },

--- a/dataflow/gemma/Dockerfile
+++ b/dataflow/gemma/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --upgrade --no-cache-dir pip \
     && pip install --no-cache-dir -r requirements.txt
 
 # Copy files from official SDK image, including script/dependencies.
-COPY --from=apache/beam_python3.11_sdk:2.54.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 
 # Copy the model directory downloaded from Kaggle and the pipeline code.
 COPY gemma_2b gemma_2B

--- a/dataflow/gemma/noxfile_config.py
+++ b/dataflow/gemma/noxfile_config.py
@@ -19,6 +19,7 @@ TEST_CONFIG_OVERRIDE = {
     # Opting out of all Python versions except 3.11.
     # The Python version used is defined by the Dockerfile and the job
     # submission enviornment must match.
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.12", "3.13"],
     "envs": {
         "PYTHONPATH": ".."

--- a/dataflow/gemma/noxfile_config.py
+++ b/dataflow/gemma/noxfile_config.py
@@ -16,11 +16,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # Opting out of all Python versions except 3.11.
     # The Python version used is defined by the Dockerfile and the job
     # submission enviornment must match.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     "envs": {
         "PYTHONPATH": ".."
     },

--- a/dataflow/gpu-examples/pytorch-minimal/Dockerfile
+++ b/dataflow/gpu-examples/pytorch-minimal/Dockerfile
@@ -27,5 +27,5 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip check
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
-COPY --from=apache/beam_python3.10_sdk:2.62.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/pytorch-minimal/noxfile_config.py
+++ b/dataflow/gpu-examples/pytorch-minimal/noxfile_config.py
@@ -25,7 +25,8 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ We're opting out of all Python versions except 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12", "3.13"],
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/pytorch-minimal/noxfile_config.py
+++ b/dataflow/gpu-examples/pytorch-minimal/noxfile_config.py
@@ -22,11 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ We're opting out of all Python versions except 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.10_sdk:2.62.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
@@ -25,9 +25,9 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-        curl g++ python3.10-dev python3.10-venv python3-distutils \
+        curl g++ python3.14-dev python3.14-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.14 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
     # Install the pipeline requirements.
     && pip install --no-cache-dir -r requirements.txt \

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/noxfile_config.py
@@ -25,7 +25,8 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12", "3.13"],
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/noxfile_config.py
@@ -22,11 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.10_sdk:2.62.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
@@ -25,9 +25,9 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-    curl g++ python3.10-dev python3.10-venv python3-distutils \
+    curl g++ python3.14-dev python3.14-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.14 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
     # Install the pipeline requirements.
     && pip install --no-cache-dir -r requirements.txt \

--- a/dataflow/gpu-examples/tensorflow-landsat/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-landsat/noxfile_config.py
@@ -25,7 +25,8 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12", "3.13"],
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-landsat/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-landsat/noxfile_config.py
@@ -22,11 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.10_sdk:2.62.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
@@ -25,9 +25,9 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-        curl g++ python3.10-dev python3.10-venv python3-distutils \
+        curl g++ python3.14-dev python3.14-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.10 10 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.14 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
     # Install the pipeline requirements.
     && pip install --no-cache-dir -r requirements.txt \

--- a/dataflow/gpu-examples/tensorflow-minimal/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-minimal/noxfile_config.py
@@ -25,7 +25,8 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12", "3.13"],
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/gpu-examples/tensorflow-minimal/noxfile_config.py
+++ b/dataflow/gpu-examples/tensorflow-minimal/noxfile_config.py
@@ -22,11 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
     # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/dataflow/snippets/Dockerfile
+++ b/dataflow/snippets/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends docker.io
 
 # Install dependencies.
-RUN pip3 install --no-cache-dir apache-beam[gcp]==2.63.0
+RUN pip3 install --no-cache-dir apache-beam[gcp]==2.73.0
 RUN pip install --no-cache-dir kafka-python==2.0.6
 
 # Verify that the image does not have conflicting dependencies.

--- a/dataflow/snippets/Dockerfile
+++ b/dataflow/snippets/Dockerfile
@@ -18,7 +18,7 @@
 # on the host machine. This Dockerfile is derived from the
 # dataflow/custom-containers/ubuntu sample.
 
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 # Install JRE
 COPY --from=openjdk:8-jre-slim /usr/local/openjdk-8 /usr/local/openjdk-8
@@ -28,7 +28,7 @@ RUN update-alternatives --install /usr/bin/java java /usr/local/openjdk-8/bin/ja
 WORKDIR /pipeline
 
 # Copy files from official SDK image.
-COPY --from=apache/beam_python3.11_sdk:2.63.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
 # Set the entrypoint to Apache Beam SDK launcher.
 ENTRYPOINT [ "/opt/apache/beam/boot" ]
 

--- a/dataflow/snippets/noxfile_config.py
+++ b/dataflow/snippets/noxfile_config.py
@@ -22,6 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
+    # Note: Docker-based sample, testing only against version specified in Dockerfile (3.14)
     "ignored_versions": ["2.7", "3.7", "3.8", "3.9", "3.10", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them

--- a/endpoints/bookstore-grpc-transcoding/requirements-test.txt
+++ b/endpoints/bookstore-grpc-transcoding/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/endpoints/bookstore-grpc/requirements-test.txt
+++ b/endpoints/bookstore-grpc/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/endpoints/getting-started-grpc/requirements-test.txt
+++ b/endpoints/getting-started-grpc/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/endpoints/getting-started/Dockerfile.custom
+++ b/endpoints/getting-started/Dockerfile.custom
@@ -5,7 +5,7 @@
 FROM gcr.io/google_appengine/python
 
 RUN apt-get update && \
-    apt-get install -y python2.7 python-pip && \
+    apt-get install -y python3.14 python-pip && \
     apt-get clean && \
     rm /var/lib/apt/lists/*_*
 

--- a/endpoints/getting-started/Dockerfile.custom
+++ b/endpoints/getting-started/Dockerfile.custom
@@ -5,7 +5,7 @@
 FROM gcr.io/google_appengine/python
 
 RUN apt-get update && \
-    apt-get install -y python3.14 python-pip && \
+    apt-get install -y python2.7 python-pip && \
     apt-get clean && \
     rm /var/lib/apt/lists/*_*
 

--- a/endpoints/getting-started/clients/service_to_service_non_default/requirements-test.txt
+++ b/endpoints/getting-started/clients/service_to_service_non_default/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/endpoints/getting-started/clients/service_to_service_non_default/requirements-test.txt
+++ b/endpoints/getting-started/clients/service_to_service_non_default/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==9.0.3; python_version >= "3.10"
+endpoints/getting-started/clients/service_to_service_non_default/requirements-test.txt

--- a/endpoints/getting-started/noxfile_config.py
+++ b/endpoints/getting-started/noxfile_config.py
@@ -22,10 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ Test only on Python 3.14.
+    # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     # "enforce_type_hints": True,

--- a/endpoints/getting-started/noxfile_config.py
+++ b/endpoints/getting-started/noxfile_config.py
@@ -22,10 +22,10 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    # > ℹ️ Test only on Python 3.10.
+    # > ℹ️ Test only on Python 3.14.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     # "enforce_type_hints": True,

--- a/endpoints/getting-started/noxfile_config.py
+++ b/endpoints/getting-started/noxfile_config.py
@@ -25,7 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.8", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     # "enforce_type_hints": True,

--- a/endpoints/getting-started/requirements-test.txt
+++ b/endpoints/getting-started/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/endpoints/getting-started/requirements-test.txt
+++ b/endpoints/getting-started/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==9.0.3; python_version >= "3.10"
+pytest==8.2.0

--- a/enterpriseknowledgegraph/entity_reconciliation/requirements-test.txt
+++ b/enterpriseknowledgegraph/entity_reconciliation/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 google-api-core
 google-cloud-enterpriseknowledgegraph

--- a/enterpriseknowledgegraph/search/requirements-test.txt
+++ b/enterpriseknowledgegraph/search/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/error_reporting/fluent_on_compute/requirements-test.txt
+++ b/error_reporting/fluent_on_compute/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/error_reporting/snippets/requirements-test.txt
+++ b/error_reporting/snippets/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/eventarc/audit-storage/Dockerfile
+++ b/eventarc/audit-storage/Dockerfile
@@ -16,7 +16,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/eventarc/audit-storage/requirements-test.txt
+++ b/eventarc/audit-storage/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/eventarc/audit_iam/requirements-test.txt
+++ b/eventarc/audit_iam/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/eventarc/generic/Dockerfile
+++ b/eventarc/generic/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/eventarc/generic/requirements-test.txt
+++ b/eventarc/generic/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/eventarc/pubsub/Dockerfile
+++ b/eventarc/pubsub/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True

--- a/eventarc/pubsub/requirements-test.txt
+++ b/eventarc/pubsub/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/eventarc/storage_handler/requirements-test.txt
+++ b/eventarc/storage_handler/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/gemma2/noxfile_config.py
+++ b/gemma2/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/gemma2/requirements-test.txt
+++ b/gemma2/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.3.3
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/batch_prediction/noxfile_config.py
+++ b/genai/batch_prediction/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/batch_prediction/requirements-test.txt
+++ b/genai/batch_prediction/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/bounding_box/noxfile_config.py
+++ b/genai/bounding_box/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/bounding_box/requirements-test.txt
+++ b/genai/bounding_box/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/code_execution/noxfile_config.py
+++ b/genai/code_execution/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11", "3.13", "3.14"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/code_execution/requirements-test.txt
+++ b/genai/code_execution/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.29.0
-pytest==9.0.2
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==1.3.0

--- a/genai/content_cache/noxfile_config.py
+++ b/genai/content_cache/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/content_cache/requirements-test.txt
+++ b/genai/content_cache/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/controlled_generation/noxfile_config.py
+++ b/genai/controlled_generation/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/controlled_generation/requirements-test.txt
+++ b/genai/controlled_generation/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/genai/count_tokens/noxfile_config.py
+++ b/genai/count_tokens/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/count_tokens/requirements-test.txt
+++ b/genai/count_tokens/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/genai/embeddings/noxfile_config.py
+++ b/genai/embeddings/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/embeddings/requirements-test.txt
+++ b/genai/embeddings/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/express_mode/noxfile_config.py
+++ b/genai/express_mode/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/express_mode/requirements-test.txt
+++ b/genai/express_mode/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/image_generation/noxfile_config.py
+++ b/genai/image_generation/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/image_generation/requirements-test.txt
+++ b/genai/image_generation/requirements-test.txt
@@ -1,3 +1,3 @@
 google-api-core==2.24.0
 google-cloud-storage==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/live/noxfile_config.py
+++ b/genai/live/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/live/requirements-test.txt
+++ b/genai/live/requirements-test.txt
@@ -1,5 +1,5 @@
 backoff==2.2.1
 google-api-core==2.25.1
-pytest==8.4.1
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==1.1.0
 pytest-mock==3.14.0

--- a/genai/model_optimizer/noxfile_config.py
+++ b/genai/model_optimizer/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/model_optimizer/requirements-test.txt
+++ b/genai/model_optimizer/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/genai/provisioned_throughput/noxfile_config.py
+++ b/genai/provisioned_throughput/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/provisioned_throughput/requirements-test.txt
+++ b/genai/provisioned_throughput/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/safety/noxfile_config.py
+++ b/genai/safety/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/safety/requirements-test.txt
+++ b/genai/safety/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/template_folder/noxfile_config.py
+++ b/genai/template_folder/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/template_folder/requirements-test.txt
+++ b/genai/template_folder/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/genai/text_generation/noxfile_config.py
+++ b/genai/text_generation/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/text_generation/requirements-test.txt
+++ b/genai/text_generation/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/thinking/noxfile_config.py
+++ b/genai/thinking/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/thinking/requirements-test.txt
+++ b/genai/thinking/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/genai/tools/noxfile_config.py
+++ b/genai/tools/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/tools/requirements-test.txt
+++ b/genai/tools/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/genai/tuning/noxfile_config.py
+++ b/genai/tuning/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/tuning/requirements-test.txt
+++ b/genai/tuning/requirements-test.txt
@@ -1,3 +1,3 @@
 google-api-core==2.24.0
 google-cloud-storage==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/genai/video_generation/noxfile_config.py
+++ b/genai/video_generation/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/genai/video_generation/requirements-test.txt
+++ b/genai/video_generation/requirements-test.txt
@@ -1,3 +1,3 @@
 google-api-core==2.24.0
 google-cloud-storage==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/generative_ai/chat_completions/noxfile_config.py
+++ b/generative_ai/chat_completions/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/chat_completions/requirements-test.txt
+++ b/generative_ai/chat_completions/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/embeddings/noxfile_config.py
+++ b/generative_ai/embeddings/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/embeddings/requirements-test.txt
+++ b/generative_ai/embeddings/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/evaluation/noxfile_config.py
+++ b/generative_ai/evaluation/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/evaluation/requirements-test.txt
+++ b/generative_ai/evaluation/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/extensions/noxfile_config.py
+++ b/generative_ai/extensions/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/extensions/requirements-test.txt
+++ b/generative_ai/extensions/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/function_calling/noxfile_config.py
+++ b/generative_ai/function_calling/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/function_calling/requirements-test.txt
+++ b/generative_ai/function_calling/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.24.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/image_generation/noxfile_config.py
+++ b/generative_ai/image_generation/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/image_generation/requirements-test.txt
+++ b/generative_ai/image_generation/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/labels/noxfile_config.py
+++ b/generative_ai/labels/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/labels/requirements-test.txt
+++ b/generative_ai/labels/requirements-test.txt
@@ -1,2 +1,2 @@
 google-api-core==2.23.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/generative_ai/model_garden/noxfile_config.py
+++ b/generative_ai/model_garden/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/model_garden/requirements-test.txt
+++ b/generative_ai/model_garden/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/model_tuning/noxfile_config.py
+++ b/generative_ai/model_tuning/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/model_tuning/requirements-test.txt
+++ b/generative_ai/model_tuning/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/prompts/noxfile_config.py
+++ b/generative_ai/prompts/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/prompts/requirements-test.txt
+++ b/generative_ai/prompts/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/provisioned_throughput/noxfile_config.py
+++ b/generative_ai/provisioned_throughput/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/provisioned_throughput/requirements-test.txt
+++ b/generative_ai/provisioned_throughput/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/rag/noxfile_config.py
+++ b/generative_ai/rag/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/rag/requirements-test.txt
+++ b/generative_ai/rag/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/generative_ai/reasoning_engine/noxfile_config.py
+++ b/generative_ai/reasoning_engine/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/generative_ai/reasoning_engine/requirements-test.txt
+++ b/generative_ai/reasoning_engine/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/healthcare/api-client/v1/consent/noxfile_config.py
+++ b/healthcare/api-client/v1/consent/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/healthcare/api-client/v1/consent/requirements-test.txt
+++ b/healthcare/api-client/v1/consent/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 backoff==2.2.1; python_version < "3.7"
 backoff==2.2.1; python_version >= "3.7"

--- a/healthcare/api-client/v1/datasets/noxfile_config.py
+++ b/healthcare/api-client/v1/datasets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/healthcare/api-client/v1/datasets/requirements-test.txt
+++ b/healthcare/api-client/v1/datasets/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 retrying==1.3.4

--- a/healthcare/api-client/v1/dicom/noxfile_config.py
+++ b/healthcare/api-client/v1/dicom/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/healthcare/api-client/v1/dicom/requirements-test.txt
+++ b/healthcare/api-client/v1/dicom/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 backoff==2.2.1; python_version < "3.7"
 backoff==2.2.1; python_version >= "3.7"

--- a/healthcare/api-client/v1/fhir/noxfile_config.py
+++ b/healthcare/api-client/v1/fhir/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/healthcare/api-client/v1/fhir/requirements-test.txt
+++ b/healthcare/api-client/v1/fhir/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 backoff==2.2.1; python_version < "3.7"
 backoff==2.2.1; python_version >= "3.7"

--- a/healthcare/api-client/v1/hl7v2/noxfile_config.py
+++ b/healthcare/api-client/v1/hl7v2/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/healthcare/api-client/v1/hl7v2/requirements-test.txt
+++ b/healthcare/api-client/v1/hl7v2/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 backoff==2.2.1; python_version < "3.7"
 backoff==2.2.1; python_version >= "3.7"

--- a/healthcare/api-client/v1beta1/fhir/requirements-test.txt
+++ b/healthcare/api-client/v1beta1/fhir/requirements-test.txt
@@ -1,3 +1,3 @@
 backoff==2.2.1; python_version < "3.7"
 backoff==2.2.1; python_version >= "3.7"
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/iam/api-client/noxfile_config.py
+++ b/iam/api-client/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Declare optional test sessions you want to opt-in. Currently we
     # have the following optional test sessions:
     #     'cloud_run' # Test session for Cloud Run application.

--- a/iam/api-client/requirements-test.txt
+++ b/iam/api-client/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 retrying==1.3.4

--- a/iam/cloud-client/snippets/noxfile_config.py
+++ b/iam/cloud-client/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/iam/cloud-client/snippets/requirements-test.txt
+++ b/iam/cloud-client/snippets/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 backoff==2.2.1

--- a/iap/app_engine_app/requirements-test.txt
+++ b/iap/app_engine_app/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/iap/requirements-test.txt
+++ b/iap/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 flaky==3.8.1

--- a/jobs/v3/api_client/noxfile_config.py
+++ b/jobs/v3/api_client/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/jobs/v3/api_client/requirements-test.txt
+++ b/jobs/v3/api_client/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1; python_version < "3.7"
 backoff==2.2.1; python_version >= "3.7"
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 flaky==3.8.1

--- a/kms/attestations/noxfile_config.py
+++ b/kms/attestations/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/kms/attestations/requirements-test.txt
+++ b/kms/attestations/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/kms/snippets/noxfile_config.py
+++ b/kms/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/kms/snippets/requirements-test.txt
+++ b/kms/snippets/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/kubernetes_engine/api-client/requirements-test.txt
+++ b/kubernetes_engine/api-client/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/kubernetes_engine/django_tutorial/requirements-test.txt
+++ b/kubernetes_engine/django_tutorial/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/language/snippets/api/requirements-test.txt
+++ b/language/snippets/api/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/language/snippets/classify_text/noxfile_config.py
+++ b/language/snippets/classify_text/noxfile_config.py
@@ -25,7 +25,7 @@ TEST_CONFIG_OVERRIDE = {
     # > ℹ️ Test only on Python 3.10.
     # > The Python version used is defined by the Dockerfile, so it's redundant
     # > to run multiple tests since they would all be running the same Dockerfile.
-    "ignored_versions": ["2.7", "3.6", "3.7", "3.9", "3.11", "3.12", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     # "enforce_type_hints": True,

--- a/language/snippets/classify_text/requirements-test.txt
+++ b/language/snippets/classify_text/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/language/snippets/cloud-client/v1/requirements-test.txt
+++ b/language/snippets/cloud-client/v1/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/language/snippets/sentiment/requirements-test.txt
+++ b/language/snippets/sentiment/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/language/v1/requirements-test.txt
+++ b/language/v1/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/language/v2/noxfile_config.py
+++ b/language/v2/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/language/v2/requirements-test.txt
+++ b/language/v2/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/logging/import-logs/noxfile_config.py
+++ b/logging/import-logs/noxfile_config.py
@@ -17,5 +17,5 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.6", "3.7"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
 }

--- a/logging/import-logs/requirements-test.txt
+++ b/logging/import-logs/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 google-cloud-logging~=3.11.4
 google-cloud-storage~=2.10.0

--- a/logging/samples/snippets/requirements-test.txt
+++ b/logging/samples/snippets/requirements-test.txt
@@ -1,3 +1,2 @@
 backoff==2.2.1
-pytest===7.4.4; python_version == '3.7'
-pytest==8.2.2; python_version >= '3.8'
+pytest==9.0.3; python_version >= "3.10"

--- a/managedkafka/snippets/connect/clusters/requirements.txt
+++ b/managedkafka/snippets/connect/clusters/requirements.txt
@@ -1,5 +1,5 @@
 protobuf==5.29.4
-pytest==8.2.2
+pytest==9.0.3; python_version >= "3.10"
 google-api-core==2.23.0
 google-auth==2.38.0
 google-cloud-managedkafka==0.1.12

--- a/managedkafka/snippets/requirements.txt
+++ b/managedkafka/snippets/requirements.txt
@@ -1,5 +1,5 @@
 protobuf==5.29.4
-pytest==8.2.2
+pytest==9.0.3; python_version >= "3.10"
 google-api-core==2.23.0
 google-auth==2.38.0
 google-cloud-managedkafka==0.1.12

--- a/media-translation/snippets/noxfile_config.py
+++ b/media-translation/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": False,

--- a/media-translation/snippets/requirements-test.txt
+++ b/media-translation/snippets/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/media_cdn/requirements-test.txt
+++ b/media_cdn/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/memorystore/memcache/noxfile_config.py
+++ b/memorystore/memcache/noxfile_config.py
@@ -23,7 +23,7 @@
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # We only run the cloud run tests in py38 session.
-    "ignored_versions": ["2.7", "3.6", "3.7"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/memorystore/redis/cloud_run_deployment/Dockerfile
+++ b/memorystore/redis/cloud_run_deployment/Dockerfile
@@ -14,7 +14,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 # Copy local code to the container image.
 ENV APP_HOME /app

--- a/memorystore/redis/noxfile_config.py
+++ b/memorystore/redis/noxfile_config.py
@@ -23,7 +23,7 @@
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
     # We only run the cloud run tests in py38 session.
-    "ignored_versions": ["2.7", "3.6", "3.7"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # An envvar key for determining the project id to use. Change it
     # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
     # build specific Cloud project. You can also use your own string

--- a/memorystore/redis/requirements-test.txt
+++ b/memorystore/redis/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/model_armor/snippets/noxfile_config.py
+++ b/model_armor/snippets/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/model_armor/snippets/requirements-test.txt
+++ b/model_armor/snippets/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.3.4
+pytest==9.0.3; python_version >= "3.10"

--- a/model_garden/anthropic/noxfile_config.py
+++ b/model_garden/anthropic/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.12"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/model_garden/anthropic/requirements-test.txt
+++ b/model_garden/anthropic/requirements-test.txt
@@ -1,4 +1,4 @@
 google-api-core==2.24.0
 google-cloud-bigquery==3.29.0
 google-cloud-storage==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/model_garden/gemma/noxfile_config.py
+++ b/model_garden/gemma/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.8", "3.10", "3.11", "3.13"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Old samples are opted out of enforcing Python type hints
     # All new samples should feature them
     "enforce_type_hints": True,

--- a/model_garden/gemma/requirements-test.txt
+++ b/model_garden/gemma/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1
 google-api-core==2.19.0
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 pytest-asyncio==0.23.6

--- a/monitoring/api/v3/api-client/requirements-test.txt
+++ b/monitoring/api/v3/api-client/requirements-test.txt
@@ -1,4 +1,4 @@
 backoff==2.2.1; python_version < "3.7"
 backoff==2.2.1; python_version >= "3.7"
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 flaky==3.8.1

--- a/monitoring/opencensus/requirements-test.txt
+++ b/monitoring/opencensus/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/monitoring/prometheus/requirements-test.txt
+++ b/monitoring/prometheus/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/monitoring/snippets/v3/alerts-client/noxfile_config.py
+++ b/monitoring/snippets/v3/alerts-client/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Declare optional test sessions you want to opt-in. Currently we
     # have the following optional test sessions:
     #     'cloud_run' # Test session for Cloud Run application.

--- a/monitoring/snippets/v3/alerts-client/requirements-test.txt
+++ b/monitoring/snippets/v3/alerts-client/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"
 retrying==1.3.4
 flaky==3.8.1

--- a/monitoring/snippets/v3/cloud-client/noxfile_config.py
+++ b/monitoring/snippets/v3/cloud-client/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Declare optional test sessions you want to opt-in. Currently we
     # have the following optional test sessions:
     #     'cloud_run' # Test session for Cloud Run application.

--- a/monitoring/snippets/v3/cloud-client/requirements-test.txt
+++ b/monitoring/snippets/v3/cloud-client/requirements-test.txt
@@ -1,2 +1,2 @@
 backoff==2.2.1
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"

--- a/monitoring/snippets/v3/uptime-check-client/noxfile_config.py
+++ b/monitoring/snippets/v3/uptime-check-client/noxfile_config.py
@@ -22,7 +22,7 @@
 
 TEST_CONFIG_OVERRIDE = {
     # You can opt out from the test for specific Python versions.
-    "ignored_versions": ["2.7", "3.7", "3.9", "3.10", "3.11"],
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
     # Declare optional test sessions you want to opt-in. Currently we
     # have the following optional test sessions:
     #     'cloud_run' # Test session for Cloud Run application.

--- a/monitoring/snippets/v3/uptime-check-client/requirements-test.txt
+++ b/monitoring/snippets/v3/uptime-check-client/requirements-test.txt
@@ -1,2 +1,2 @@
 backoff==2.2.1
-pytest==8.2.0
+pytest==9.0.3; python_version >= "3.10"


### PR DESCRIPTION
Directories that start from E to M.

 - Bump pytest to 9.0.3 (pinned to Python >= 3.10)
 - Update noxfile configs to only test against Python 3.10 and 3.14
 - Upgrade Dockerfile base images and Beam SDKs to Python 3.14 (Note, previously missed directories were modified too)

## Description

Fixes b/516829625

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [ ] Please **merge** this PR for me once it is approved