### PR TITLE
docs(bigquery/bigframes): add query_dry_run code sample

### DIFF
--- a/bigquery/bigframes/query_dry_run.py
+++ b/bigquery/bigframes/query_dry_run.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START bigquery_bigframes_query_dry_run]
+import bigframes.pandas as bpd
+
+from google.cloud import bigquery
+
+# Set partial ordering mode as the default configuration for BigQuery
+# DataFrames.
+bpd.options.bigquery.ordering_mode = "partial"
+
+
+def query_dry_run() -> int:
+    sql = """
+    SELECT name, COUNT(*) as name_count
+    FROM `bigquery-public-data.usa_names.usa_1910_2013`
+    WHERE state = 'WA'
+    GROUP BY name
+    """
+
+    session = bpd.get_global_session()
+    job_config = bigquery.QueryJobConfig(dry_run=True, use_query_cache=False)
+
+    # Perform a dry run query using the session BigQuery client.
+    query_job = session.bqclient.query(sql, job_config=job_config)
+
+    # A dry run query completes immediately and returns query metadata.
+    print(f"This query will process {query_job.total_bytes_processed} bytes.")
+    return query_job.total_bytes_processed
+# [END bigquery_bigframes_query_dry_run]
+
+
+if __name__ == "__main__":
+    query_dry_run()

--- a/bigquery/bigframes/query_dry_run.py
+++ b/bigquery/bigframes/query_dry_run.py
@@ -33,8 +33,12 @@ def query_dry_run() -> int:
     query_job = session.bqclient.query(sql, job_config=job_config)
 
     # A dry run query completes immediately and returns query metadata.
-    print(f"This query will process {query_job.total_bytes_processed} bytes.")
-    return query_job.total_bytes_processed
+    bytes_processed = query_job.total_bytes_processed
+    if bytes_processed is None:
+        raise RuntimeError("Query dry run did not return the number of bytes processed.")
+
+    print(f"This query will process {bytes_processed} bytes.")
+    return bytes_processed
 # [END bigquery_bigframes_query_dry_run]
 
 

--- a/bigquery/bigframes/query_dry_run.py
+++ b/bigquery/bigframes/query_dry_run.py
@@ -17,10 +17,6 @@ import bigframes.pandas as bpd
 
 from google.cloud import bigquery
 
-# Set partial ordering mode as the default configuration for BigQuery
-# DataFrames.
-bpd.options.bigquery.ordering_mode = "partial"
-
 
 def query_dry_run() -> int:
     sql = """

--- a/bigquery/bigframes/query_dry_run_test.py
+++ b/bigquery/bigframes/query_dry_run_test.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import query_dry_run
+
+
+def test_query_dry_run() -> None:
+    bytes_processed = query_dry_run.query_dry_run()
+    assert bytes_processed is not None
+    assert bytes_processed > 0


### PR DESCRIPTION
## Description

Adds a BigQuery DataFrames (`bigframes`) code sample demonstrating how to execute a **query dry run** to estimate bytes processed without running the actual query, targeting the documentation page [`bigquery-query-dry-run`](https://cloud.google.com/bigquery/docs/samples/bigquery-query-dry-run/).

Fixes b/546160994 (Subtask of b/522898394)

### Summary of Changes
- **New Sample:** Added `bigquery/bigframes/query_dry_run.py` showing how to perform a dry run using `session.bqclient.query(sql, job_config=job_config)` to inspect `query_job.total_bytes_processed`.
