### PR TITLE
 chore(multiple samples): update google-cloud-aiplatform dependency 

### DIFF
--- a/gemma2/requirements.txt
+++ b/gemma2/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform[full]==1.157.0
 protobuf==5.29.5

--- a/gemma2/requirements.txt
+++ b/gemma2/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-aiplatform[all]==1.64.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 protobuf==5.29.5

--- a/generative_ai/embeddings/requirements.txt
+++ b/generative_ai/embeddings/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.84.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.29.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/embeddings/requirements.txt
+++ b/generative_ai/embeddings/requirements.txt
@@ -1,8 +1,8 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.29.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/evaluation/requirements.txt
+++ b/generative_ai/evaluation/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= '3.10'
-langchain-google-vertexai==3.2.3; python_version >= '3.10'
+langchain-core==1.4.0
+langchain-google-vertexai==3.2.3
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/evaluation/requirements.txt
+++ b/generative_ai/evaluation/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.69.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/extensions/requirements.txt
+++ b/generative_ai/extensions/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= '3.10'
-langchain-google-vertexai==3.2.3; python_version >= '3.10'
+langchain-core==1.4.0
+langchain-google-vertexai==3.2.3
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/extensions/requirements.txt
+++ b/generative_ai/extensions/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.69.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/function_calling/requirements.txt
+++ b/generative_ai/function_calling/requirements.txt
@@ -1,3 +1,3 @@
 google-auth==2.38.0
 openai==1.68.2
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0

--- a/generative_ai/function_calling/requirements.txt
+++ b/generative_ai/function_calling/requirements.txt
@@ -1,3 +1,3 @@
 google-auth==2.38.0
 openai==1.68.2
-google-cloud-aiplatform==1.86.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"

--- a/generative_ai/function_calling/requirements.txt
+++ b/generative_ai/function_calling/requirements.txt
@@ -1,3 +1,3 @@
 google-auth==2.38.0
 openai==1.68.2
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"

--- a/generative_ai/image_generation/requirements.txt
+++ b/generative_ai/image_generation/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= '3.10'
-langchain-google-vertexai==3.2.3; python_version >= '3.10'
+langchain-core==1.4.0
+langchain-google-vertexai==3.2.3
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/image_generation/requirements.txt
+++ b/generative_ai/image_generation/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.69.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/labels/requirements.txt
+++ b/generative_ai/labels/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform==1.133.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"

--- a/generative_ai/labels/requirements.txt
+++ b/generative_ai/labels/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"

--- a/generative_ai/labels/requirements.txt
+++ b/generative_ai/labels/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0

--- a/generative_ai/model_garden/requirements.txt
+++ b/generative_ai/model_garden/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= '3.10'
-langchain-google-vertexai==3.2.3; python_version >= '3.10'
+langchain-core==1.4.0
+langchain-google-vertexai==3.2.3
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/model_garden/requirements.txt
+++ b/generative_ai/model_garden/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.69.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/model_tuning/requirements.txt
+++ b/generative_ai/model_tuning/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= '3.10'
-langchain-google-vertexai==3.2.3; python_version >= '3.10'
+langchain-core==1.4.0
+langchain-google-vertexai==3.2.3
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/model_tuning/requirements.txt
+++ b/generative_ai/model_tuning/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.69.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/prompts/requirements.txt
+++ b/generative_ai/prompts/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.74.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0

--- a/generative_ai/prompts/requirements.txt
+++ b/generative_ai/prompts/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= '3.10'
-langchain-google-vertexai==3.2.3; python_version >= '3.10'
+langchain-core==1.4.0
+langchain-google-vertexai==3.2.3
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/provisioned_throughput/requirements.txt
+++ b/generative_ai/provisioned_throughput/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0
 google-auth==2.38.0

--- a/generative_ai/provisioned_throughput/requirements.txt
+++ b/generative_ai/provisioned_throughput/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-aiplatform==1.82.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 google-auth==2.38.0

--- a/generative_ai/provisioned_throughput/requirements.txt
+++ b/generative_ai/provisioned_throughput/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"
 google-auth==2.38.0

--- a/generative_ai/rag/requirements.txt
+++ b/generative_ai/rag/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform==1.87.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"

--- a/generative_ai/rag/requirements.txt
+++ b/generative_ai/rag/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"

--- a/generative_ai/rag/requirements.txt
+++ b/generative_ai/rag/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0

--- a/generative_ai/reasoning_engine/requirements.txt
+++ b/generative_ai/reasoning_engine/requirements.txt
@@ -1,13 +1,13 @@
 pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+pillow==12.2.0
+google-cloud-aiplatform[full]==1.157.0
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
-langchain-core==1.4.0; python_version >= '3.10'
-langchain-google-vertexai==3.2.3; python_version >= '3.10'
+langchain-core==1.4.0
+langchain-google-vertexai==3.2.3
 numpy<3
 openai==1.68.2
 immutabledict==4.2.0

--- a/generative_ai/reasoning_engine/requirements.txt
+++ b/generative_ai/reasoning_engine/requirements.txt
@@ -2,7 +2,7 @@ pandas==2.2.3; python_version == '3.7'
 pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0; python_version >= '3.10'
-google-cloud-aiplatform[all]==1.69.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 sentencepiece==0.2.0
 google-auth==2.38.0
 anthropic[vertex]==0.28.0

