### PR TITLE
docs(bigquery/bigframes): add query_results_dataframe code sample

### DIFF
--- a/bigquery/bigframes/query_results_dataframe.py
+++ b/bigquery/bigframes/query_results_dataframe.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START bigquery_bigframes_query_results_dataframe]
+import bigframes.pandas as bpd
+
+# Set partial ordering mode as the default configuration for BigQuery
+# DataFrames.
+bpd.options.bigquery.ordering_mode = "partial"
+
+
+def query_results_dataframe() -> bpd.DataFrame:
+    sql = """
+    SELECT name, SUM(number) as total_people
+    FROM `bigquery-public-data.usa_names.usa_1910_2013`
+    WHERE state = 'TX'
+    GROUP BY name
+    ORDER BY total_people DESC
+    LIMIT 20
+    """
+
+    # Run query and load results directly into a BigQuery DataFrame.
+    df = bpd.read_gbq(sql)
+    return df
+# [END bigquery_bigframes_query_results_dataframe]
+
+
+if __name__ == "__main__":
+    df = query_results_dataframe()
+    print(df.head())

--- a/bigquery/bigframes/query_results_dataframe_test.py
+++ b/bigquery/bigframes/query_results_dataframe_test.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import query_results_dataframe
+
+
+def test_query_results_dataframe() -> None:
+    df = query_results_dataframe.query_results_dataframe()
+    assert df is not None
+    assert len(df) == 20
+    assert "total_people" in df.columns


### PR DESCRIPTION
## Description

Adds a BigQuery DataFrames (`bigframes`) code sample demonstrating how to execute a query and load the results directly into a DataFrame, targeting the documentation page [`bigquery-query-results-dataframe`](https://cloud.google.com/bigquery/docs/samples/bigquery-query-results-dataframe/).

Fixes b/546158959 (Subtask of b/522898394)

### Summary of Changes
- Added `bigquery/bigframes/query_results_dataframe.py` demonstrating reading query results into a BigQuery DataFrame via `bpd.read_gbq(sql)`.
- Added corresponding unit test `query_results_dataframe_test.py`.

