### PR TITLE
docs(bigquery/bigframes): add table_insert_rows code sample

### DIFF
--- a/bigquery/bigframes/table_insert_rows.py
+++ b/bigquery/bigframes/table_insert_rows.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START bigquery_bigframes_table_insert_rows]
+import bigframes.pandas as bpd
+
+# Set partial ordering mode as the default configuration for BigQuery
+# DataFrames.
+bpd.options.bigquery.ordering_mode = "partial"
+
+
+def table_insert_rows(
+    table_id: str = "your-project.your_dataset.your_table_name",
+) -> bpd.DataFrame:
+    rows_to_insert = [
+        {"full_name": "Phred Phlyntstone", "age": 32},
+        {"full_name": "Wylma Phlyntstone", "age": 29},
+    ]
+
+    # Create a BigQuery DataFrame from the records.
+    df = bpd.DataFrame(rows_to_insert)
+
+    # Append rows to the destination BigQuery table.
+    df.to_gbq(table_id, if_exists="append")
+    return df
+# [END bigquery_bigframes_table_insert_rows]
+
+
+if __name__ == "__main__":
+    import os
+
+    table_id = os.environ.get(
+        "TABLE_ID", "your-project.your_dataset.your_table_name"
+    )
+    print(table_insert_rows(table_id=table_id))

--- a/bigquery/bigframes/table_insert_rows_test.py
+++ b/bigquery/bigframes/table_insert_rows_test.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import table_insert_rows
+
+
+def test_table_insert_rows(project_id: str, dataset_id: str) -> None:
+    table_id = f"{project_id}.{dataset_id}.table_insert_rows"
+    import bigframes.pandas as bpd
+
+    df = table_insert_rows.table_insert_rows(table_id=table_id)
+    assert df is not None
+
+    # Verify that the rows were actually written to BigQuery
+    df_loaded = bpd.read_gbq(table_id)
+    assert len(df_loaded) == 2


### PR DESCRIPTION
## Description

Fixes b/546157676 (Subtask of b/522898394)

Adds a BigQuery DataFrames (`bigframes`) code sample for inserting/appending rows into a BigQuery table, targeting the high-traffic documentation page [`bigquery-table-insert-rows`](https://cloud.google.com/bigquery/docs/samples/bigquery-table-insert-rows/).

### Summary of Changes
- **New Sample:** Added `bigquery/bigframes/table_insert_rows.py` demonstrating how to append rows to a BigQuery table via `df.to_gbq(table_id, if_exists="append")`.
