### PR TITLE
 chore(dataflow): bump pyOpenSSL to 26.3.0 to fix dependabot alert

### DIFF
--- a/cloud-media-livestream/keypublisher/requirements.txt
+++ b/cloud-media-livestream/keypublisher/requirements.txt
@@ -3,7 +3,7 @@ functions-framework==3.9.2
 google-cloud-secret-manager==2.21.1
 lxml==5.2.1
 pycryptodome==3.21.0
-pyOpenSSL==25.0.0
+pyOpenSSL==26.3.0
 requests==2.34.2; python_version >= '3.10'
 signxml==4.0.4
 pytest==9.0.3; python_version >= "3.10"

--- a/dataflow/gemma/requirements.txt
+++ b/dataflow/gemma/requirements.txt
@@ -2,4 +2,4 @@ protobuf==6.33.6
 apache_beam[gcp]==2.74.0
 keras==3.14.1
 keras_nlp==0.29.1
-pyOpenSSL==25.3.0
+pyOpenSSL==26.3.0


### PR DESCRIPTION

## Description

 - Updated `pyOpenSSL` to 26.3.0 in `cloud-media-livestream/keypublisher` and `dataflow/gemma` to address a Dependabot vulnerability.

Fixes b/532268582

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [ ] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [ ] Please **merge** this PR for me once it is approved
