### PR TITLE
 chore(gemma2/dataflow): update google-cloud-aiplatform and protobuf for gemma2

### DIFF
--- a/dataflow/gemma-flex-template/requirements-test.txt
+++ b/dataflow/gemma-flex-template/requirements-test.txt
@@ -1,4 +1,4 @@
-google-cloud-aiplatform==1.62.0
+google-cloud-aiplatform==1.158.0
 google-cloud-dataflow-client==0.8.14
 google-cloud-pubsub==2.28.0
 google-cloud-storage==2.18.2

--- a/dataflow/gemma/requirements-test.txt
+++ b/dataflow/gemma/requirements-test.txt
@@ -1,4 +1,4 @@
-google-cloud-aiplatform==1.49.0
+google-cloud-aiplatform==1.158.0
 google-cloud-dataflow-client==0.8.10
 google-cloud-storage==2.16.0
 pytest==9.0.3; python_version >= "3.10"

--- a/dataflow/run-inference/requirements-test.txt
+++ b/dataflow/run-inference/requirements-test.txt
@@ -1,4 +1,4 @@
-google-cloud-aiplatform==1.57.0
+google-cloud-aiplatform==1.158.0
 google-cloud-dataflow-client==0.8.14
 google-cloud-storage==2.10.0
 pytest==9.0.3; python_version >= "3.10"

--- a/gemma2/requirements-test.txt
+++ b/gemma2/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/gemma2/requirements.txt
+++ b/gemma2/requirements.txt
@@ -1,2 +1,2 @@
-google-cloud-aiplatform[full]==1.157.0
-protobuf==5.29.5
+google-cloud-aiplatform==1.158.0
+protobuf==6.33.6


### PR DESCRIPTION

## Description

 - Update `google-cloud-aiplatform` to 1.158.0 in `gemma2/` and `dataflow/` samples
 - Update `protobuf` to 6.33.6 in `gemma2/`
 - Remove python version constraint for pytest in `gemma2/`

Fixes b/8400024

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [ ] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [ ] Please **merge** this PR for me once it is approved
