### PR TITLE
feat(secretmanager): Add Cloud SQL managed-rotation samples

### DIFF
--- a/secretmanager/snippets/regional_samples/create_regional_secret_with_cloud_sql_credentials.py
+++ b/secretmanager/snippets/regional_samples/create_regional_secret_with_cloud_sql_credentials.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for creating a new secret that is
+eligible for Cloud SQL managed rotation.
+"""
+
+# [START secretmanager_create_regional_secret_with_cloud_sql_credentials]
+import argparse
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager_v1
+
+
+def create_regional_secret_with_cloud_sql_credentials(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+) -> secretmanager_v1.Secret:
+    """
+    Create a new secret with the Cloud SQL DB credentials secret type. This
+    type is required to enable Secret Manager's automatic rotation of Cloud
+    SQL passwords. It can only be set when the secret is created, and the
+    secret's location must match the region of the target Cloud SQL
+    instance.
+    """
+
+    # Endpoint to call the regional Secret Manager API.
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager_v1.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name of the parent project.
+    parent = f"projects/{project_id}/locations/{location_id}"
+
+    # Create the secret.
+    response = client.create_secret(
+        request={
+            "parent": parent,
+            "secret_id": secret_id,
+            "secret": {
+                "secret_type": secretmanager_v1.Secret.SecretType.CLOUD_SQL_DB_CREDENTIALS,
+            },
+        }
+    )
+
+    # Print the new secret name.
+    print(f"Created secret: {response.name}")
+
+    # This built-in identity is what you grant Cloud SQL IAM permissions to,
+    # so that Secret Manager can rotate the database password on its behalf.
+    print(
+        "Grant this identity Cloud SQL IAM permissions to enable rotation: "
+        f"{response.policy_member.iam_policy_uid_principal}"
+    )
+
+    return response
+
+
+# [END secretmanager_create_regional_secret_with_cloud_sql_credentials]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument(
+        "location_id",
+        help="id of the location where secret is to be created; must match "
+        "the Cloud SQL instance's region",
+    )
+    parser.add_argument("secret_id", help="id of the secret to create")
+    args = parser.parse_args()
+
+    create_regional_secret_with_cloud_sql_credentials(
+        args.project_id, args.location_id, args.secret_id
+    )

--- a/secretmanager/snippets/regional_samples/enable_regional_secret_managed_rotation.py
+++ b/secretmanager/snippets/regional_samples/enable_regional_secret_managed_rotation.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for enabling managed rotation of
+a Cloud SQL DB credentials secret.
+"""
+
+# [START secretmanager_enable_regional_secret_managed_rotation]
+import argparse
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager_v1
+
+
+def enable_regional_secret_managed_rotation(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+    instance_id: str,
+    username: str,
+) -> secretmanager_v1.SecretVersion:
+    """
+    Enable managed rotation for a Cloud SQL DB credentials secret. This
+    links the secret to a Cloud SQL instance and database user, and can
+    only be called once per secret. It adds the secret's first version and
+    sets the matching password on the Cloud SQL user, taking the place of
+    a manually added secret version, which this secret type doesn't
+    support. Afterwards, use rotate_regional_secret.py to trigger further
+    rotations.
+
+    instance_id is the bare Cloud SQL instance ID (e.g. "my-instance") --
+    not a connection name. Neither the project nor the region should be
+    included: passing "PROJECT_ID:INSTANCE_ID" (as gcloud's own
+    `enable-managed-rotation --help` examples misleadingly show) or the
+    full "PROJECT_ID:LOCATION_ID:INSTANCE_ID" connection name both fail --
+    the service already knows the project from the secret's own path, and
+    prepends it internally, so a qualified value ends up double-prefixed.
+    """
+
+    # Endpoint to call the regional Secret Manager API.
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager_v1.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name of the secret.
+    parent = f"projects/{project_id}/locations/{location_id}/secrets/{secret_id}"
+
+    # Enable managed rotation. Leaving password unset lets Secret Manager
+    # generate a secure password itself.
+    response = client.enable_managed_rotation(
+        request={
+            "parent": parent,
+            "cloud_sql_single_user_credentials": {
+                "instance_id": instance_id,
+                "username": username,
+            },
+        }
+    )
+
+    print(f"Enabled managed rotation, created secret version: {response.name}")
+
+    return response
+
+
+# [END secretmanager_enable_regional_secret_managed_rotation]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("location_id", help="id of location where secret is stored")
+    parser.add_argument(
+        "secret_id", help="id of the Cloud SQL DB credentials secret to rotate"
+    )
+    parser.add_argument(
+        "instance_id",
+        help="bare id of the Cloud SQL instance (no project or region prefix)",
+    )
+    parser.add_argument("username", help="username of the Cloud SQL database user")
+    args = parser.parse_args()
+
+    enable_regional_secret_managed_rotation(
+        args.project_id,
+        args.location_id,
+        args.secret_id,
+        args.instance_id,
+        args.username,
+    )

--- a/secretmanager/snippets/regional_samples/enable_regional_secret_managed_rotation.py
+++ b/secretmanager/snippets/regional_samples/enable_regional_secret_managed_rotation.py
@@ -86,7 +86,8 @@ if __name__ == "__main__":
     parser.add_argument("project_id", help="id of the GCP project")
     parser.add_argument("location_id", help="id of location where secret is stored")
     parser.add_argument(
-        "secret_id", help="id of the Cloud SQL DB credentials secret to rotate"
+        "secret_id",
+        help="id of the Cloud SQL DB credentials secret to enable rotation on",
     )
     parser.add_argument(
         "instance_id",

--- a/secretmanager/snippets/regional_samples/rotate_regional_secret.py
+++ b/secretmanager/snippets/regional_samples/rotate_regional_secret.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+"""
+command line application and sample code for triggering a managed
+rotation of a Cloud SQL DB credentials secret.
+"""
+
+# [START secretmanager_rotate_regional_secret]
+import argparse
+
+# Import the Secret Manager client library.
+from google.cloud import secretmanager_v1
+
+
+def rotate_regional_secret(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+) -> secretmanager_v1.SecretVersion:
+    """
+    Trigger a managed rotation for a Cloud SQL DB credentials secret.
+    Managed rotation must already be enabled on the secret (see
+    enable_regional_secret_managed_rotation.py). Each call generates a new
+    password, updates the Cloud SQL user, and adds the result as a new
+    secret version.
+    """
+
+    # Endpoint to call the regional Secret Manager API.
+    api_endpoint = f"secretmanager.{location_id}.rep.googleapis.com"
+
+    # Create the Secret Manager client.
+    client = secretmanager_v1.SecretManagerServiceClient(
+        client_options={"api_endpoint": api_endpoint},
+    )
+
+    # Build the resource name of the secret.
+    parent = f"projects/{project_id}/locations/{location_id}/secrets/{secret_id}"
+
+    # Rotate the secret.
+    response = client.rotate_secret(request={"parent": parent})
+
+    print(f"Rotated secret, created secret version: {response.name}")
+
+    return response
+
+
+# [END secretmanager_rotate_regional_secret]
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("project_id", help="id of the GCP project")
+    parser.add_argument("location_id", help="id of location where secret is stored")
+    parser.add_argument(
+        "secret_id", help="id of the Cloud SQL DB credentials secret to rotate"
+    )
+    args = parser.parse_args()
+
+    rotate_regional_secret(args.project_id, args.location_id, args.secret_id)

--- a/secretmanager/snippets/regional_samples/snippets_test.py
+++ b/secretmanager/snippets/regional_samples/snippets_test.py
@@ -28,6 +28,7 @@ from regional_samples import add_regional_secret_version
 from regional_samples import bind_tags_to_regional_secret
 from regional_samples import create_regional_secret
 from regional_samples import create_regional_secret_with_annotations
+from regional_samples import create_regional_secret_with_cloud_sql_credentials
 from regional_samples import create_regional_secret_with_delayed_destroy
 from regional_samples import create_regional_secret_with_labels
 from regional_samples import create_regional_secret_with_tags
@@ -440,6 +441,21 @@ def test_create_regional_secret_with_annotations(
         )
     )
     assert secret_id in secret.name
+
+
+def test_create_regional_secret_with_cloud_sql_credentials(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+) -> None:
+    secret = create_regional_secret_with_cloud_sql_credentials.create_regional_secret_with_cloud_sql_credentials(
+        project_id, location_id, secret_id
+    )
+    assert secret_id in secret.name
+    assert (
+        secret.secret_type
+        == secretmanager_v1.Secret.SecretType.CLOUD_SQL_DB_CREDENTIALS
+    )
 
 
 def test_create_regional_secret_with_delayed_destroy(

--- a/secretmanager/snippets/regional_samples/snippets_test.py
+++ b/secretmanager/snippets/regional_samples/snippets_test.py
@@ -20,6 +20,7 @@ import uuid
 from google.api_core import exceptions, retry
 from google.cloud import resourcemanager_v3
 from google.cloud import secretmanager_v1
+from google.iam.v1 import policy_pb2
 from google.protobuf.duration_pb2 import Duration
 import pytest
 
@@ -94,6 +95,18 @@ def tag_keys_client() -> resourcemanager_v3.TagKeysClient:
 @pytest.fixture()
 def tag_values_client() -> resourcemanager_v3.TagValuesClient:
     return resourcemanager_v3.TagValuesClient()
+
+
+@pytest.fixture()
+def projects_client() -> resourcemanager_v3.ProjectsClient:
+    return resourcemanager_v3.ProjectsClient()
+
+
+# Role granted to a Cloud SQL DB credentials secret's built-in identity so
+# that managed rotation can update the Cloud SQL user's password. This grant
+# is per-secret (the member is the secret's own generated principal), so it
+# has to be made fresh for every secret managed_rotation tests create.
+CLOUD_SQL_ROLE = "roles/cloudsql.admin"
 
 
 @pytest.fixture()
@@ -218,6 +231,55 @@ def retry_client_delete_tag_key(
     operation = tag_keys_client.delete_tag_key(request=request)
     response = operation.result()
     return response.name
+
+
+@retry.Retry(predicate=retry.if_exception_type(exceptions.Aborted))
+def grant_cloud_sql_role(
+    projects_client: resourcemanager_v3.ProjectsClient,
+    project_id: str,
+    member: str,
+) -> None:
+    """
+    Grants CLOUD_SQL_ROLE to member on the project. SetIamPolicy replaces
+    the whole policy, so this reads the current policy, adds the member to
+    the existing (or a new) binding for the role, and writes it back with
+    the same etag -- retrying the whole read-modify-write if another writer
+    raced us (Aborted, from an etag mismatch).
+    """
+    resource = f"projects/{project_id}"
+    policy = projects_client.get_iam_policy(request={"resource": resource})
+
+    for binding in policy.bindings:
+        if binding.role == CLOUD_SQL_ROLE:
+            if member not in binding.members:
+                binding.members.append(member)
+            break
+    else:
+        policy.bindings.append(
+            policy_pb2.Binding(role=CLOUD_SQL_ROLE, members=[member])
+        )
+
+    projects_client.set_iam_policy(request={"resource": resource, "policy": policy})
+
+
+@retry.Retry(predicate=retry.if_exception_type(exceptions.Aborted))
+def revoke_cloud_sql_role(
+    projects_client: resourcemanager_v3.ProjectsClient,
+    project_id: str,
+    member: str,
+) -> None:
+    """Removes member from CLOUD_SQL_ROLE on the project, added by grant_cloud_sql_role."""
+    resource = f"projects/{project_id}"
+    policy = projects_client.get_iam_policy(request={"resource": resource})
+
+    changed = False
+    for binding in policy.bindings:
+        if binding.role == CLOUD_SQL_ROLE and member in binding.members:
+            binding.members.remove(member)
+            changed = True
+
+    if changed:
+        projects_client.set_iam_policy(request={"resource": resource, "policy": policy})
 
 
 @pytest.fixture()
@@ -370,16 +432,29 @@ def regional_secret_with_delayed_destroy(
 
 @pytest.fixture()
 def regional_secret_with_cloud_sql_credentials(
+    projects_client: resourcemanager_v3.ProjectsClient,
     project_id: str,
     location_id: str,
     secret_id: str,
 ) -> Iterator[str]:
     print(f"creating cloud sql credentials secret {secret_id}")
-    create_regional_secret_with_cloud_sql_credentials.create_regional_secret_with_cloud_sql_credentials(
+    secret = create_regional_secret_with_cloud_sql_credentials.create_regional_secret_with_cloud_sql_credentials(
         project_id, location_id, secret_id
     )
 
+    # enable_managed_rotation needs this secret's own built-in identity
+    # granted Cloud SQL IAM permissions first -- there's no broader grant
+    # that covers a secret before it exists, so every secret created here
+    # needs its own grant/revoke around the test that uses it.
+    member = secret.policy_member.iam_policy_uid_principal
+    grant_cloud_sql_role(projects_client, project_id, member)
+    # IAM grants are eventually consistent; give it a moment before a caller
+    # tries to use it for managed rotation.
+    time.sleep(10)
+
     yield secret_id
+
+    revoke_cloud_sql_role(projects_client, project_id, member)
 
 
 def test_regional_quickstart(project_id: str, location_id: str, secret_id: str) -> None:

--- a/secretmanager/snippets/regional_samples/snippets_test.py
+++ b/secretmanager/snippets/regional_samples/snippets_test.py
@@ -43,6 +43,7 @@ from regional_samples import disable_regional_secret_version
 from regional_samples import disable_regional_secret_version_with_etag
 from regional_samples import edit_regional_secret_annotations
 from regional_samples import edit_regional_secret_label
+from regional_samples import enable_regional_secret_managed_rotation
 from regional_samples import enable_regional_secret_version
 from regional_samples import enable_regional_secret_version_with_etag
 from regional_samples import get_regional_secret
@@ -54,6 +55,7 @@ from regional_samples import list_regional_secret_versions_with_filter
 from regional_samples import list_regional_secrets
 from regional_samples import list_regional_secrets_with_filter
 from regional_samples import regional_quickstart
+from regional_samples import rotate_regional_secret
 from regional_samples import update_regional_secret
 from regional_samples import update_regional_secret_with_delayed_destroy
 from regional_samples import update_regional_secret_with_etag
@@ -102,6 +104,16 @@ def project_id() -> str:
 @pytest.fixture()
 def iam_user() -> str:
     return "serviceAccount:" + os.environ["GCLOUD_SECRETS_SERVICE_ACCOUNT"]
+
+
+@pytest.fixture()
+def cloud_sql_instance_id() -> str:
+    return os.environ["CLOUD_SQL_INSTANCE"]
+
+
+@pytest.fixture()
+def cloud_sql_username() -> str:
+    return os.environ["CLOUD_SQL_USER"]
 
 
 @pytest.fixture()
@@ -356,6 +368,20 @@ def regional_secret_with_delayed_destroy(
     yield secret_id
 
 
+@pytest.fixture()
+def regional_secret_with_cloud_sql_credentials(
+    project_id: str,
+    location_id: str,
+    secret_id: str,
+) -> Iterator[str]:
+    print(f"creating cloud sql credentials secret {secret_id}")
+    create_regional_secret_with_cloud_sql_credentials.create_regional_secret_with_cloud_sql_credentials(
+        project_id, location_id, secret_id
+    )
+
+    yield secret_id
+
+
 def test_regional_quickstart(project_id: str, location_id: str, secret_id: str) -> None:
     regional_quickstart.regional_quickstart(project_id, location_id, secret_id)
 
@@ -456,6 +482,40 @@ def test_create_regional_secret_with_cloud_sql_credentials(
         secret.secret_type
         == secretmanager_v1.Secret.SecretType.CLOUD_SQL_DB_CREDENTIALS
     )
+
+
+def test_enable_regional_secret_managed_rotation(
+    regional_secret_with_cloud_sql_credentials: str,
+    project_id: str,
+    location_id: str,
+    cloud_sql_instance_id: str,
+    cloud_sql_username: str,
+) -> None:
+    secret_id = regional_secret_with_cloud_sql_credentials
+    version = enable_regional_secret_managed_rotation.enable_regional_secret_managed_rotation(
+        project_id, location_id, secret_id, cloud_sql_instance_id, cloud_sql_username
+    )
+    assert secret_id in version.name
+    assert version.state == secretmanager_v1.SecretVersion.State.ENABLED
+
+
+def test_rotate_regional_secret(
+    regional_secret_with_cloud_sql_credentials: str,
+    project_id: str,
+    location_id: str,
+    cloud_sql_instance_id: str,
+    cloud_sql_username: str,
+) -> None:
+    secret_id = regional_secret_with_cloud_sql_credentials
+    first_version = enable_regional_secret_managed_rotation.enable_regional_secret_managed_rotation(
+        project_id, location_id, secret_id, cloud_sql_instance_id, cloud_sql_username
+    )
+    rotated_version = rotate_regional_secret.rotate_regional_secret(
+        project_id, location_id, secret_id
+    )
+    assert secret_id in rotated_version.name
+    assert rotated_version.name != first_version.name
+    assert rotated_version.state == secretmanager_v1.SecretVersion.State.ENABLED
 
 
 def test_create_regional_secret_with_delayed_destroy(

--- a/secretmanager/snippets/requirements.txt
+++ b/secretmanager/snippets/requirements.txt
@@ -1,4 +1,4 @@
 protobuf==6.33.6
 google-cloud-resource-manager==1.18.0
-google-cloud-secret-manager==2.29.0
+google-cloud-secret-manager==2.30.0
 google-crc32c==1.8.0


### PR DESCRIPTION
Added samples for Secret Manager's Cloud SQL managed-rotation feature (regional secrets only — this feature isn't available for global secrets)
- create_regional_secret_with_cloud_sql_credentials
- enable_regional_secret_managed_rotation
- rotate_regional_secret

Added a test case for creating the Cloud SQL DB credentials secret type.

Note: requires google-cloud-secret-manager>=2.30.0, which itself requires Python>=3.10 — this feature does not exist in 2.29.0 or earlier.

##Checklist
- [x] I have followed [Sample Guidelines from AUTHORING_GUIDE.MD](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md)
- [ ] README is updated to include [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file)
- [ ] **Tests** pass:   `nox -s py-3.9` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [ ] **Lint** pass:   `nox -s lint` (see [Test Environment Setup](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#test-environment-setup))
- [x] These samples need a new **API enabled** in testing projects to pass (Cloud SQL Admin API — sqladmin.googleapis.com)
- [x] These samples need a new/updated **env vars** in testing projects set to pass (let us know which ones)
       - `CLOUD_SQL_INSTANCE` / `CLOUD_SQL_USER` — a pre-provisioned, long-lived Cloud SQL instance + DB user for managed-rotation tests to point at (same pattern as this repo's other Cloud SQL-backed sample tests)
       - The identity running these tests additionally needs `resourcemanager.projects.getIamPolicy`/`setIamPolicy` on the test project (e.g. `roles/resourcemanager.projectIamAdmin`)
- [ ] This sample adds a new sample directory, and I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS) with the codeowners for this sample
- [ ] This sample adds a new **Product API**, and I updated the [Blunderbuss issue/PR auto-assigner](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/blunderbuss.yml) with the codeowners for this sample
- [x] Please **merge** this PR for me once it is approved