### PR TITLE
 chore(multiple samples): update protobuf to 7.35.0 and clean up pins

### DIFF
--- a/dataflow/gemma/requirements.txt
+++ b/dataflow/gemma/requirements.txt
@@ -1,4 +1,4 @@
 apache_beam[gcp]==2.54.0
-protobuf==4.25.0
+protobuf==7.35.0
 keras_nlp==0.8.2
 keras==3.0.5

--- a/functions/v2/datastore/hello-datastore/requirements.txt
+++ b/functions/v2/datastore/hello-datastore/requirements.txt
@@ -2,5 +2,5 @@ functions-framework==3.9.2
 google-events==0.14.0
 google-cloud-datastore==2.20.2
 google-api-core==2.17.1
-protobuf==4.25.8
+protobuf==7.35.0
 cloudevents==1.11.0

--- a/functions/v2/firebase/hello-firestore/requirements.txt
+++ b/functions/v2/firebase/hello-firestore/requirements.txt
@@ -1,5 +1,5 @@
 functions-framework==3.9.2
 google-events==0.14.0
 google-api-core==2.17.1
-protobuf==4.25.6
+protobuf==7.35.0
 cloudevents==1.11.0

--- a/functions/v2/firebase/upper-firestore/requirements.txt
+++ b/functions/v2/firebase/upper-firestore/requirements.txt
@@ -1,6 +1,6 @@
 functions-framework==3.9.2
 google-events==0.14.0
 google-api-core==2.17.1
-protobuf==4.25.6
+protobuf==7.35.0
 google-cloud-firestore==2.19.0
 cloudevents==1.11.0

--- a/gemma2/requirements.txt
+++ b/gemma2/requirements.txt
@@ -1,2 +1,2 @@
 google-cloud-aiplatform[all]==1.64.0
-protobuf==5.29.5
+protobuf==7.35.0

--- a/managedkafka/snippets/connect/clusters/requirements.txt
+++ b/managedkafka/snippets/connect/clusters/requirements.txt
@@ -1,5 +1,5 @@
-protobuf==5.29.4
-pytest==9.0.3; python_version >= "3.10"
+protobuf==7.35.0
+pytest==9.0.3
 google-api-core==2.23.0
 google-auth==2.38.0
 google-cloud-managedkafka==0.1.12

--- a/managedkafka/snippets/requirements.txt
+++ b/managedkafka/snippets/requirements.txt
@@ -1,5 +1,5 @@
-protobuf==5.29.4
-pytest==9.0.3; python_version >= "3.10"
+protobuf==7.35.0
+pytest==9.0.3
 google-api-core==2.23.0
 google-auth==2.38.0
 google-cloud-managedkafka==0.1.12

--- a/secretmanager/snippets/requirements.txt
+++ b/secretmanager/snippets/requirements.txt
@@ -1,4 +1,4 @@
 google-cloud-resource-manager==1.14.2
 google-cloud-secret-manager==2.24.0
 google-crc32c==1.6.0
-protobuf==5.29.4
+protobuf==7.35.0


### PR DESCRIPTION

## Description

 With the objective to solve dependabot security alerts:
 
 - Update protobuf dependency to version 7.35.0
 - Remove unnecessary python >= 3.10 version pins

Fixes b/521868313
## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
