### PR TITLE
chore: add shuoweil and sycai to CODEOWNERS for bigquery/bigframes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -78,7 +78,7 @@
 /appengine/standard_python3/spanner/*  @GoogleCloudPlatform/api-spanner-python @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /asset/**/*                            @GoogleCloudPlatform/cloud-asset-analysis-team @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /bigquery/**/*                         @chalmerlowe @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
-/bigquery/bigframes/**/*               @tswast @GoogleCloudPlatform/api-bigquery @GoogleCloudPlatform/cloud-samples-reviewers
+/bigquery/bigframes/**/*               @tswast @shuoweil @sycai @GoogleCloudPlatform/api-bigquery @GoogleCloudPlatform/cloud-samples-reviewers
 /bigquery/remote_function/**/*         @autoerr @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /cloud-media-livestream/**/*           @GoogleCloudPlatform/cloud-media-team @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers
 /bigquery-connection/**/*              @GoogleCloudPlatform/api-bigquery @GoogleCloudPlatform/python-samples-reviewers @GoogleCloudPlatform/cloud-samples-reviewers


### PR DESCRIPTION
## Description

Adds `@shuoweil` and `@sycai` to the CODEOWNERS configuration for `/bigquery/bigframes/**/*` to enable direct review assignments and approvals on BigQuery DataFrames sample contributions.

### Summary of Changes
- Updated `.github/CODEOWNERS` for `/bigquery/bigframes/**/*` to include `@tswast`, `@shuoweil`, and `@sycai`.

