### PR TITLE
 chore(bigquery): bump pyarrow to 24.0.0 to fix dependabot alert

### DIFF
--- a/bigquery/bqml/requirements.txt
+++ b/bigquery/bqml/requirements.txt
@@ -2,7 +2,6 @@ google-cloud-bigquery[pandas,bqstorage]==3.27.0
 google-cloud-bigquery-storage==2.27.0
 pandas==2.0.3; python_version == '3.8'
 pandas==2.2.3; python_version > '3.8'
-pyarrow==17.0.0; python_version <= '3.8'
-pyarrow==20.0.0; python_version > '3.9'
+pyarrow==24.0.0
 flaky==3.8.1
 mock==5.1.0

--- a/bigquery/pandas-gbq-migration/requirements.txt
+++ b/bigquery/pandas-gbq-migration/requirements.txt
@@ -5,5 +5,4 @@ pandas==2.2.3; python_version > '3.8'
 pandas-gbq==0.24.0
 grpcio==1.70.0; python_version == '3.8'
 grpcio==1.74.0; python_version > '3.8'
-pyarrow==17.0.0; python_version <= '3.8'
-pyarrow==20.0.0; python_version > '3.9'
+pyarrow==24.0.0

--- a/bigquery_storage/to_dataframe/requirements.txt
+++ b/bigquery_storage/to_dataframe/requirements.txt
@@ -1,17 +1,17 @@
 google-auth==2.40.3
 google-cloud-bigquery-storage==2.32.0
-google-cloud-bigquery===3.30.0; python_version <= '3.8'
+google-cloud-bigquery==3.30.0; python_version <= '3.8'
 google-cloud-bigquery==3.35.1; python_version >= '3.9'
-pyarrow===24.0.0
-ipython===7.31.1; python_version == '3.7'
-ipython===8.10.0; python_version == '3.8'
-ipython===8.18.1; python_version == '3.9'
-ipython===8.33.0; python_version == '3.10'
+pyarrow==24.0.0
+ipython==7.31.1; python_version == '3.7'
+ipython==8.10.0; python_version == '3.8'
+ipython==8.18.1; python_version == '3.9'
+ipython==8.33.0; python_version == '3.10'
 ipython==9.4.0; python_version >= '3.11'
 ipywidgets==8.1.7
-pandas===1.3.5; python_version == '3.7'
-pandas===2.0.3; python_version == '3.8'
+pandas==1.3.5; python_version == '3.7'
+pandas==2.0.3; python_version == '3.8'
 pandas==2.3.1; python_version >= '3.9'
 tqdm==4.67.1
-db-dtypes===1.4.2; python_version <= '3.8'
+db-dtypes==1.4.2; python_version <= '3.8'
 db-dtypes==1.4.3; python_version >= '3.9'

--- a/bigquery_storage/to_dataframe/requirements.txt
+++ b/bigquery_storage/to_dataframe/requirements.txt
@@ -2,9 +2,7 @@ google-auth==2.40.3
 google-cloud-bigquery-storage==2.32.0
 google-cloud-bigquery===3.30.0; python_version <= '3.8'
 google-cloud-bigquery==3.35.1; python_version >= '3.9'
-pyarrow===12.0.1; python_version == '3.7'
-pyarrow===17.0.0; python_version == '3.8'
-pyarrow==21.0.0; python_version >= '3.9'
+pyarrow===24.0.0
 ipython===7.31.1; python_version == '3.7'
 ipython===8.10.0; python_version == '3.8'
 ipython===8.18.1; python_version == '3.9'


### PR DESCRIPTION

## Description

 - Bumped `pyarrow` to 24.0.0 in `bigquery/bqml`, `bigquery/pandas-gbq-migration`, and `bigquery_storage/to_dataframe` to address a Dependabot vulnerability.
 - Simplified dependency entries by removing Python version constraints for `pyarrow`.

Fixes b/532266679

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
