### PR TITLE
 chore(multiple samples): bump TensorFlow and downgrade python/beam on Dockerfiles

### DIFF
--- a/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
@@ -25,7 +25,6 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-        curl g++ python3.13-dev python3.13-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.13 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/Dockerfile
@@ -15,7 +15,7 @@
 # NVIDIA CUDA container: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda
 # Supported NVIDIA images: https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md
 # TensorFlow/CUDA compatibility: https://www.tensorflow.org/install/source#gpu
-FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04
 
 WORKDIR /pipeline
 
@@ -25,9 +25,9 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-        curl g++ python3.14-dev python3.14-venv python3-distutils \
+        curl g++ python3.13-dev python3.13-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.14 10 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.13 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
     # Install the pipeline requirements.
     && pip install --no-cache-dir -r requirements.txt \
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.13_sdk:2.74.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/requirements-test.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/requirements-test.txt
@@ -1,3 +1,3 @@
 google-api-python-client==2.87.0
 google-cloud-storage==2.9.0
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/dataflow/gpu-examples/tensorflow-landsat-prime/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat-prime/requirements.txt
@@ -1,4 +1,4 @@
 pillow==12.2.0; python_version >= "3.10"
-apache-beam[gcp]==2.58.1
+apache-beam[gcp]==2.74.0
 rasterio==1.3.10
-tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu
+tensorflow==2.21.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu

--- a/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
@@ -25,7 +25,6 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-    curl g++ python3.13-dev python3.13-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.13 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \

--- a/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-landsat/Dockerfile
@@ -15,7 +15,7 @@
 # NVIDIA CUDA container: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda
 # Supported NVIDIA images: https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md
 # TensorFlow/CUDA compatibility: https://www.tensorflow.org/install/source#gpu
-FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04
 
 WORKDIR /pipeline
 
@@ -25,9 +25,9 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-    curl g++ python3.14-dev python3.14-venv python3-distutils \
+    curl g++ python3.13-dev python3.13-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.14 10 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.13 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
     # Install the pipeline requirements.
     && pip install --no-cache-dir -r requirements.txt \
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.13_sdk:2.74.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-landsat/requirements-test.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat/requirements-test.txt
@@ -1,3 +1,3 @@
 google-api-python-client==2.87.0
 google-cloud-storage==2.9.0
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/dataflow/gpu-examples/tensorflow-landsat/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-landsat/requirements.txt
@@ -1,4 +1,4 @@
 pillow==12.2.0; python_version >= "3.10"
-apache-beam[gcp]==2.58.1
+apache-beam[gcp]==2.74.0
 rasterio==1.3.10
-tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu
+tensorflow==2.21.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu

--- a/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
@@ -25,7 +25,6 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-        curl g++ python3.13-dev python3.13-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
     && update-alternatives --install /usr/bin/python python /usr/bin/python3.13 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \

--- a/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
+++ b/dataflow/gpu-examples/tensorflow-minimal/Dockerfile
@@ -15,7 +15,7 @@
 # NVIDIA CUDA container: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda
 # Supported NVIDIA images: https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md
 # TensorFlow/CUDA compatibility: https://www.tensorflow.org/install/source#gpu
-FROM nvcr.io/nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04
 
 WORKDIR /pipeline
 
@@ -25,9 +25,9 @@ COPY *.py ./
 RUN apt-get update \
     # Install Python and other system dependencies.
     && apt-get install -y --no-install-recommends \
-        curl g++ python3.14-dev python3.14-venv python3-distutils \
+        curl g++ python3.13-dev python3.13-venv python3-distutils \
     && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.14 10 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.13 10 \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
     # Install the pipeline requirements.
     && pip install --no-cache-dir -r requirements.txt \
@@ -35,5 +35,5 @@ RUN apt-get update \
 
 # Set the entrypoint to Apache Beam SDK worker launcher.
 # Check this matches the apache-beam version in the requirements.txt
-COPY --from=apache/beam_python3.14_sdk:2.73.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.13_sdk:2.74.0 /opt/apache/beam /opt/apache/beam
 ENTRYPOINT [ "/opt/apache/beam/boot" ]

--- a/dataflow/gpu-examples/tensorflow-minimal/requirements-test.txt
+++ b/dataflow/gpu-examples/tensorflow-minimal/requirements-test.txt
@@ -1,3 +1,3 @@
 google-api-python-client==2.131.0
 google-cloud-storage==2.9.0
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/dataflow/gpu-examples/tensorflow-minimal/requirements.txt
+++ b/dataflow/gpu-examples/tensorflow-minimal/requirements.txt
@@ -1,2 +1,2 @@
-apache-beam[gcp]==2.46.0
-tensorflow==2.12.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu
+apache-beam[gcp]==2.74.0
+tensorflow==2.21.0  # Check TensorFlow/CUDA compatibility with Dockerfile: https://www.tensorflow.org/install/source#gpu

--- a/people-and-planet-ai/geospatial-classification/requirements-test.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3
 pytest-xdist==3.3.0

--- a/people-and-planet-ai/geospatial-classification/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/requirements.txt
@@ -2,4 +2,4 @@ earthengine-api==1.5.9
 folium==0.19.5
 google-cloud-aiplatform==1.157.0
 pandas==2.2.3
-tensorflow==2.12.0
+tensorflow==2.21.0

--- a/people-and-planet-ai/geospatial-classification/serving_app/Dockerfile
+++ b/people-and-planet-ai/geospatial-classification/serving_app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/people-and-planet-ai/geospatial-classification/serving_app/requirements.txt
+++ b/people-and-planet-ai/geospatial-classification/serving_app/requirements.txt
@@ -1,4 +1,4 @@
 Flask==3.1.3; python_version >= '3.9'
 gunicorn==23.0.0
-tensorflow==2.12.0
+tensorflow==2.21.0
 Werkzeug==3.1.8; python_version >= '3.9'

--- a/people-and-planet-ai/land-cover-classification/requirements-test.txt
+++ b/people-and-planet-ai/land-cover-classification/requirements-test.txt
@@ -4,4 +4,4 @@ importnb==2023.11.1
 ipykernel==6.23.3
 nbclient==0.8.0
 pytest-xdist==3.3.0
-pytest==9.0.3; python_version >= "3.10"
+pytest==9.0.3

--- a/people-and-planet-ai/land-cover-classification/requirements.txt
+++ b/people-and-planet-ai/land-cover-classification/requirements.txt
@@ -1,8 +1,8 @@
 # Requirements to run the notebooks.
-apache-beam[gcp]==2.46.0
+apache-beam[gcp]==2.74.0
 earthengine-api==1.5.9
 folium==0.19.5
 google-cloud-aiplatform==1.157.0
 imageio==2.36.1
 plotly==5.15.0
-tensorflow==2.12.0
+tensorflow==2.21.0

--- a/people-and-planet-ai/land-cover-classification/serving/requirements.txt
+++ b/people-and-planet-ai/land-cover-classification/serving/requirements.txt
@@ -2,5 +2,5 @@
 Flask==3.1.3; python_version >= '3.9'
 earthengine-api==1.5.9
 gunicorn==23.0.0
-tensorflow==2.12.0
+tensorflow==2.21.0
 Werkzeug==3.1.8; python_version >= '3.9'

--- a/people-and-planet-ai/land-cover-classification/setup.py
+++ b/people-and-planet-ai/land-cover-classification/setup.py
@@ -20,8 +20,8 @@ setup(
     url="https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/people-and-planet-ai/land-cover-classification",
     packages=["serving"],
     install_requires=[
-        "apache-beam[gcp]==2.46.0",
+        "apache-beam[gcp]==2.74.0",
         "earthengine-api==1.5.9",
-        "tensorflow==2.12.0",
+        "tensorflow==2.21.0",
     ],
 )


### PR DESCRIPTION

## Description

Fixing dependabot alerts:

 - Update TensorFlow to 2.21.0 and Apache Beam to 2.74.0 across samples.
 - Modify Dockerfiles to use Python 3.13 and matching beam images due to compatibility with the updated CUDA base image (`12.5.1`).
 - Remove pytest version constraints in `requirements-test.txt`

Fixes b/531809402

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
