### PR TITLE
fix: remove kokoro as required for running

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,15 +2,17 @@
 
 Fixes #<ISSUE-NUMBER>
 
-Note: Before submitting a pull request, please open an issue for discussion if you are not associated with Google.
-
 ## Checklist
-- [ ] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
-- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
-- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
-- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
-- [ ] These samples need a new **API enabled** in testing projects to pass (let us know which ones)
-- [ ] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
-- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
-- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
+
+### Testing
+- [ ] **I have tested this change on a live environment and verified it works as intended.**
+
+### Compliance & Style
+- [ ] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
+- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
+- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).
+
+---
+
+## Post-Approval Actions
 - [ ] Please **merge** this PR for me once it is approved

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -43,8 +43,6 @@ branchProtectionRules:
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
     - "Lint"
-    # - "Kokoro CI - Python 3.9"
-    # - "Kokoro CI - Python 3.13"
     - "cla/google"
     - "snippet-bot check"
 # List of explicit permissions to add (additive only)

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -42,20 +42,12 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   # List of required status check contexts that must pass for commits to be accepted to matching branches.
   requiredStatusCheckContexts:
-    - "Kokoro CI - Lint"
-    - "Kokoro CI - Python 3.9"
-    - "Kokoro CI - Python 3.13"
+    - "Lint"
+    # - "Kokoro CI - Python 3.9"
+    # - "Kokoro CI - Python 3.13"
     - "cla/google"
     - "snippet-bot check"
 # List of explicit permissions to add (additive only)
 permissionRules:
-    # Team slug to add to repository permissions
-  - team: yoshi-admins
-    # Access level required, one of push|pull|admin
-    permission: admin
-  - team: yoshi-python-admins
-    permission: admin
-  - team: yoshi-python
-    permission: push
   - team: python-samples-owners
     permission: admin


### PR DESCRIPTION
## Description

* removes broken kokoro testing and the defunct yoshi teams. 
* updates checklist to reflect changes in testing guidance and improve sample contributor experience

replaces #14263
