### PR TITLE
chore(secretmanager): format snippets and update dependencies

### DIFF
--- a/secretmanager/snippets/create_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/create_secret_with_delayed_destroy.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="id of the GCP project")
     parser.add_argument("secret_id", help="id of the secret to create")
     parser.add_argument(
-        "version_destroy_ttl", help="version_destroy_ttl you want to add"
+        "version_destroy_ttl", type=int, help="version_destroy_ttl you want to add"
     )
     args = parser.parse_args()
 

--- a/secretmanager/snippets/create_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/create_secret_with_delayed_destroy.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("project_id", help="id of the Google Cloud project")
     parser.add_argument("secret_id", help="id of the secret to create")
     parser.add_argument(
         "version_destroy_ttl", type=int, help="version_destroy_ttl you want to add"

--- a/secretmanager/snippets/create_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/create_secret_with_delayed_destroy.py
@@ -60,6 +60,7 @@ def create_secret_with_delayed_destroy(
 
     return response
 
+
 # [END secretmanager_create_secret_with_delayed_destroy]
 
 
@@ -69,7 +70,11 @@ if __name__ == "__main__":
     )
     parser.add_argument("project_id", help="id of the GCP project")
     parser.add_argument("secret_id", help="id of the secret to create")
-    parser.add_argument("version_destroy_ttl", help="version_destroy_ttl you want to add")
+    parser.add_argument(
+        "version_destroy_ttl", help="version_destroy_ttl you want to add"
+    )
     args = parser.parse_args()
 
-    create_secret_with_delayed_destroy(args.project_id, args.secret_id, args.version_destroy_ttl)
+    create_secret_with_delayed_destroy(
+        args.project_id, args.secret_id, args.version_destroy_ttl
+    )

--- a/secretmanager/snippets/create_secret_with_tags.py
+++ b/secretmanager/snippets/create_secret_with_tags.py
@@ -47,12 +47,7 @@ def create_secret_with_tags(
         request={
             "parent": parent,
             "secret_id": secret_id,
-            "secret": {
-                "replication": {"automatic": {}},
-                "tags": {
-                    tag_key: tag_value
-                }
-            },
+            "secret": {"replication": {"automatic": {}}, "tags": {tag_key: tag_value}},
         }
     )
 
@@ -74,4 +69,6 @@ if __name__ == "__main__":
     parser.add_argument("tag_value", help="value of the tag you want to add")
     args = parser.parse_args()
 
-    create_secret_with_tags(args.project_id, args.secret_id, args.tag_key, args.tag_value)
+    create_secret_with_tags(
+        args.project_id, args.secret_id, args.tag_key, args.tag_value
+    )

--- a/secretmanager/snippets/disable_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/disable_secret_with_delayed_destroy.py
@@ -37,12 +37,15 @@ def disable_secret_with_delayed_destroy(
     # Delayed destroy of the secret version.
     secret = {"name": name}
     update_mask = {"paths": ["version_destroy_ttl"]}
-    response = client.update_secret(request={"secret": secret, "update_mask": update_mask})
+    response = client.update_secret(
+        request={"secret": secret, "update_mask": update_mask}
+    )
 
     # Print the new secret name.
     print(f"Disabled delayed destroy on secret: {response.name}")
 
     return response
+
 
 # [END secretmanager_disable_secret_delayed_destroy]
 
@@ -55,6 +58,4 @@ if __name__ == "__main__":
     parser.add_argument("secret_id", help="id of the secret from which to act")
     args = parser.parse_args()
 
-    disable_secret_with_delayed_destroy(
-        args.project_id, args.secret_id
-    )
+    disable_secret_with_delayed_destroy(args.project_id, args.secret_id)

--- a/secretmanager/snippets/requirements-test.txt
+++ b/secretmanager/snippets/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/secretmanager/snippets/requirements.txt
+++ b/secretmanager/snippets/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-resource-manager==1.14.2
-google-cloud-secret-manager==2.24.0
-google-crc32c==1.6.0
-protobuf==5.29.4
+protobuf==6.33.6
+google-cloud-resource-manager==1.18.0
+google-cloud-secret-manager==2.29.0
+google-crc32c==1.8.0

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -745,7 +745,7 @@ def test_update_secret_with_alias(secret_version: Tuple[str, str, str, str]) -> 
 
 
 def test_update_secret_with_delayed_destroy(
-    secret_with_delayed_destroy: Tuple[str, str], version_destroy_ttl: str
+    secret_with_delayed_destroy: Tuple[str, str]
 ) -> None:
     project_id, secret_id = secret_with_delayed_destroy
     updated_version_destroy_ttl_value = 118400

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -12,18 +12,16 @@
 # See the License for the specific language governing permissions and
 
 import base64
-from datetime import timedelta
+import uuid
 import os
 import time
+from datetime import timedelta
 from typing import Iterator, Optional, Tuple, Union
-import uuid
 
 from google.api_core import exceptions, retry
 from google.cloud import resourcemanager_v3
 from google.cloud import secretmanager
 from google.protobuf.duration_pb2 import Duration
-
-import pytest
 
 from access_secret_version import access_secret_version
 from add_secret_version import add_secret_version
@@ -63,6 +61,8 @@ from update_secret_with_delayed_destroy import update_secret_with_delayed_destro
 from update_secret_with_etag import update_secret_with_etag
 from view_secret_annotations import view_secret_annotations
 from view_secret_labels import view_secret_labels
+
+import pytest
 
 
 @pytest.fixture()

--- a/secretmanager/snippets/snippets_test.py
+++ b/secretmanager/snippets/snippets_test.py
@@ -468,9 +468,13 @@ def test_create_secret_with_annotations(
 
 def test_create_secret_with_delayed_destroy(
     client: secretmanager.SecretManagerServiceClient,
-    project_id: str, secret_id: str, version_destroy_ttl: int
+    project_id: str,
+    secret_id: str,
+    version_destroy_ttl: int,
 ) -> None:
-    secret = create_secret_with_delayed_destroy(project_id, secret_id, version_destroy_ttl)
+    secret = create_secret_with_delayed_destroy(
+        project_id, secret_id, version_destroy_ttl
+    )
     assert secret_id in secret.name
     assert timedelta(seconds=version_destroy_ttl) == secret.version_destroy_ttl
 
@@ -740,8 +744,14 @@ def test_update_secret_with_alias(secret_version: Tuple[str, str, str, str]) -> 
     assert secret.version_aliases["test"] == 1
 
 
-def test_update_secret_with_delayed_destroy(secret_with_delayed_destroy: Tuple[str, str], version_destroy_ttl: str) -> None:
+def test_update_secret_with_delayed_destroy(
+    secret_with_delayed_destroy: Tuple[str, str], version_destroy_ttl: str
+) -> None:
     project_id, secret_id = secret_with_delayed_destroy
     updated_version_destroy_ttl_value = 118400
-    updated_secret = update_secret_with_delayed_destroy(project_id, secret_id, updated_version_destroy_ttl_value)
-    assert updated_secret.version_destroy_ttl == timedelta(seconds=updated_version_destroy_ttl_value)
+    updated_secret = update_secret_with_delayed_destroy(
+        project_id, secret_id, updated_version_destroy_ttl_value
+    )
+    assert updated_secret.version_destroy_ttl == timedelta(
+        seconds=updated_version_destroy_ttl_value
+    )

--- a/secretmanager/snippets/update_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/update_secret_with_delayed_destroy.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("project_id", help="id of the Google Cloud project")
     parser.add_argument("secret-id", help="id of the secret to act on")
     parser.add_argument("version_destroy_ttl", type=int, help="new version destroy ttl to be added")
     args = parser.parse_args()

--- a/secretmanager/snippets/update_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/update_secret_with_delayed_destroy.py
@@ -36,7 +36,10 @@ def update_secret_with_delayed_destroy(
     name = client.secret_path(project_id, secret_id)
 
     # Update the version_destroy_ttl.
-    secret = {"name": name, "version_destroy_ttl": Duration(seconds=new_version_destroy_ttl)}
+    secret = {
+        "name": name,
+        "version_destroy_ttl": Duration(seconds=new_version_destroy_ttl),
+    }
     update_mask = {"paths": ["version_destroy_ttl"]}
     response = client.update_secret(
         request={"secret": secret, "update_mask": update_mask}
@@ -46,6 +49,7 @@ def update_secret_with_delayed_destroy(
     print(f"Updated secret: {response.name}")
 
     return response
+
 
 # [END secretmanager_update_secret_with_delayed_destroy]
 
@@ -59,4 +63,6 @@ if __name__ == "__main__":
     parser.add_argument("version_destroy_ttl", "new version destroy ttl to be added")
     args = parser.parse_args()
 
-    update_secret_with_delayed_destroy(args.project_id, args.secret_id, args.version_destroy_ttl)
+    update_secret_with_delayed_destroy(
+        args.project_id, args.secret_id, args.version_destroy_ttl
+    )

--- a/secretmanager/snippets/update_secret_with_delayed_destroy.py
+++ b/secretmanager/snippets/update_secret_with_delayed_destroy.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("project_id", help="id of the GCP project")
     parser.add_argument("secret-id", help="id of the secret to act on")
-    parser.add_argument("version_destroy_ttl", "new version destroy ttl to be added")
+    parser.add_argument("version_destroy_ttl", type=int, help="new version destroy ttl to be added")
     args = parser.parse_args()
 
     update_secret_with_delayed_destroy(

--- a/secretmanager/snippets/view_secret_annotations.py
+++ b/secretmanager/snippets/view_secret_annotations.py
@@ -16,6 +16,7 @@
 command line application and sample code for listing annotations of a
 secret.
 """
+
 # [START secretmanager_view_secret_annotations]
 import argparse
 

--- a/secretmanager/snippets/view_secret_labels.py
+++ b/secretmanager/snippets/view_secret_labels.py
@@ -16,6 +16,7 @@
 command line application and sample code for listing labels of a
 secret.
 """
+
 # [START secretmanager_view_secret_labels]
 import argparse
 


### PR DESCRIPTION

## Description

   - Run black formatter on secretmanager snippet files.
   - Update protobuf, google-cloud-resource-manager, google-cloud-secret-manager, and google-crc32c.
   - Remove python version constraint for pytest in requirements-test.txt.


Fixes b/527484406

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [ ] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [ ] Please **merge** this PR for me once it is approved
