### PR TITLE
chore: add alloydb-vector-search-docs to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,7 +55,7 @@
 /storagecontrol/**/*                   @GoogleCloudPlatform/gcs-sdk-team @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /storagetransfer/**/*                  @GoogleCloudPlatform/gcs-sdk-team @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 # ---* Infra DB
-/alloydb/**/*                          @GoogleCloudPlatform/alloydb-connectors-code-owners @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
+/alloydb/**/*                          @GoogleCloudPlatform/alloydb-connectors-code-owners @GoogleCloudPlatform/alloydb-vector-search-docs @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /cloud-sql/**/*                        @GoogleCloudPlatform/cloud-sql-connectors @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 
 # Self-service


### PR DESCRIPTION
Added @GoogleCloudPlatform/alloydb-vector-search-docs as a co-owner of the /alloydb/ directory.

## Description

Fixes #<ISSUE-NUMBER>

## Checklist

### Testing
- [x] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [x] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [x] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
