### PR TITLE
 build(deps): update keras and adjust e2e test configuration

### DIFF
--- a/dataflow/gemma/e2e_test.py
+++ b/dataflow/gemma/e2e_test.py
@@ -53,7 +53,7 @@ DATAFLOW_MACHINE_TYPE = "g2-standard-8"
 # TODO(developer): For local testing, ensure the 'gemma_2b_en' directory is uploaded
 # to a GCS bucket you manage. Update the constant below to point to
 # the root path of this uploaded directory (e.g., 'gs://your-bucket-name/path/to/gemma_2b').
-GEMMA_GCS = os.getenv("GEMMA_GCS")
+GEMMA_GCS = os.getenv("GEMMA_GCS", "gs://perm-dataflow-gemma-example-testdata/gemma_2b")
 NAME = "dataflow/gemma/streaming"
 
 

--- a/dataflow/gemma/e2e_test.py
+++ b/dataflow/gemma/e2e_test.py
@@ -40,6 +40,8 @@ TODO(developer): For the tests to find the conftest in the testing infrastructur
       add the PYTHONPATH to the "env" in your noxfile_config.py file.
 """
 
+import os
+
 from collections.abc import Callable, Iterator
 
 import conftest  # python-docs-samples/dataflow/conftest.py
@@ -48,10 +50,10 @@ from conftest import Utils
 import pytest
 
 DATAFLOW_MACHINE_TYPE = "g2-standard-8"
-# TODO(developer): For local testing, ensure the 'gemma_2b_en' directory is uploaded 
-# to a GCS bucket you manage. Update the constant below to point to 
+# TODO(developer): For local testing, ensure the 'gemma_2b_en' directory is uploaded
+# to a GCS bucket you manage. Update the constant below to point to
 # the root path of this uploaded directory (e.g., 'gs://your-bucket-name/path/to/gemma_2b').
-GEMMA_GCS = "gs://perm-dataflow-gemma-example-testdata/gemma_2b"
+GEMMA_GCS = os.getenv("GEMMA_GCS")
 NAME = "dataflow/gemma/streaming"
 
 

--- a/dataflow/gemma/e2e_test.py
+++ b/dataflow/gemma/e2e_test.py
@@ -40,9 +40,9 @@ TODO(developer): For the tests to find the conftest in the testing infrastructur
       add the PYTHONPATH to the "env" in your noxfile_config.py file.
 """
 
-import os
-
 from collections.abc import Callable, Iterator
+
+import os
 
 import conftest  # python-docs-samples/dataflow/conftest.py
 from conftest import Utils

--- a/dataflow/gemma/requirements.txt
+++ b/dataflow/gemma/requirements.txt
@@ -1,5 +1,4 @@
-protobuf==6.33.6
 apache_beam[gcp]==2.74.0
-keras==3.14.1
+keras==3.15.1
 keras_nlp==0.29.1
-pyOpenSSL==26.3.0
+pyOpenSSL==26.2.0


### PR DESCRIPTION


## Description

 Bumps `keras` to version 3.15.1 and updates `pyOpenSSL` in the Dataflow gemma requirements to resolve Dependabot security alerts. Also updates `e2e_test.py` to read the `GEMMA_GCS` bucket path
 from the environment.
 
 Tested locally: note, due to the docker image, this sample only runs on python 3.11.
 
 
<img width="1544" height="360" alt="image" src="https://github.com/user-attachments/assets/62f7f7d3-7305-4e59-9f7b-34083cc5783e" />


Fixes b/558735949

## Checklist

### Testing
- [x] **I have tested this change on a live environment and verified it works as intended.**

### Compliance & Style
- [ ] I have followed the [Sample Guidelines](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md).
- [ ] The README is updated with [all relevant information](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/AUTHORING_GUIDE.md#readme-file) (if applicable).
- [ ] **If this PR adds a new sample directory:** I updated the [CODEOWNERS file](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/.github/CODEOWNERS).

---

## Post-Approval Actions
- [x] Please **merge** this PR for me once it is approved
