### PR TITLE
chore(generative_ai): update langchain dependencies for generative_ai samples

### DIFF
--- a/generative_ai/evaluation/requirements.txt
+++ b/generative_ai/evaluation/requirements.txt
@@ -7,8 +7,8 @@ google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
+langchain-core==1.4.0; python_version >= "3.10"
+langchain-google-vertexai==3.2.3; python_version >= "3.10"
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/extensions/requirements.txt
+++ b/generative_ai/extensions/requirements.txt
@@ -7,8 +7,8 @@ google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
+langchain-core==1.4.0; python_version >= "3.10"
+langchain-google-vertexai==3.2.3; python_version >= "3.10"
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/image_generation/requirements.txt
+++ b/generative_ai/image_generation/requirements.txt
@@ -7,8 +7,8 @@ google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
+langchain-core==1.4.0; python_version >= "3.10"
+langchain-google-vertexai==3.2.3; python_version >= "3.10"
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/model_garden/requirements.txt
+++ b/generative_ai/model_garden/requirements.txt
@@ -7,8 +7,8 @@ google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
+langchain-core==1.4.0; python_version >= "3.10"
+langchain-google-vertexai==3.2.3; python_version >= "3.10"
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/model_tuning/requirements.txt
+++ b/generative_ai/model_tuning/requirements.txt
@@ -7,8 +7,8 @@ google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
+langchain-core==1.4.0; python_version >= "3.10"
+langchain-google-vertexai==3.2.3; python_version >= "3.10"
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/prompts/requirements.txt
+++ b/generative_ai/prompts/requirements.txt
@@ -7,8 +7,8 @@ google-cloud-aiplatform[all]==1.74.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
+langchain-core==1.4.0; python_version >= "3.10"
+langchain-google-vertexai==3.2.3; python_version >= "3.10"
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/reasoning_engine/requirements.txt
+++ b/generative_ai/reasoning_engine/requirements.txt
@@ -7,8 +7,8 @@ google-cloud-aiplatform[all]==1.69.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==0.2.33
-langchain-google-vertexai==1.0.10
+langchain-core==1.4.0; python_version >= "3.10"
+langchain-google-vertexai==3.2.3; python_version >= "3.10"
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0


### PR DESCRIPTION
## Description

 This PR fixes

 - Update langchain-core to 1.4.0
 - Update langchain-google-vertexai to 3.2.3
 - Pin both dependencies to python 3.10 and newer

Fixes b/518888434

Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [x] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved