### PR TITLE
feat(genai/embeddings/multimodal): Add multimodal video embedding example

### DIFF
--- a/genai/embeddings/multimodal_embedding_video.py
+++ b/genai/embeddings/multimodal_embedding_video.py
@@ -20,11 +20,13 @@ from google.genai import types
 def embed_content() -> types.EmbedContentResponse:
     client = genai.Client()
 
-    part = types.Part.from_uri(
-        file_uri="gs://cloud-samples-data/vertex-ai-vision/highway_vehicles.mp4",
-        mime_type="video/mp4",
+    part = types.Part(
+        file_data=types.FileData(
+            file_uri="gs://cloud-samples-data/vertex-ai-vision/highway_vehicles.mp4",
+            mime_type="video/mp4",
+        ),
+        video_metadata=types.VideoMetadata(end_offset="1s"),
     )
-    part.video_metadata = types.VideoMetadata(end_offset="1s")
 
     content = types.Content(parts=[part])
 

--- a/genai/embeddings/multimodal_embedding_video.py
+++ b/genai/embeddings/multimodal_embedding_video.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START googlegenaisdk_multimodal_embedding_video]
+from google import genai
+from google.genai import types
+
+
+def embed_content() -> types.EmbedContentResponse:
+    client = genai.Client()
+
+    part = types.Part.from_uri(
+        file_uri="gs://cloud-samples-data/vertex-ai-vision/highway_vehicles.mp4",
+        mime_type="video/mp4",
+    )
+    part.video_metadata = types.VideoMetadata(end_offset="1s")
+
+    content = types.Content(parts=[part])
+
+    response = client.models.embed_content(
+        model="gemini-embedding-2",
+        contents=[content],
+    )
+    print(response)
+    # Example response:
+    # embeddings=[ContentEmbedding(values=[-0.0123147098, 0.0727171078, ...])]
+    return response
+
+
+# [END googlegenaisdk_multimodal_embedding_video]

--- a/genai/embeddings/multimodal_embedding_video.py
+++ b/genai/embeddings/multimodal_embedding_video.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START googlegenaisdk_multimodal_embedding_video]
+# [START aiplatform_genai_multimodal_embedding_video]
 from google import genai
 from google.genai import types
 
@@ -40,4 +40,4 @@ def embed_content() -> types.EmbedContentResponse:
     return response
 
 
-# [END googlegenaisdk_multimodal_embedding_video]
+# [END aiplatform_genai_multimodal_embedding_video]

--- a/genai/embeddings/test_embeddings_examples.py
+++ b/genai/embeddings/test_embeddings_examples.py
@@ -21,9 +21,10 @@ import os
 import code_retrieval_example
 import embeddings_docretrieval_with_txt
 import model_tuning_example
+import multimodal_embedding_video
 
 os.environ["GOOGLE_GENAI_USE_ENTERPRISE"] = "True"
-os.environ["GOOGLE_CLOUD_LOCATION"] = "us-central1"
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
 # The project name is included in the CICD pipeline
 # os.environ['GOOGLE_CLOUD_PROJECT'] = "add-your-project-name"
 
@@ -39,4 +40,9 @@ def test_code_retrieval_example() -> None:
 
 def test_model_tuning_example() -> None:
     response = model_tuning_example.tune_embedding_model()
+    assert response
+
+
+def test_multimodal_embedding_video() -> None:
+    response = multimodal_embedding_video.embed_content()
     assert response


### PR DESCRIPTION
## Description

Fixes #
b/546128007

Add new example for generating multimodal videos embeddings using the Gemini API and corresponding test. 

- Added `multimodal_embedding_video.py` implementing an example of embedding image and text content using the Gemini embedding model (`gemini-embedding-2`).
- Changed the default `GOOGLE_CLOUD_LOCATION` for tests from `us-central1` to `global` for broader compatibility.

<img width="1320" height="467" alt="image" src="https://github.com/user-attachments/assets/9fd8fbd4-1370-4285-a374-075f31c980f9" />
<img width="1308" height="755" alt="image" src="https://github.com/user-attachments/assets/6ea3cbb1-b2df-4dc6-bc4f-d0275b010881" />

## Checklist

### Testing
- [x] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [x] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
