### PR TITLE
docs(bigquery/bigframes): add load_table_dataframe code sample

### DIFF
--- a/bigquery/bigframes/load_table_dataframe.py
+++ b/bigquery/bigframes/load_table_dataframe.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START bigquery_bigframes_load_table_dataframe]
+import datetime
+
+import bigframes.pandas as bpd
+
+import pandas as pd
+
+import pytz
+
+# Set partial ordering mode as the default configuration for BigQuery
+# DataFrames.
+bpd.options.bigquery.ordering_mode = "partial"
+
+
+def load_table_dataframe(
+    table_id: str = "your-project.your_dataset.your_table_name",
+) -> bpd.DataFrame:
+    records = [
+        {
+            "title": "The Meaning of Life",
+            "release_year": 1983,
+            "length_minutes": 112.5,
+            "release_date": pytz.timezone("Europe/Paris")
+            .localize(datetime.datetime(1983, 5, 9, 13, 0, 0))
+            .astimezone(pytz.utc),
+            # Assume UTC timezone when a datetime object contains no timezone.
+            "dvd_release": datetime.datetime(2002, 1, 22, 7, 0, 0),
+        },
+        {
+            "title": "Monty Python and the Holy Grail",
+            "release_year": 1975,
+            "length_minutes": 91.5,
+            "release_date": pytz.timezone("Europe/London")
+            .localize(datetime.datetime(1975, 4, 9, 23, 59, 2))
+            .astimezone(pytz.utc),
+            "dvd_release": datetime.datetime(2002, 7, 16, 9, 0, 0),
+        },
+        {
+            "title": "Life of Brian",
+            "release_year": 1979,
+            "length_minutes": 94.25,
+            "release_date": pytz.timezone("America/New_York")
+            .localize(datetime.datetime(1979, 8, 17, 23, 59, 5))
+            .astimezone(pytz.utc),
+            "dvd_release": datetime.datetime(2008, 1, 14, 8, 0, 0),
+        },
+        {
+            "title": "And Now for Something Completely Different",
+            "release_year": 1971,
+            "length_minutes": 88.0,
+            "release_date": pytz.timezone("Europe/London")
+            .localize(datetime.datetime(1971, 9, 28, 23, 59, 7))
+            .astimezone(pytz.utc),
+            "dvd_release": datetime.datetime(2003, 10, 22, 10, 0, 0),
+        },
+    ]
+    dataframe = pd.DataFrame(
+        records,
+        # In the loaded table, the column order reflects the order of the
+        # columns in the DataFrame.
+        columns=[
+            "title",
+            "release_year",
+            "length_minutes",
+            "release_date",
+            "dvd_release",
+        ],
+        # Optionally, set a named index, which can also be written to the
+        # BigQuery table.
+        index=pd.Index(
+            ["Q24980", "Q25043", "Q24953", "Q16403"], name="wikidata_id"
+        ),
+    )
+
+    # Convert the local pandas DataFrame into a BigQuery DataFrame.
+    bq_df = bpd.read_pandas(dataframe)
+
+    # Write the DataFrame to a BigQuery table.
+    bq_df.to_gbq(table_id, if_exists="replace", index=True)
+    return bq_df
+# [END bigquery_bigframes_load_table_dataframe]
+
+
+if __name__ == "__main__":
+    import os
+
+    table_id = os.environ.get(
+        "TABLE_ID", "your-project.your_dataset.your_table_name"
+    )
+    print(load_table_dataframe(table_id=table_id))

--- a/bigquery/bigframes/load_table_dataframe_test.py
+++ b/bigquery/bigframes/load_table_dataframe_test.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import load_table_dataframe
+
+
+def test_load_table_dataframe(project_id: str, dataset_id: str) -> None:
+    table_id = f"{project_id}.{dataset_id}.load_table_dataframe"
+    import bigframes.pandas as bpd
+
+    bq_df = load_table_dataframe.load_table_dataframe(table_id=table_id)
+    assert bq_df is not None
+
+    # Verify that the rows were actually written to BigQuery
+    df_loaded = bpd.read_gbq(table_id)
+    assert len(df_loaded) == 4


### PR DESCRIPTION
## Description

Adds a BigQuery DataFrames (`bigframes`) code sample demonstrating how to load a pandas DataFrame into a BigQuery table, targeting the documentation page [`bigquery-load-table-dataframe`](https://cloud.google.com/bigquery/docs/samples/bigquery-load-table-dataframe/).

Fixes b/546158350 (Subtask of b/522898394)

### Summary of Changes
- Added `bigquery/bigframes/load_table_dataframe.py` demonstrating converting a local pandas DataFrame to BigQuery DataFrames and writing to BigQuery using `to_gbq`.
- Added corresponding unit test `load_table_dataframe_test.py`.
