### PR TITLE
 chore(kubernetes_engine): bump Django to 6.0.6 and remove pytest version constraint

### DIFF
--- a/kubernetes_engine/django_tutorial/requirements-test.txt
+++ b/kubernetes_engine/django_tutorial/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/kubernetes_engine/django_tutorial/requirements.txt
+++ b/kubernetes_engine/django_tutorial/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.1; python_version >= "3.12"
+Django==6.0.6; python_version >= "3.12"
 # Uncomment the mysqlclient requirement if you are using MySQL rather than
 # PostgreSQL. You must also have a MySQL client installed in that case.
 #mysqlclient==1.4.1


### PR DESCRIPTION

## Description

To fix some dependeabot alerts:
- bump Django to 6.0.6 and remove pytest version constraint

Fixes b/530945250

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
