### PR TITLE
 build(multiple samples): bump Django to 6.1.1 in requirements

### DIFF
--- a/appengine/flexible/django_cloudsql/requirements.txt
+++ b/appengine/flexible/django_cloudsql/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.5; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 gunicorn==23.0.0
 psycopg2-binary==2.9.11
 django-environ==0.13.0

--- a/appengine/flexible/hello_world_django/requirements.txt
+++ b/appengine/flexible/hello_world_django/requirements.txt
@@ -1,2 +1,2 @@
-Django==6.0.5; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 gunicorn==23.0.0

--- a/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/blobstore/django/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.5; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 django-environ==0.13.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.2.3

--- a/appengine/standard_python3/bundled-services/deferred/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/deferred/django/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.5; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 django-environ==0.13.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.3.1

--- a/appengine/standard_python3/bundled-services/mail/django/requirements.txt
+++ b/appengine/standard_python3/bundled-services/mail/django/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.5; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 django-environ==0.13.0
 google-cloud-logging==3.5.0
 appengine-python-standard>=0.2.3

--- a/appengine/standard_python3/django/requirements.txt
+++ b/appengine/standard_python3/django/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.5; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 django-environ==0.13.0
 psycopg2-binary==2.9.9
 google-cloud-secret-manager==2.16.1

--- a/kubernetes_engine/django_tutorial/requirements.txt
+++ b/kubernetes_engine/django_tutorial/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.6; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 # Uncomment the mysqlclient requirement if you are using MySQL rather than
 # PostgreSQL. You must also have a MySQL client installed in that case.
 #mysqlclient==1.4.1

--- a/run/django/requirements.txt
+++ b/run/django/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.5; python_version >= "3.12"
+Django==6.1.1; python_version >= "3.12"
 django-storages[google]==1.14.6
 django-environ==0.13.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION


## Description

 Updates the Django dependency to version 6.1.1 for Python 3.12+ across App Engine, Kubernetes Engine, and Cloud Run tutorials to resolve Dependabot alerts.

Fixes b/557225598

## Checklist

### Testing
- [ ] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [ ] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [ ] Please **merge** this PR for me once it is approved
