### PR TITLE
 feat(logging): update write_entry snippet to use Python logging framework

### DIFF
--- a/logging/samples/snippets/requirements-test.txt
+++ b/logging/samples/snippets/requirements-test.txt
@@ -1,2 +1,2 @@
 backoff==2.2.1
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/logging/samples/snippets/snippets.py
+++ b/logging/samples/snippets/snippets.py
@@ -22,35 +22,38 @@ documentation at https://cloud.google.com/logging/docs.
 """
 
 import argparse
+import logging
+import time
 
-from google.cloud import logging
+import google.cloud.logging
 
 
 # [START logging_write_log_entry]
-def write_entry(logger_name):
+def write_entry():
     """Writes log entries to the given logger."""
-    logging_client = logging.Client()
+    logging_client = google.cloud.logging.Client()
 
-    # This log can be found in the Cloud Logging console under 'Custom Logs'.
-    logger = logging_client.logger(logger_name)
+    # By default, all logs sent through setup_logging()
+    # appear under the log name projects/[PROJECT_ID]/logs/python
+    logging_client.setup_logging(log_level=logging.INFO)
 
     # Make a simple text log
-    logger.log_text("Hello, world!")
+    logging.info("Hello, world!")
 
     # Simple text log with severity.
-    logger.log_text("Goodbye, world!", severity="WARNING")
+    logging.warning("Goodbye, world!")
 
-    # Struct log. The struct can be any JSON-serializable dictionary.
-    logger.log_struct(
-        {
-            "name": "King Arthur",
-            "quest": "Find the Holy Grail",
-            "favorite_color": "Blue",
-        },
-        severity="INFO",
-    )
+    # Prepare your structured data as a dictionary.
+    json_log = {
+        "name": "King Arthur",
+        "quest": "Find the Holy Grail",
+        "favorite_color": "Blue",
+    }
 
-    print("Wrote logs to {}.".format(logger.name))
+    logging.info("This is a JSON log.", extra={"json_fields": json_log})
+
+    # wait for threads
+    time.sleep(5)
 
 
 # [END logging_write_log_entry]
@@ -105,6 +108,6 @@ if __name__ == "__main__":
     if args.command == "list":
         list_entries(args.logger_name)
     elif args.command == "write":
-        write_entry(args.logger_name)
+        write_entry()
     elif args.command == "delete":
         delete_logger(args.logger_name)

--- a/logging/samples/snippets/snippets.py
+++ b/logging/samples/snippets/snippets.py
@@ -24,14 +24,14 @@ documentation at https://cloud.google.com/logging/docs.
 import argparse
 import time
 
-import logging
-
 import google.cloud.logging
+
+import logging
 
 
 # [START logging_write_log_entry]
 def write_entry():
-    """Writes log entries to the given logger."""
+    """Writes log entries to the default logger."""
     logging_client = google.cloud.logging.Client()
 
     # By default, all logs sent through setup_logging()

--- a/logging/samples/snippets/snippets.py
+++ b/logging/samples/snippets/snippets.py
@@ -34,8 +34,8 @@ def write_entry():
     """Demonstrates how to write log entries to Google Cloud using Python's standard logging library."""
     logging_client = google.cloud.logging.Client()
 
-    # Logs default to projects/[PROJECT_ID]/logs/python unless routed
-    # differently by a custom handler or managed GCP infrastructure.
+    # By default, logs route to projects/[PROJECT_ID]/logs/python
+    # unless overridden by GCP or custom handlers.
     logging_client.setup_logging(log_level=logging.INFO)
 
     # Make a simple text log

--- a/logging/samples/snippets/snippets.py
+++ b/logging/samples/snippets/snippets.py
@@ -31,11 +31,11 @@ import logging
 
 # [START logging_write_log_entry]
 def write_entry():
-    """Writes log entries to the default logger."""
+    """Demonstrates how to write log entries to Google Cloud using Python's standard logging library."""
     logging_client = google.cloud.logging.Client()
 
-    # By default, all logs sent through setup_logging()
-    # appear under the log name projects/[PROJECT_ID]/logs/python
+    # Logs default to projects/[PROJECT_ID]/logs/python unless routed
+    # differently by a custom handler or managed GCP infrastructure.
     logging_client.setup_logging(log_level=logging.INFO)
 
     # Make a simple text log
