### PR TITLE
 refactor(genai/labels): replace vertexai.generative_models with genai

### DIFF
--- a/genai/labels/labels_example.py
+++ b/genai/labels/labels_example.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START aiplatform_genai_gemini_set_labels]
+
+import os
+
+from google import genai
+
+PROJECT_ID = os.getenv("GOOGLE_CLOUD_PROJECT")
+LOCATION = os.getenv("LOCATION_ID")
+GEMINI_MODEL = os.getenv("GEMINI_MODEL_ID", "gemini-2.5-flash")
+
+
+def generate_content() -> genai.types.GenerateContentResponse:
+
+    genai_client = genai.Client(enterprise=True, project=PROJECT_ID, location=LOCATION)
+
+    labels = {
+        "environment": "testing",
+        "feature": "genai",
+        "model": "gemini",
+    }
+
+    config = genai.types.GenerateContentConfig(temperature=0.4, labels=labels)
+
+    response = genai_client.models.generate_content(
+        model=GEMINI_MODEL, contents="What is Generative AI?", config=config
+    )
+
+    print(response.text)
+    return response
+
+
+# [END aiplatform_genai_gemini_set_labels]
+
+
+if __name__ == "__main__":
+    generate_content()

--- a/genai/labels/labels_example.py
+++ b/genai/labels/labels_example.py
@@ -44,7 +44,3 @@ def generate_content() -> genai.types.GenerateContentResponse:
 
 
 # [END aiplatform_genai_gemini_set_labels]
-
-
-if __name__ == "__main__":
-    generate_content()

--- a/genai/labels/noxfile_config.py
+++ b/genai/labels/noxfile_config.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/genai/labels/noxfile_config.py
+++ b/genai/labels/noxfile_config.py
@@ -1,0 +1,42 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default TEST_CONFIG_OVERRIDE for python repos.
+
+# You can copy this file into your directory, then it will be imported from
+# the noxfile.py.
+
+# The source of truth:
+# https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/noxfile_config.py
+
+TEST_CONFIG_OVERRIDE = {
+    # You can opt out from the test for specific Python versions.
+    "ignored_versions": ["3.8", "3.9", "3.11", "3.12", "3.13"],
+    # Old samples are opted out of enforcing Python type hints
+    # All new samples should feature them
+    "enforce_type_hints": True,
+    # An envvar key for determining the project id to use. Change it
+    # to 'BUILD_SPECIFIC_GCLOUD_PROJECT' if you want to opt in using a
+    # build specific Cloud project. You can also use your own string
+    # to use your own Cloud project.
+    "gcloud_project_env": "GOOGLE_CLOUD_PROJECT",
+    # 'gcloud_project_env': 'BUILD_SPECIFIC_GCLOUD_PROJECT',
+    # If you need to use a specific version of pip,
+    # change pip_version_override to the string representation
+    # of the version number, for example, "20.2.4"
+    "pip_version_override": None,
+    # A dictionary you want to inject into your test. Don't put any
+    # secrets here. These values will override predefined values.
+    "envs": {},
+}

--- a/genai/labels/requirements-test.txt
+++ b/genai/labels/requirements-test.txt
@@ -1,0 +1,2 @@
+google-api-core==2.32.0
+pytest==9.0.3

--- a/genai/labels/requirements.txt
+++ b/genai/labels/requirements.txt
@@ -1,0 +1,1 @@
+google-genai==2.12.1

--- a/genai/labels/test_labels_examples.py
+++ b/genai/labels/test_labels_examples.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/genai/labels/test_labels_examples.py
+++ b/genai/labels/test_labels_examples.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import labels_example
+
+
+def test_set_labels() -> None:
+    response = labels_example.generate_content()
+    assert response

--- a/genai/labels/test_labels_examples.py
+++ b/genai/labels/test_labels_examples.py
@@ -17,4 +17,4 @@ import labels_example
 
 def test_set_labels() -> None:
     response = labels_example.generate_content()
-    assert response
+    assert response.text


### PR DESCRIPTION
 
## Description

Update the codebase to use the new `genai` SDK replacement for all legacy `vertexai.generative_models` imports and usage.

Fixes b/537370586

## Checklist

### Testing
- [x] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
