### PR TITLE
 chore(multiple samples): update cryptography to 48.0.1 and clean up pins

### DIFF
--- a/compute/encryption/requirements.txt
+++ b/compute/encryption/requirements.txt
@@ -1,5 +1,5 @@
-cryptography==45.0.1
-requests==2.34.2; python_version >= '3.10'
+cryptography==48.0.1
+requests==2.34.2
 google-api-python-client==2.131.0
 google-auth==2.38.0
 google-auth-httplib2==0.2.0

--- a/iap/requirements.txt
+++ b/iap/requirements.txt
@@ -1,8 +1,8 @@
-cryptography==46.0.7
+cryptography==48.0.1
 Flask==3.1.3; python_version >= '3.9'
 google-auth==2.38.0
 gunicorn==23.0.0
-requests==2.34.2; python_version >= '3.10'
+requests==2.34.2
 requests-toolbelt==1.0.0
 Werkzeug==3.1.8; python_version >= '3.9'
 google-cloud-iam~=2.17.0

--- a/kms/attestations/requirements.txt
+++ b/kms/attestations/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==45.0.1
+cryptography==48.0.1
 pem==23.1.0; python_version < '3.8'
 pem==23.1.0; python_version > '3.7'
-requests==2.34.2; python_version >= '3.10'
+requests==2.34.2

--- a/kms/snippets/requirements.txt
+++ b/kms/snippets/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-kms==3.11.0
-cryptography==45.0.1
+cryptography==48.0.1
 crcmod==1.7
 jwcrypto==1.5.6

--- a/media_cdn/requirements.txt
+++ b/media_cdn/requirements.txt
@@ -1,2 +1,2 @@
 six==1.16.0
-cryptography==45.0.1
+cryptography==48.0.1

--- a/privateca/snippets/requirements-test.txt
+++ b/privateca/snippets/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3
 google-auth==2.38.0
-cryptography==45.0.1
+cryptography==48.0.1
 backoff==2.2.1


### PR DESCRIPTION

## Description

The purpose is to solve dependabot security alerts:

 - Update cryptography dependency to version 48.0.1
 - Remove unnecessary python >= 3.10 version pins

Fixes b/512538784
## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
