### PR TITLE
chore(genai): update sentencepiece dependency

### DIFF
--- a/generative_ai/embeddings/requirements.txt
+++ b/generative_ai/embeddings/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.29.0
 anthropic[vertex]==0.28.0
 numpy<3

--- a/generative_ai/evaluation/requirements.txt
+++ b/generative_ai/evaluation/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
 langchain-core==1.4.0

--- a/generative_ai/extensions/requirements.txt
+++ b/generative_ai/extensions/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
 langchain-core==1.4.0

--- a/generative_ai/image_generation/requirements.txt
+++ b/generative_ai/image_generation/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
 langchain-core==1.4.0

--- a/generative_ai/model_garden/requirements.txt
+++ b/generative_ai/model_garden/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
 langchain-core==1.4.0

--- a/generative_ai/model_tuning/requirements.txt
+++ b/generative_ai/model_tuning/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
 langchain-core==1.4.0

--- a/generative_ai/prompts/requirements.txt
+++ b/generative_ai/prompts/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
 langchain-core==1.4.0

--- a/generative_ai/reasoning_engine/requirements.txt
+++ b/generative_ai/reasoning_engine/requirements.txt
@@ -3,7 +3,7 @@ pandas==2.2.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
 pillow==12.2.0
 google-cloud-aiplatform[full]==1.157.0
-sentencepiece==0.2.0
+sentencepiece==0.2.1
 google-auth==2.38.0
 anthropic[vertex]==0.28.0
 langchain-core==1.4.0


### PR DESCRIPTION

## Description

To fix dependabot security alerts:

   - Bump sentencepiece from 0.2.0 to 0.2.1 across generative_ai samples.

Fixes b/521868650

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