@@ -53,7 +53,7 @@ def write_entry():
 
     logging.info("This is a JSON log.", extra={"json_fields": json_log})
 
-    # wait for threads
+    # wait for threads to finish working on the background.
     time.sleep(5)
 
 

--- a/logging/samples/snippets/snippets.py
+++ b/logging/samples/snippets/snippets.py
@@ -22,8 +22,9 @@ documentation at https://cloud.google.com/logging/docs.
 """
 
 import argparse
-import logging
 import time
+
+import logging
 
 import google.cloud.logging
 

--- a/logging/samples/snippets/snippets_test.py
+++ b/logging/samples/snippets/snippets_test.py
@@ -25,7 +25,7 @@ import snippets
 TEST_LOGGER_NAME = "example_log_{}".format(uuid.uuid4().hex)
 TEST_TEXT = "Hello, world."
 GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
-DEFAULT_LOG_ID = f"projects/{GOOGLE_CLOUD_PROJECT}/logs/python"
+DEFAULT_LOGGER = f"projects/{GOOGLE_CLOUD_PROJECT}/logs/python"
 
 
 @pytest.fixture
@@ -56,18 +56,17 @@ def test_write(capsys):
         # retrieve logs
         client = logging.Client()
 
-        log_filter = DEFAULT_LOG_ID
+        log_filter = DEFAULT_LOGGER
 
         entries = client.list_entries(
             filter_=log_filter, order_by=logging.DESCENDING, max_results=3
         )
 
-        entry_1 = next(entries)
-        assert entry_1.payload["message"] == "This is a JSON log."
-        entry_2 = next(entries)
-        assert entry_2.payload == "Goodbye, world!"
-        entry_3 = next(entries)
-        assert entry_3.payload == "Hello, world!"
+        retrieved_entries = list(entries)
+
+        assert retrieved_entries[0].payload["message"] == "This is a JSON log."
+        assert retrieved_entries[1].payload == "Goodbye, world!"
+        assert retrieved_entries[2].payload == "Hello, world!"
 
     eventually_consistent_test()
 

--- a/logging/samples/snippets/snippets_test.py
+++ b/logging/samples/snippets/snippets_test.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import uuid
 import os
+import uuid
 
 import backoff
 from google.api_core.exceptions import NotFound

--- a/logging/samples/snippets/snippets_test.py
+++ b/logging/samples/snippets/snippets_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import uuid
+import os
 
 import backoff
 from google.api_core.exceptions import NotFound
@@ -21,9 +22,10 @@ import pytest
 
 import snippets
 
-
 TEST_LOGGER_NAME = "example_log_{}".format(uuid.uuid4().hex)
 TEST_TEXT = "Hello, world."
+GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
+DEFAULT_LOG_ID = f"projects/{GOOGLE_CLOUD_PROJECT}/logs/python"
 
 
 @pytest.fixture
@@ -47,13 +49,25 @@ def test_list(example_log, capsys):
 
 def test_write(capsys):
 
-    snippets.write_entry(TEST_LOGGER_NAME)
+    snippets.write_entry()
 
     @backoff.on_exception(backoff.expo, AssertionError, max_time=120)
     def eventually_consistent_test():
-        snippets.list_entries(TEST_LOGGER_NAME)
-        out, _ = capsys.readouterr()
-        assert TEST_TEXT in out
+        # retrieve logs
+        client = logging.Client()
+
+        log_filter = DEFAULT_LOG_ID
+
+        entries = client.list_entries(
+            filter_=log_filter, order_by=logging.DESCENDING, max_results=3
+        )
+
+        entry_1 = next(entries)
+        assert entry_1.payload["message"] == "This is a JSON log."
+        entry_2 = next(entries)
+        assert entry_2.payload == "Goodbye, world!"
+        entry_3 = next(entries)
+        assert entry_3.payload == "Hello, world!"
 
     eventually_consistent_test()
 


### PR DESCRIPTION


## Description

 - Update `write_entry` in `snippets.py` to use `google.cloud.logging.setup_logging()` instead of calling the client logger methods directly.
 - Demonstrate writing a structured JSON log using the standard `logging` library's `extra` parameter.
 - Update `test_write` in `snippets_test.py` to verify logs written via the default python logging handler.
 - Remove python version constraint for pytest in `requirements-test.txt`.

Fixes b/234303347

## Checklist

### Testing
- [x] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
