### PR TITLE
chore(multiple samples): bump pillow to 12.2.0 and restrict to python 3.10+

### DIFF
--- a/appengine/flexible/scipy/requirements.txt
+++ b/appengine/flexible/scipy/requirements.txt
@@ -5,6 +5,6 @@ imageio==2.36.1; python_version >= '3.9'
 numpy==2.2.4; python_version > '3.9'
 numpy==1.26.4; python_version == '3.9'
 numpy==1.24.4; python_version == '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 scipy==1.10.1; python_version <= '3.9'
 scipy==1.14.1; python_version > '3.9'

--- a/appengine/flexible/scipy/requirements.txt
+++ b/appengine/flexible/scipy/requirements.txt
@@ -5,6 +5,6 @@ imageio==2.36.1; python_version >= '3.9'
 numpy==2.2.4; python_version > '3.9'
 numpy==1.26.4; python_version == '3.9'
 numpy==1.24.4; python_version == '3.8'
-pillow==10.4.0
+pillow==12.2.0; python_version >= "3.10"
 scipy==1.10.1; python_version <= '3.9'
 scipy==1.14.1; python_version > '3.9'

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/requirements.txt
@@ -1,4 +1,4 @@
-Pillow==10.4.0
+pillow==12.2.0; python_version >= "3.10"
 apache-beam[gcp]==2.58.1
 rasterio==1.3.10
 tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu

--- a/dataflow/gpu-examples/tensorflow-landsat/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat/requirements.txt
@@ -1,4 +1,4 @@
-Pillow==10.4.0
+pillow==12.2.0; python_version >= "3.10"
 apache-beam[gcp]==2.58.1
 rasterio==1.3.10
 tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu

--- a/genai/bounding_box/requirements.txt
+++ b/genai/bounding_box/requirements.txt
@@ -1,2 +1,2 @@
 google-genai==1.42.0
-pillow==11.1.0
+pillow==12.2.0; python_version >= "3.10"

--- a/genai/code_execution/requirements.txt
+++ b/genai/code_execution/requirements.txt
@@ -1,2 +1,2 @@
 google-genai==1.60.0
-pillow==11.1.0
+pillow==12.2.0; python_version >= "3.10"

--- a/genai/image_generation/requirements.txt
+++ b/genai/image_generation/requirements.txt
@@ -1,2 +1,2 @@
 google-genai==1.42.0
-pillow==11.1.0
+pillow==12.2.0; python_version >= "3.10"

--- a/genai/tools/requirements.txt
+++ b/genai/tools/requirements.txt
@@ -1,3 +1,3 @@
 google-genai==1.45.0
 # PIl is required for tools_code_execution_with_txt_img.py
-pillow==11.1.0
+pillow==12.2.0; python_version >= "3.10"

--- a/generative_ai/embeddings/requirements.txt
+++ b/generative_ai/embeddings/requirements.txt
@@ -1,7 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.84.0
 sentencepiece==0.2.0
 google-auth==2.29.0

--- a/generative_ai/embeddings/requirements.txt
+++ b/generative_ai/embeddings/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.84.0
 sentencepiece==0.2.0
 google-auth==2.29.0

--- a/generative_ai/evaluation/requirements.txt
+++ b/generative_ai/evaluation/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0

--- a/generative_ai/evaluation/requirements.txt
+++ b/generative_ai/evaluation/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= "3.10"
-langchain-google-vertexai==3.2.3; python_version >= "3.10"
+langchain-core==1.4.0; python_version >= '3.10'
+langchain-google-vertexai==3.2.3; python_version >= '3.10'
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/extensions/requirements.txt
+++ b/generative_ai/extensions/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0

--- a/generative_ai/extensions/requirements.txt
+++ b/generative_ai/extensions/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= "3.10"
-langchain-google-vertexai==3.2.3; python_version >= "3.10"
+langchain-core==1.4.0; python_version >= '3.10'
+langchain-google-vertexai==3.2.3; python_version >= '3.10'
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/image_generation/requirements.txt
+++ b/generative_ai/image_generation/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0

--- a/generative_ai/image_generation/requirements.txt
+++ b/generative_ai/image_generation/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= "3.10"
-langchain-google-vertexai==3.2.3; python_version >= "3.10"
+langchain-core==1.4.0; python_version >= '3.10'
+langchain-google-vertexai==3.2.3; python_version >= '3.10'
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/model_garden/requirements.txt
+++ b/generative_ai/model_garden/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0

--- a/generative_ai/model_garden/requirements.txt
+++ b/generative_ai/model_garden/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= "3.10"
-langchain-google-vertexai==3.2.3; python_version >= "3.10"
+langchain-core==1.4.0; python_version >= '3.10'
+langchain-google-vertexai==3.2.3; python_version >= '3.10'
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/model_tuning/requirements.txt
+++ b/generative_ai/model_tuning/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0

--- a/generative_ai/model_tuning/requirements.txt
+++ b/generative_ai/model_tuning/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= "3.10"
-langchain-google-vertexai==3.2.3; python_version >= "3.10"
+langchain-core==1.4.0; python_version >= '3.10'
+langchain-google-vertexai==3.2.3; python_version >= '3.10'
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/prompts/requirements.txt
+++ b/generative_ai/prompts/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.74.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= "3.10"
-langchain-google-vertexai==3.2.3; python_version >= "3.10"
+langchain-core==1.4.0; python_version >= '3.10'
+langchain-google-vertexai==3.2.3; python_version >= '3.10'
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/prompts/requirements.txt
+++ b/generative_ai/prompts/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.74.0
 sentencepiece==0.2.0
 google-auth==2.38.0

--- a/generative_ai/reasoning_engine/requirements.txt
+++ b/generative_ai/reasoning_engine/requirements.txt
@@ -1,8 +1,7 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==10.4.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0

--- a/generative_ai/reasoning_engine/requirements.txt
+++ b/generative_ai/reasoning_engine/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0; python_version >= '3.10'
 google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= "3.10"
-langchain-google-vertexai==3.2.3; python_version >= "3.10"
+langchain-core==1.4.0; python_version >= '3.10'
+langchain-google-vertexai==3.2.3; python_version >= '3.10'
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/people-and-planet-ai/image-classification/requirements.txt
+++ b/people-and-planet-ai/image-classification/requirements.txt
@@ -1,3 +1,3 @@
-pillow==10.3.0
+pillow==12.2.0; python_version >= "3.10"
 apache-beam[gcp]==2.55.1
 google-cloud-aiplatform==1.47.0

--- a/vision/snippets/crop_hints/requirements.txt
+++ b/vision/snippets/crop_hints/requirements.txt
@@ -1,3 +1,2 @@
 google-cloud-vision==3.8.1
-pillow==10.3.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"

--- a/vision/snippets/document_text/requirements.txt
+++ b/vision/snippets/document_text/requirements.txt
@@ -1,3 +1,2 @@
 google-cloud-vision==3.8.1
-pillow==10.3.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"

--- a/vision/snippets/face_detection/requirements.txt
+++ b/vision/snippets/face_detection/requirements.txt
@@ -1,3 +1,2 @@
 google-cloud-vision==3.8.1
-pillow==10.3.0; python_version < '3.8'
-pillow==10.4.0; python_version >= '3.8'
+pillow==12.2.0; python_version >= "3.10"


### PR DESCRIPTION

 - Consolidated multiple pillow entries across requirements files into a single, version-pinned entry (`pillow==12.2.0`).
 - Restricted execution strictly to Python 3.10 and newer (`python_version >= "3.10"`) to resolve compatibility conflicts.

## Description

Fixes b/517989048

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved