### PR TITLE
fix: address inconsistent runtime_version with ubuntu

### DIFF
--- a/appengine/flexible/hello_world/app.yaml
+++ b/appengine/flexible/hello_world/app.yaml
@@ -18,7 +18,7 @@ entrypoint: gunicorn -b :$PORT main:app
 
 runtime_config:
   operating_system: ubuntu24
-  runtime_version: 3.12
+  runtime_version: 3.14
 
 # This sample incurs costs to run on the App Engine flexible environment.
 # The settings below are to reduce costs during testing and are not appropriate


### PR DESCRIPTION
## Description

Fixes #<ISSUE-NUMBER>

as per documentation guidance on the support for versions https://docs.cloud.google.com/appengine/docs/flexible/lifecycle/support-schedule#python

ubuntu 24.04 requires python 3.14