--- a/model_garden/gemma/requirements.txt
+++ b/model_garden/gemma/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform[full]==1.157.0

--- a/model_garden/gemma/requirements.txt
+++ b/model_garden/gemma/requirements.txt
@@ -1,1 +1,1 @@
-google-cloud-aiplatform[all]==1.103.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"

--- a/people-and-planet-ai/geospatial-classification/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements.txt
@@ -1,5 +1,5 @@
 earthengine-api==1.5.9
 folium==0.19.5
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"
 pandas==2.2.3
 tensorflow==2.12.0

--- a/people-and-planet-ai/geospatial-classification/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements.txt
@@ -1,5 +1,5 @@
 earthengine-api==1.5.9
 folium==0.19.5
-google-cloud-aiplatform==1.47.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 pandas==2.2.3
 tensorflow==2.12.0

--- a/people-and-planet-ai/geospatial-classification/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements.txt
@@ -1,5 +1,5 @@
 earthengine-api==1.5.9
 folium==0.19.5
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0
 pandas==2.2.3
 tensorflow==2.12.0

--- a/people-and-planet-ai/image-classification/requirements.txt
+++ b/people-and-planet-ai/image-classification/requirements.txt
@@ -1,3 +1,3 @@
 pillow==12.2.0; python_version >= "3.10"
 apache-beam[gcp]==2.55.1
-google-cloud-aiplatform==1.47.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"

--- a/people-and-planet-ai/image-classification/requirements.txt
+++ b/people-and-planet-ai/image-classification/requirements.txt
@@ -1,3 +1,3 @@
 pillow==12.2.0; python_version >= "3.10"
 apache-beam[gcp]==2.55.1
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"

--- a/people-and-planet-ai/image-classification/requirements.txt
+++ b/people-and-planet-ai/image-classification/requirements.txt
@@ -1,3 +1,3 @@
-pillow==12.2.0; python_version >= "3.10"
+pillow==12.2.0
 apache-beam[gcp]==2.55.1
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0

--- a/people-and-planet-ai/land-cover-classification/requirements.txt
+++ b/people-and-planet-ai/land-cover-classification/requirements.txt
@@ -2,7 +2,7 @@
 apache-beam[gcp]==2.46.0
 earthengine-api==1.5.9
 folium==0.19.5
-google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"
 imageio==2.36.1
 plotly==5.15.0
 tensorflow==2.12.0

--- a/people-and-planet-ai/land-cover-classification/requirements.txt
+++ b/people-and-planet-ai/land-cover-classification/requirements.txt
@@ -2,7 +2,7 @@
 apache-beam[gcp]==2.46.0
 earthengine-api==1.5.9
 folium==0.19.5
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0
 imageio==2.36.1
 plotly==5.15.0
 tensorflow==2.12.0

--- a/people-and-planet-ai/land-cover-classification/requirements.txt
+++ b/people-and-planet-ai/land-cover-classification/requirements.txt
@@ -2,7 +2,7 @@
 apache-beam[gcp]==2.46.0
 earthengine-api==1.5.9
 folium==0.19.5
-google-cloud-aiplatform==1.47.0
+google-cloud-aiplatform[full]==1.157.0; python_version >= "3.10"
 imageio==2.36.1
 plotly==5.15.0
 tensorflow==2.12.0

--- a/people-and-planet-ai/timeseries-classification/requirements.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.1.3; python_version >= '3.9'
 apache-beam[gcp]==2.46.0
-google-cloud-aiplatform==1.47.0
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"
 gunicorn==23.0.0
 pandas==2.2.3
 tensorflow==2.12.1

--- a/people-and-planet-ai/timeseries-classification/requirements.txt
+++ b/people-and-planet-ai/timeseries-classification/requirements.txt
@@ -1,6 +1,6 @@
 Flask==3.1.3; python_version >= '3.9'
 apache-beam[gcp]==2.46.0
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0
 gunicorn==23.0.0
 pandas==2.2.3
 tensorflow==2.12.1

--- a/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
@@ -1,3 +1,3 @@
 ../../serving/weather-model
 build==0.10.0
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0

--- a/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
+++ b/people-and-planet-ai/weather-forecasting/tests/training_tests/requirements.txt
@@ -1,3 +1,3 @@
 ../../serving/weather-model
 build==0.10.0
-google-cloud-aiplatform==1.47.0
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"

--- a/translate/samples/snippets/requirements.txt
+++ b/translate/samples/snippets/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-translate==3.18.0
 google-cloud-storage==2.9.0
 google-cloud-automl==2.14.1
-google-cloud-aiplatform==1.157.0; python_version >= "3.10"
+google-cloud-aiplatform==1.157.0

--- a/translate/samples/snippets/requirements.txt
+++ b/translate/samples/snippets/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-translate==3.18.0
 google-cloud-storage==2.9.0
 google-cloud-automl==2.14.1
-google-cloud-aiplatform[vertexai]
+google-cloud-aiplatform==1.157.0; python_version >= "3.10"


### PR DESCRIPTION

## Description

With the intention to solve dependabot security alerts:

 - Update google-cloud-aiplatform to 1.157.0 across all samples
 - Removed pin google-cloud-aiplatform dependency to python 3.10 and newer

Fixes b/521869719

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [ ] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [ ] Please **merge** this PR for me once it is approved
