### PR TITLE
feat: add Data Engineering Agent A2A client example [1/3]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,6 +87,7 @@
 /connectgateway/**/*                   @GoogleCloudPlatform/connectgateway @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /dlp/**/*                              @GoogleCloudPlatform/googleapis-dlp @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /functions/spanner/*                   @GoogleCloudPlatform/api-spanner-python @GoogleCloudPlatform/functions-framework-google @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
+/geminidataanalytics/**/*              @GoogleCloudPlatform/data-engineering-agent-team @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /healthcare/**/*                       @GoogleCloudPlatform/healthcare-life-sciences @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /retail/**/*                           @GoogleCloudPlatform/cloud-retail-team @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /billing/**/*                          @GoogleCloudPlatform/billing-samples-maintainers @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers

--- a/geminidataanalytics/dataengineeringagent/requirements.txt
+++ b/geminidataanalytics/dataengineeringagent/requirements.txt
@@ -1,0 +1,3 @@
+a2a-sdk==1.0.3
+httpx==0.28.1
+google-auth==2.52.0


### PR DESCRIPTION
## Description

Adds a sample Python client implementation using the Agent-to-Agent (A2A) protocol to interact with the Google Cloud Data Engineering Agent.

Key features:
- A2A SDK integration for discovery and client creation.
- ADC authentication support.
- Multi-turn conversation state persistence via local tokens.
- Handling of DEADLINE_EXCEEDED with automated resumption.
- Support for custom agent instructions.

Part of #14252 this PR add the directory owner and requirements

## Checklist

### Testing
- [ x] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [ x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ x] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ x] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [ x] Please **merge** this PR for me once it is approved
