### PR TITLE
feat(storagecontrol): add anywhere cache samples

### DIFF
--- a/storagecontrol/anywhere_cache_create.py
+++ b/storagecontrol/anywhere_cache_create.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_create_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def create_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone where the cache will be created
+    # zone = "us-central1-f"
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = storage_control_client.common_project_path("_")
+    bucket_path = f"{project_path}/buckets/{bucket_name}"
+    cache_path = f"{bucket_path}/anywhereCaches/{zone}"
+
+    anywhere_cache = storage_control_v2.AnywhereCache(
+        name=cache_path,
+        zone=zone,
+    )
+
+    request = storage_control_v2.CreateAnywhereCacheRequest(
+        parent=bucket_path,
+        anywhere_cache=anywhere_cache,
+    )
+
+    operation = storage_control_client.create_anywhere_cache(request=request)
+
+    print("Waiting for operation to complete...")
+    response = operation.result()
+
+    print(f"Created anywhere cache: {response.name}")
+
+
+# [END storage_control_create_anywhere_cache]
+
+
+if __name__ == "__main__":
+    create_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/anywhere_cache_disable.py
+++ b/storagecontrol/anywhere_cache_disable.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_disable_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def disable_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone where the cache was created
+    # zone = "us-central1-f"
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = storage_control_client.common_project_path("_")
+    cache_path = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.DisableAnywhereCacheRequest(
+        name=cache_path,
+    )
+    response = storage_control_client.disable_anywhere_cache(request=request)
+
+    print(f"Disabled anywhere cache: {response.name}")
+
+
+# [END storage_control_disable_anywhere_cache]
+
+
+if __name__ == "__main__":
+    disable_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/anywhere_cache_get.py
+++ b/storagecontrol/anywhere_cache_get.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_get_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def get_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone where the cache was created
+    # zone = "us-central1-f"
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = storage_control_client.common_project_path("_")
+    cache_path = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.GetAnywhereCacheRequest(
+        name=cache_path,
+    )
+    response = storage_control_client.get_anywhere_cache(request=request)
+
+    print(f"Got anywhere cache: {response.name}")
+
+
+# [END storage_control_get_anywhere_cache]
+
+
+if __name__ == "__main__":
+    get_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/anywhere_cache_list.py
+++ b/storagecontrol/anywhere_cache_list.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_list_anywhere_caches]
+from google.cloud import storage_control_v2
+
+
+def list_anywhere_caches(bucket_name: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = storage_control_client.common_project_path("_")
+    bucket_path = f"{project_path}/buckets/{bucket_name}"
+
+    request = storage_control_v2.ListAnywhereCachesRequest(
+        parent=bucket_path,
+    )
+    page_result = storage_control_client.list_anywhere_caches(request=request)
+
+    for response in page_result:
+        print(response.name)
+
+
+# [END storage_control_list_anywhere_caches]
+
+
+if __name__ == "__main__":
+    list_anywhere_caches(bucket_name=sys.argv[1])

--- a/storagecontrol/anywhere_cache_pause.py
+++ b/storagecontrol/anywhere_cache_pause.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_pause_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def pause_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone where the cache was created
+    # zone = "us-central1-f"
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = storage_control_client.common_project_path("_")
+    cache_path = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.PauseAnywhereCacheRequest(
+        name=cache_path,
+    )
+    response = storage_control_client.pause_anywhere_cache(request=request)
+
+    print(f"Paused anywhere cache: {response.name}")
+
+
+# [END storage_control_pause_anywhere_cache]
+
+
+if __name__ == "__main__":
+    pause_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/anywhere_cache_resume.py
+++ b/storagecontrol/anywhere_cache_resume.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_resume_anywhere_cache]
+from google.cloud import storage_control_v2
+
+
+def resume_anywhere_cache(bucket_name: str, zone: str) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone where the cache was created
+    # zone = "us-central1-f"
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = storage_control_client.common_project_path("_")
+    cache_path = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    request = storage_control_v2.ResumeAnywhereCacheRequest(
+        name=cache_path,
+    )
+    response = storage_control_client.resume_anywhere_cache(request=request)
+
+    print(f"Resumed anywhere cache: {response.name}")
+
+
+# [END storage_control_resume_anywhere_cache]
+
+
+if __name__ == "__main__":
+    resume_anywhere_cache(bucket_name=sys.argv[1], zone=sys.argv[2])

--- a/storagecontrol/anywhere_cache_update.py
+++ b/storagecontrol/anywhere_cache_update.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+# [START storage_control_update_anywhere_cache]
+from google.cloud import storage_control_v2
+from google.protobuf import duration_pb2
+from google.protobuf import field_mask_pb2
+
+
+def update_anywhere_cache(bucket_name: str, zone: str, ttl_seconds: int) -> None:
+    # The ID of your GCS bucket
+    # bucket_name = "your-unique-bucket-name"
+
+    # The zone where the cache was created
+    # zone = "us-central1-f"
+
+    # The new TTL in seconds
+    # ttl_seconds = 86400
+
+    storage_control_client = storage_control_v2.StorageControlClient()
+
+    # The storage bucket path uses the global access pattern, in which the "_"
+    # denotes this bucket exists in the global namespace.
+    project_path = storage_control_client.common_project_path("_")
+    cache_path = f"{project_path}/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    anywhere_cache = storage_control_v2.AnywhereCache(
+        name=cache_path,
+        ttl=duration_pb2.Duration(seconds=ttl_seconds),
+    )
+
+    update_mask = field_mask_pb2.FieldMask(paths=["ttl"])
+
+    request = storage_control_v2.UpdateAnywhereCacheRequest(
+        anywhere_cache=anywhere_cache,
+        update_mask=update_mask,
+    )
+
+    operation = storage_control_client.update_anywhere_cache(request=request)
+
+    print("Waiting for operation to complete...")
+    response = operation.result()
+
+    print(f"Updated anywhere cache: {response.name}")
+
+
+# [END storage_control_update_anywhere_cache]
+
+
+if __name__ == "__main__":
+    update_anywhere_cache(
+        bucket_name=sys.argv[1], zone=sys.argv[2], ttl_seconds=int(sys.argv[3])
+    )

--- a/storagecontrol/snippets_test.py
+++ b/storagecontrol/snippets_test.py
@@ -16,6 +16,13 @@ from google.cloud import storage
 
 import pytest
 
+import anywhere_cache_create
+import anywhere_cache_disable
+import anywhere_cache_get
+import anywhere_cache_list
+import anywhere_cache_pause
+import anywhere_cache_resume
+import anywhere_cache_update
 import create_folder
 import delete_folder
 import get_folder
@@ -25,6 +32,8 @@ import managed_folder_delete
 import managed_folder_get
 import managed_folder_list
 import rename_folder
+import time
+
 
 
 # === Folders === #
@@ -103,3 +112,77 @@ def test_managed_folder_create_get_list_delete(
     )
     out, _ = capsys.readouterr()
     assert folder_name in out
+
+
+# === Anywhere Cache === #
+
+
+def test_anywhere_cache_lifecycle(
+    capsys: pytest.LogCaptureFixture, gcs_bucket: storage.Bucket
+) -> None:
+    bucket_name = gcs_bucket.name
+    zone = "us-central1-f"
+    cache_name = f"projects/_/buckets/{bucket_name}/anywhereCaches/{zone}"
+
+    try:
+        # Create
+        anywhere_cache_create.create_anywhere_cache(
+            bucket_name=bucket_name, zone=zone
+        )
+        out, _ = capsys.readouterr()
+        assert f"Created anywhere cache: {cache_name}" in out
+
+        # Pace calls due to Anywhere Cache rate limit constraints
+        time.sleep(1)
+
+        # Get
+        anywhere_cache_get.get_anywhere_cache(bucket_name=bucket_name, zone=zone)
+        out, _ = capsys.readouterr()
+        assert f"Got anywhere cache: {cache_name}" in out
+
+        time.sleep(1)
+
+        # List
+        anywhere_cache_list.list_anywhere_caches(bucket_name=bucket_name)
+        out, _ = capsys.readouterr()
+        assert cache_name in out
+
+        time.sleep(1)
+
+        # Update
+        anywhere_cache_update.update_anywhere_cache(
+            bucket_name=bucket_name, zone=zone, ttl_seconds=86400
+        )
+        out, _ = capsys.readouterr()
+        assert f"Updated anywhere cache: {cache_name}" in out
+
+        time.sleep(1)
+
+        # Pause
+        anywhere_cache_pause.pause_anywhere_cache(
+            bucket_name=bucket_name, zone=zone
+        )
+        out, _ = capsys.readouterr()
+        assert f"Paused anywhere cache: {cache_name}" in out
+
+        time.sleep(1)
+
+        # Resume
+        anywhere_cache_resume.resume_anywhere_cache(
+            bucket_name=bucket_name, zone=zone
+        )
+        out, _ = capsys.readouterr()
+        assert f"Resumed anywhere cache: {cache_name}" in out
+
+        time.sleep(1)
+
+    finally:
+        # Cleanup: Must disable the cache before bucket deletion
+        try:
+            anywhere_cache_disable.disable_anywhere_cache(
+                bucket_name=bucket_name, zone=zone
+            )
+            out, _ = capsys.readouterr()
+            assert f"Disabled anywhere cache: {cache_name}" in out
+        except Exception as e:
+            print(f"Error disabling cache during cleanup: {e}")


### PR DESCRIPTION
Implement Anywhere Cache (Rapid Cache) lifecycle operations (create, get, list, update, pause, resume, disable) in GCS Python samples.